### PR TITLE
feat(processor): expose per-page text density metadata

### DIFF
--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -60,8 +60,12 @@ async function extractPageData(doc: PDFDocumentProxy, pageNum: number, imageOps:
     parts.push(item.str);
     if (item.hasEOL) parts.push('\n');
     const w = typeof item.width === 'number' ? item.width : 0;
-    const h = typeof item.height === 'number' ? item.height : 0;
-    textArea += w * h;
+    // pdfjs reports item.height as 0 for many PDFs (e.g. those produced by
+    // certain Office exporters); fall back to the vertical scale from the
+    // text matrix, which is effectively the glyph height in user units.
+    const reportedH = typeof item.height === 'number' ? item.height : 0;
+    const h = reportedH > 0 ? reportedH : Math.abs(item.transform?.[3] ?? 0);
+    textArea += Math.abs(w * h);
   }
   const text = parts.join('').trimEnd();
 
@@ -72,8 +76,12 @@ async function extractPageData(doc: PDFDocumentProxy, pageNum: number, imageOps:
   }
 
   const view = page.view;
-  const pageArea = (view[2] - view[0]) * (view[3] - view[1]);
-  const textCoverage = pageArea > 0 ? Math.min(1, textArea / pageArea) : 0;
+  // MediaBox is normally [minX, minY, maxX, maxY] but the spec allows the
+  // pairs in either order; use abs so a flipped box still yields a sensible
+  // area instead of falling through to 0 coverage.
+  const pageArea = Math.abs((view[2] - view[0]) * (view[3] - view[1]));
+  const rawCoverage = pageArea > 0 ? textArea / pageArea : 0;
+  const textCoverage = Math.max(0, Math.min(1, rawCoverage));
 
   return {
     text,

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -26,27 +26,61 @@ interface CacheKeyInput {
 function buildCacheKey(input: CacheKeyInput): string {
   const payload = JSON.stringify({
     pages: input.pages ?? 'all',
-    format: 'structured',
+    // Bump when the on-disk DocumentResult shape changes so older entries
+    // (missing newly-added page fields) are not handed out as fresh results.
+    format: 'structured-v2',
     render: !!input.render,
   });
   const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16);
   return `result_${hash}.json`;
 }
 
+interface PageData {
+  text: string;
+  charCount: number;
+  imageCount: number;
+  textCoverage: number;
+}
+
 /**
- * Extract the text of a single page, joining glyph runs and inserting
- * line breaks where pdfjs reports an end-of-line marker.
+ * Extract a page's text plus rough density metadata.
+ *
+ * `imageCount` and `textCoverage` let agents detect "looks fine but the
+ * real content is rasterised" pages (common in Google Slides exports)
+ * and decide whether to re-run with `--render`.
  */
-async function extractText(doc: PDFDocumentProxy, pageNum: number): Promise<string> {
+async function extractPageData(doc: PDFDocumentProxy, pageNum: number, imageOps: Set<number>): Promise<PageData> {
   const page = await doc.getPage(pageNum);
   const content = await page.getTextContent();
+
   const parts: string[] = [];
+  let textArea = 0;
   for (const item of content.items) {
     if (!('str' in item)) continue;
     parts.push(item.str);
     if (item.hasEOL) parts.push('\n');
+    const w = typeof item.width === 'number' ? item.width : 0;
+    const h = typeof item.height === 'number' ? item.height : 0;
+    textArea += w * h;
   }
-  return parts.join('').trimEnd();
+  const text = parts.join('').trimEnd();
+
+  const opList = await page.getOperatorList();
+  let imageCount = 0;
+  for (const fn of opList.fnArray) {
+    if (imageOps.has(fn)) imageCount++;
+  }
+
+  const view = page.view;
+  const pageArea = (view[2] - view[0]) * (view[3] - view[1]);
+  const textCoverage = pageArea > 0 ? Math.min(1, textArea / pageArea) : 0;
+
+  return {
+    text,
+    charCount: text.length,
+    imageCount,
+    textCoverage: Math.round(textCoverage * 1000) / 1000,
+  };
 }
 
 /** Render a structured DocumentResult into the caller-requested string format. */
@@ -123,7 +157,11 @@ export async function processDocument(filePath: string, options: ProcessDocument
 
   // pdfjs-dist is multiple MB and dominates startup time; only pull it in
   // once we've confirmed there's no cache hit and we actually need to parse.
-  const { getDocument } = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const { getDocument, OPS } = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  // Opcodes that draw raster images. paintImageXObject covers ordinary
+  // embedded images; the mask/inline variants catch the cases pdf.js
+  // splits out for transparency or inline streams.
+  const imageOps = new Set<number>([OPS.paintImageXObject, OPS.paintImageMaskXObject, OPS.paintInlineImageXObject]);
   const doc = await getDocument(filePath).promise;
   try {
     const totalPages = doc.numPages;
@@ -154,11 +192,14 @@ export async function processDocument(filePath: string, options: ProcessDocument
 
     const pages: PageResult[] = [];
     for (let i = 0; i < pageNumbers.length; i++) {
-      const text = await extractText(doc, pageNumbers[i]);
+      const data = await extractPageData(doc, pageNumbers[i], imageOps);
       pages.push({
         page: pageNumbers[i],
-        text,
+        text: data.text,
         image: imagePaths?.[i],
+        charCount: data.charCount,
+        imageCount: data.imageCount,
+        textCoverage: data.textCoverage,
       });
     }
 

--- a/src/output/text.ts
+++ b/src/output/text.ts
@@ -8,7 +8,10 @@ export function formatText(result: DocumentResult): string {
   if (result.metadata.author) lines.push(`Author: ${result.metadata.author}`);
   lines.push('---');
   for (const page of result.pages) {
-    lines.push(`\n[Page ${page.page}]\n`);
+    const coveragePct = Math.round(page.textCoverage * 100);
+    lines.push(
+      `\n[Page ${page.page}] (chars: ${page.charCount}, images: ${page.imageCount}, coverage: ${coveragePct}%)\n`,
+    );
     lines.push(page.text);
     if (page.image) lines.push(`\nImage: ${page.image}`);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,16 @@ export interface PageResult {
   page: number;
   text: string;
   image?: string;
+  /** Length (in code units) of `text`. Useful for detecting image-only slides. */
+  charCount: number;
+  /** Number of raster image objects drawn on the page (XObject + inline + mask). */
+  imageCount: number;
+  /**
+   * Approximate fraction of page area covered by text glyph boxes (0–1).
+   * A heuristic — items can overlap, so this is clamped to ≤ 1. Low values
+   * (e.g. < 0.05) suggest the page is dominated by images rather than text.
+   */
+  textCoverage: number;
 }
 
 export interface DocumentMetadata {

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -28,6 +28,16 @@ describe('processDocument', () => {
     expect(result.totalPages).toBe(1);
   });
 
+  it('reports per-page density metadata so agents can spot image-only pages', async () => {
+    const result = await processDocument(SAMPLE_PDF, { noCache: true });
+    const page = result.pages[0];
+    expect(page.charCount).toBe(page.text.length);
+    expect(page.charCount).toBeGreaterThan(0);
+    expect(page.imageCount).toBeGreaterThanOrEqual(0);
+    expect(page.textCoverage).toBeGreaterThanOrEqual(0);
+    expect(page.textCoverage).toBeLessThanOrEqual(1);
+  });
+
   it('honours pages selector', async () => {
     const result = await processDocument(SAMPLE_JA_PDF, { pages: '2-3', noCache: true });
     expect(result.pages.map((p) => p.page)).toEqual([2, 3]);

--- a/tests/core/processor.test.ts
+++ b/tests/core/processor.test.ts
@@ -14,6 +14,8 @@ describe('processFile', () => {
     });
     expect(result).toContain('Pages: 1');
     expect(result).toContain('Hello pdfvision');
+    // Page header carries density signal so agents can detect image-only slides.
+    expect(result).toMatch(/\[Page 1\] \(chars: \d+, images: \d+, coverage: \d+%\)/);
   });
 
   it('extracts text as JSON', async () => {


### PR DESCRIPTION
## Summary

- Add `charCount` / `imageCount` / `textCoverage` to each page in `DocumentResult`
- Page header in text output now reads: `[Page 10] (chars: 38, images: 2, coverage: 8%)`
- Cache schema bumped to `structured-v2` so old caches are auto-invalidated

## Why

Real-world feedback (4 PDFs tested via Claude): Google Slides exports have **title text + image-flattened body**. The agent reading text-only output sees titles + a few words and confidently produces a wrong summary. There is currently no signal that "the content is hiding in the rasterised pixels".

Per-page density metadata lets an attentive agent decide automatically whether to re-run with `--render`:

> low `textCoverage` (e.g. < 0.1) + non-zero `imageCount` → page is image-dominant, text alone is unreliable

This is the smallest, lowest-risk change that addresses the silent-failure class. It only **adds information** to existing outputs — no breaking changes for text consumers, JSON gains three optional-feeling fields. The full per-page coverage redesign (P1 in the feedback doc) is deferred.

## Output sample

Text format:
```
[Page 1] (chars: 15, images: 0, coverage: 1%)

Hello pdfvision
```

JSON:
```json
{
  "page": 1,
  "text": "Hello pdfvision",
  "charCount": 15,
  "imageCount": 0,
  "textCoverage": 0.008
}
```

## Test plan

- [x] `npm test` — 42 tests pass (added 1 new + tightened 1 existing)
- [x] `npm run lint` — biome / oxlint / tsgo / secretlint all clean
- [x] `npm run build` — tsdown succeeds, dist size unchanged
- [x] Smoke test against fixture PDF, both text and JSON formats
- [ ] Verify on a Google Slides export (rasterised body) that `coverage < 5%` is reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)