### PR TITLE
feat(cli): add --render-output for rendered-image directory

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -33,7 +33,7 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         pages: { type: 'string', short: 'p' },
         format: { type: 'string', short: 'f', default: 'text' },
         render: { type: 'boolean', short: 'r' },
-        output: { type: 'string', short: 'o' },
+        'render-output': { type: 'string' },
         'no-cache': { type: 'boolean' },
       },
     });
@@ -62,12 +62,12 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     exitWithError(`Invalid --format "${format}". Expected one of: ${VALID_FORMATS.join(', ')}`);
   }
 
-  const output = values.output as string | undefined;
+  const renderOutput = values['render-output'] as string | undefined;
   const render = (values.render as boolean | undefined) ?? false;
-  if (output && !render) {
-    // -o only does something if pages are actually rendered. Failing fast
-    // here is friendlier than silently writing nothing to the user's dir.
-    exitWithError('--output requires --render');
+  if (renderOutput && !render) {
+    // --render-output only does something if pages are actually rendered.
+    // Failing fast is friendlier than silently writing nothing to the dir.
+    exitWithError('--render-output requires --render');
   }
 
   const filePath = resolve(positionals[0]);
@@ -87,7 +87,7 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
       pages: values.pages as string | undefined,
       format,
       render,
-      output,
+      renderOutput,
       noCache: (values['no-cache'] as boolean | undefined) ?? false,
     });
     console.log(result);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -33,6 +33,7 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         pages: { type: 'string', short: 'p' },
         format: { type: 'string', short: 'f', default: 'text' },
         render: { type: 'boolean', short: 'r' },
+        output: { type: 'string', short: 'o' },
         'no-cache': { type: 'boolean' },
       },
     });
@@ -61,6 +62,14 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     exitWithError(`Invalid --format "${format}". Expected one of: ${VALID_FORMATS.join(', ')}`);
   }
 
+  const output = values.output as string | undefined;
+  const render = (values.render as boolean | undefined) ?? false;
+  if (output && !render) {
+    // -o only does something if pages are actually rendered. Failing fast
+    // here is friendlier than silently writing nothing to the user's dir.
+    exitWithError('--output requires --render');
+  }
+
   const filePath = resolve(positionals[0]);
 
   try {
@@ -77,7 +86,8 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     const result = await processFile(filePath, {
       pages: values.pages as string | undefined,
       format,
-      render: (values.render as boolean | undefined) ?? false,
+      render,
+      output,
       noCache: (values['no-cache'] as boolean | undefined) ?? false,
     });
     console.log(result);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -4,18 +4,19 @@ Usage:
   pdfvision <file.pdf> [options]
 
 Options:
-  -p, --pages <range>   Page range (e.g. "1-5", "3", "1,3,5")
-  -f, --format <type>   Output format: text (default), json
-  -r, --render          Render pages as PNG images
-  -o, --output <dir>    Directory for rendered PNGs (requires --render).
-                        Created if missing.
-      --no-cache        Skip cache
-  -v, --version         Show version
-  -h, --help            Show this help
+  -p, --pages <range>     Page range (e.g. "1-5", "3", "1,3,5")
+  -f, --format <type>     Output format: text (default), json
+  -r, --render            Render pages as PNG images
+      --render-output <dir>
+                          Directory for rendered PNGs (requires --render).
+                          Created if missing.
+      --no-cache          Skip cache
+  -v, --version           Show version
+  -h, --help              Show this help
 
 Examples:
   pdfvision document.pdf
   pdfvision document.pdf -p 1-3
   pdfvision document.pdf -r -p 1-5
-  pdfvision document.pdf -r -o ./images
+  pdfvision document.pdf -r --render-output ./images
   pdfvision document.pdf -f json`;

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -7,6 +7,8 @@ Options:
   -p, --pages <range>   Page range (e.g. "1-5", "3", "1,3,5")
   -f, --format <type>   Output format: text (default), json
   -r, --render          Render pages as PNG images
+  -o, --output <dir>    Directory for rendered PNGs (requires --render).
+                        Created if missing.
       --no-cache        Skip cache
   -v, --version         Show version
   -h, --help            Show this help
@@ -15,4 +17,5 @@ Examples:
   pdfvision document.pdf
   pdfvision document.pdf -p 1-3
   pdfvision document.pdf -r -p 1-5
+  pdfvision document.pdf -r -o ./images
   pdfvision document.pdf -f json`;

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -13,7 +13,7 @@ import { parsePageRange } from './pageRange.js';
 interface CacheKeyInput {
   pages?: string;
   render?: boolean;
-  output?: string;
+  renderOutput?: string;
 }
 
 /**
@@ -31,9 +31,9 @@ function buildCacheKey(input: CacheKeyInput): string {
     // (missing newly-added page fields) are not handed out as fresh results.
     format: 'structured-v3',
     render: !!input.render,
-    // Including the resolved output dir keeps two invocations with
-    // different `--output` targets from sharing image paths.
-    output: input.output ? resolve(input.output) : null,
+    // Including the resolved render-output dir keeps two invocations with
+    // different `--render-output` targets from sharing image paths.
+    renderOutput: input.renderOutput ? resolve(input.renderOutput) : null,
   });
   const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16);
   return `result_${hash}.json`;
@@ -199,11 +199,11 @@ export async function processDocument(filePath: string, options: ProcessDocument
     let imagePaths: string[] | null = null;
     if (options.render) {
       let imagesDir: string;
-      if (options.output) {
+      if (options.renderOutput) {
         // User-supplied path: don't enforce 0o700 here — the caller owns
         // their output directory and may need it readable for downstream
         // consumers. We do create it if missing.
-        imagesDir = resolve(options.output);
+        imagesDir = resolve(options.renderOutput);
         mkdirSync(imagesDir, { recursive: true });
       } else if (cacheDir) {
         imagesDir = join(cacheDir, 'images');
@@ -266,7 +266,7 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
     pages: options.pages,
     render: options.render,
     noCache: options.noCache,
-    output: options.output,
+    renderOutput: options.renderOutput,
   });
   return render(result, options.format);
 }

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
-import { lstatSync, mkdtempSync, statSync } from 'node:fs';
+import { lstatSync, mkdirSync, mkdtempSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { formatJson } from '../output/json.js';
 import { formatText } from '../output/text.js';
@@ -13,6 +13,7 @@ import { parsePageRange } from './pageRange.js';
 interface CacheKeyInput {
   pages?: string;
   render?: boolean;
+  output?: string;
 }
 
 /**
@@ -30,6 +31,9 @@ function buildCacheKey(input: CacheKeyInput): string {
     // (missing newly-added page fields) are not handed out as fresh results.
     format: 'structured-v3',
     render: !!input.render,
+    // Including the resolved output dir keeps two invocations with
+    // different `--output` targets from sharing image paths.
+    output: input.output ? resolve(input.output) : null,
   });
   const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16);
   return `result_${hash}.json`;
@@ -195,7 +199,13 @@ export async function processDocument(filePath: string, options: ProcessDocument
     let imagePaths: string[] | null = null;
     if (options.render) {
       let imagesDir: string;
-      if (cacheDir) {
+      if (options.output) {
+        // User-supplied path: don't enforce 0o700 here — the caller owns
+        // their output directory and may need it readable for downstream
+        // consumers. We do create it if missing.
+        imagesDir = resolve(options.output);
+        mkdirSync(imagesDir, { recursive: true });
+      } else if (cacheDir) {
         imagesDir = join(cacheDir, 'images');
         ensurePrivateDir(imagesDir);
       } else {
@@ -256,6 +266,7 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
     pages: options.pages,
     render: options.render,
     noCache: options.noCache,
+    output: options.output,
   });
   return render(result, options.format);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,12 @@ export interface ProcessDocumentOptions {
   render?: boolean;
   /** Skip the on-disk cache, always re-extract. Defaults to `false`. */
   noCache?: boolean;
+  /**
+   * Directory to write rendered PNGs into. Only used when `render` is true.
+   * If unset, pdfvision picks a path under the cache (or OS tmp) directory.
+   * The directory is created if it doesn't already exist.
+   */
+  output?: string;
 }
 
 export interface ProcessOptions {
@@ -19,6 +25,7 @@ export interface ProcessOptions {
   format: OutputFormat;
   noCache: boolean;
   render?: boolean;
+  output?: string;
 }
 
 export interface PageResult {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,7 @@ export interface ProcessDocumentOptions {
    * If unset, pdfvision picks a path under the cache (or OS tmp) directory.
    * The directory is created if it doesn't already exist.
    */
-  output?: string;
+  renderOutput?: string;
 }
 
 export interface ProcessOptions {
@@ -25,7 +25,7 @@ export interface ProcessOptions {
   format: OutputFormat;
   noCache: boolean;
   render?: boolean;
-  output?: string;
+  renderOutput?: string;
 }
 
 export interface PageResult {

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -102,12 +102,13 @@ describe('cli', () => {
     expect(out).toMatch(/\[Page 1\] \(chars: \d+, images: \d+, coverage: \d+%\)/);
   });
 
-  it('rejects --output without --render', async () => {
-    // -o only meaningfully writes when --render is requested. Silent no-op
-    // would leave the user's empty directory looking like a tooling bug.
-    const r = await captureRun([SAMPLE_PDF, '--output', '/tmp/whatever']);
+  it('rejects --render-output without --render', async () => {
+    // --render-output only meaningfully writes when --render is requested.
+    // Silent no-op would leave the user's empty directory looking like a
+    // tooling bug.
+    const r = await captureRun([SAMPLE_PDF, '--render-output', '/tmp/whatever']);
     expect(r.exitCode).toBe(1);
-    expect(r.stderr.join('\n')).toMatch(/--output requires --render/);
+    expect(r.stderr.join('\n')).toMatch(/--render-output requires --render/);
   });
 
   it('surfaces processor errors as a clean CLI error', async () => {

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -102,6 +102,14 @@ describe('cli', () => {
     expect(out).toMatch(/\[Page 1\] \(chars: \d+, images: \d+, coverage: \d+%\)/);
   });
 
+  it('rejects --output without --render', async () => {
+    // -o only meaningfully writes when --render is requested. Silent no-op
+    // would leave the user's empty directory looking like a tooling bug.
+    const r = await captureRun([SAMPLE_PDF, '--output', '/tmp/whatever']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--output requires --render/);
+  });
+
   it('surfaces processor errors as a clean CLI error', async () => {
     // Invalid pages selector — processor throws, CLI should turn that into
     // exit(1) + stderr message instead of an unhandled rejection.

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -61,18 +61,18 @@ describe('processDocument', () => {
     expect(existsSync(result.pages[0].image as string)).toBe(true);
   });
 
-  it('writes rendered PNGs into a caller-supplied output directory', async () => {
-    // Agent ergonomics: with -o the output should land directly in the
-    // caller's chosen directory (created if missing) rather than under tmp.
+  it('writes rendered PNGs into a caller-supplied renderOutput directory', async () => {
+    // Agent ergonomics: with renderOutput the PNGs should land directly in
+    // the caller's chosen directory (created if missing) rather than tmp.
     const { mkdtempSync, rmSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
     const { join, dirname } = await import('node:path');
-    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-output-test-'));
+    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-output-test-'));
     const outDir = join(baseTmp, 'nested', 'images'); // not yet created
     try {
       const result = await processDocument(SAMPLE_PDF, {
         render: true,
-        output: outDir,
+        renderOutput: outDir,
         noCache: true,
       });
       const imagePath = result.pages[0].image as string;

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -61,6 +61,30 @@ describe('processDocument', () => {
     expect(existsSync(result.pages[0].image as string)).toBe(true);
   });
 
+  it('writes rendered PNGs into a caller-supplied output directory', async () => {
+    // Agent ergonomics: with -o the output should land directly in the
+    // caller's chosen directory (created if missing) rather than under tmp.
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join, dirname } = await import('node:path');
+    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-output-test-'));
+    const outDir = join(baseTmp, 'nested', 'images'); // not yet created
+    try {
+      const result = await processDocument(SAMPLE_PDF, {
+        render: true,
+        output: outDir,
+        noCache: true,
+      });
+      const imagePath = result.pages[0].image as string;
+      expect(imagePath).toBeTypeOf('string');
+      expect(existsSync(imagePath)).toBe(true);
+      // The PNG must be inside the requested directory, not anywhere else.
+      expect(dirname(imagePath)).toBe(outDir);
+    } finally {
+      rmSync(baseTmp, { recursive: true, force: true });
+    }
+  });
+
   it('produces the same DocumentResult that processFile then JSON.parse would', async () => {
     // Same content under both APIs is the contract.
     const direct = await processDocument(SAMPLE_PDF, { noCache: true });


### PR DESCRIPTION
## Summary

- New CLI flag: \`--render-output <dir>\` — write rendered PNGs into the caller's chosen directory
- Library API: \`ProcessDocumentOptions.renderOutput\`
- Directory is created if missing
- \`--render-output\` without \`-r/--render\` errors out (no silent no-op)
- Render-output path folded into the cache key so different targets don't share cached image paths
- HELP_TEXT updated with usage + example

## Why

Without this, agents wanting to keep render output had to either work with paths inside the OS tempdir or grep the JSON output for image paths and \`cp\` them. Now \`pdfvision foo.pdf -r --render-output ./images\` puts \`page-1.png\` etc. directly where the agent will read them.

A bare \`-o\` was the original design but reads as "the output of pdfvision" (text/json), which is misleading — the flag only affects PNGs. \`--render-output\` is self-documenting and leaves \`-o\` available for a future text-output flag if needed.

## Smoke test

\`\`\`bash
$ pdfvision tests/fixtures/sample.pdf -r --render-output /tmp/pdfv-out
# JSON includes "image": "/tmp/pdfv-out/page-1.png"
$ ls /tmp/pdfv-out/
page-1.png

$ pdfvision tests/fixtures/sample.pdf --render-output /tmp/x
Error: --render-output requires --render
\`\`\`

## Test plan

- [x] \`npm test\` — 63 tests pass (added 2 new: CLI rejects --render-output without --render, processor writes to specified dir)
- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [x] Manual smoke test with the rename applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)