### PR TITLE
feat(output): add --format markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It's the missing piece between "I have a PDF" and "my AI agent can use it."
 - 🏷️ **Metadata extraction** (title, author, subject, creator)
 - 🎯 **Page range selection** (`1-5`, `3`, `1,3,5`)
 - 🖼️ **Page rendering** to PNG (`--render`) for multimodal LLMs
-- 📦 **Output formats**: human-readable `text` and structured `json`
+- 📦 **Output formats**: human-readable `text`, agent-friendly `markdown`, and structured `json`
 - ⚡ **Cache-first**: same PDF is parsed once, then served instantly from a `pdfvision/<hash>/` directory under the OS temp dir
 - 🛡️ **Hardened cache**: content-addressed, POSIX `0700/0600` permissions, symlink/TOCTOU defences
 - 🪶 **Small & fast**: ~11 KB tarball, ~30 ms warm startup for `--help`/`--version`
@@ -59,7 +59,7 @@ pdfvision <file.pdf> [options]
 
 Options:
   -p, --pages <range>   Page range (e.g. "1-5", "3", "1,3,5")
-  -f, --format <type>   Output format: text (default), json
+  -f, --format <type>   Output format: text (default), json, markdown
   -r, --render          Render pages as PNG images
       --no-cache        Skip cache
   -v, --version         Show version
@@ -81,6 +81,9 @@ pdfvision document.pdf -r -p 1-5
 
 # Get JSON output
 pdfvision document.pdf -f json
+
+# Get Markdown output (each page as ## Page N, with density signals and image links)
+pdfvision document.pdf -f markdown
 ```
 
 ### Caching
@@ -134,7 +137,7 @@ process or a log), use **`processFile()`**:
 import { processFile } from 'pdfvision';
 
 const text = await processFile('./document.pdf', {
-  format: 'text',           // or 'json'
+  format: 'text',           // or 'json' / 'markdown'
   noCache: false,
 });
 ```

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -5,7 +5,7 @@ import type { OutputFormat } from '../types/index.js';
 import { HELP_TEXT } from './help.js';
 import { getVersion } from './version.js';
 
-const VALID_FORMATS: readonly OutputFormat[] = ['text', 'json'];
+const VALID_FORMATS: readonly OutputFormat[] = ['text', 'json', 'markdown'];
 
 function isValidFormat(value: string): value is OutputFormat {
   return (VALID_FORMATS as readonly string[]).includes(value);

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -5,7 +5,7 @@ Usage:
 
 Options:
   -p, --pages <range>     Page range (e.g. "1-5", "3", "1,3,5")
-  -f, --format <type>     Output format: text (default), json
+  -f, --format <type>     Output format: text (default), json, markdown
   -r, --render            Render pages as PNG images
       --render-output <dir>
                           Directory for rendered PNGs (requires --render).
@@ -19,4 +19,5 @@ Examples:
   pdfvision document.pdf -p 1-3
   pdfvision document.pdf -r -p 1-5
   pdfvision document.pdf -r --render-output ./images
-  pdfvision document.pdf -f json`;
+  pdfvision document.pdf -f json
+  pdfvision document.pdf -f markdown`;

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { formatJson } from '../output/json.js';
+import { formatMarkdown } from '../output/markdown.js';
 import { formatText } from '../output/text.js';
 import type { DocumentResult, PageResult, ProcessDocumentOptions, ProcessOptions } from '../types/index.js';
 import { dropCached, ensurePrivateDir, getCacheDir, getCached, setCache } from './cache.js';
@@ -97,7 +98,9 @@ async function extractPageData(doc: PDFDocumentProxy, pageNum: number, imageOps:
 
 /** Render a structured DocumentResult into the caller-requested string format. */
 function render(result: DocumentResult, format: ProcessOptions['format']): string {
-  return format === 'json' ? formatJson(result) : formatText(result);
+  if (format === 'json') return formatJson(result);
+  if (format === 'markdown') return formatMarkdown(result);
+  return formatText(result);
 }
 
 /**

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -14,6 +14,8 @@ export function formatMarkdown(result: DocumentResult): string {
   lines.push(`- **Pages:** ${result.totalPages}`);
   if (result.metadata.title) lines.push(`- **Title:** ${result.metadata.title}`);
   if (result.metadata.author) lines.push(`- **Author:** ${result.metadata.author}`);
+  if (result.metadata.subject) lines.push(`- **Subject:** ${result.metadata.subject}`);
+  if (result.metadata.creator) lines.push(`- **Creator:** ${result.metadata.creator}`);
 
   for (const page of result.pages) {
     const coveragePct = Math.round(page.textCoverage * 100);

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -1,0 +1,40 @@
+import type { DocumentResult } from '../types/index.js';
+
+/**
+ * Markdown variant of the formatter, intended for agents that already speak
+ * Markdown (Claude / Cursor / chat UIs). Each page becomes its own `## Page N`
+ * heading so callers can jump or chunk by page, and density metadata stays
+ * visible as a single italic line to keep the silent-failure signal close to
+ * the text.
+ */
+export function formatMarkdown(result: DocumentResult): string {
+  const lines: string[] = [];
+  lines.push(`# ${result.file}`);
+  lines.push('');
+  lines.push(`- **Pages:** ${result.totalPages}`);
+  if (result.metadata.title) lines.push(`- **Title:** ${result.metadata.title}`);
+  if (result.metadata.author) lines.push(`- **Author:** ${result.metadata.author}`);
+
+  for (const page of result.pages) {
+    const coveragePct = Math.round(page.textCoverage * 100);
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+    lines.push(`## Page ${page.page}`);
+    lines.push('');
+    lines.push(`_chars: ${page.charCount} · images: ${page.imageCount} · coverage: ${coveragePct}%_`);
+    if (page.text) {
+      lines.push('');
+      lines.push(page.text);
+    }
+    if (page.image) {
+      lines.push('');
+      // Use the <...> link destination form so paths with spaces or
+      // parentheses (common with `--render-output ./my (drafts)/`) don't
+      // break the image link. Filesystem paths effectively never contain
+      // `<` or `>`, so no further escaping is needed.
+      lines.push(`![Page ${page.page}](<${page.image}>)`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type OutputFormat = 'text' | 'json';
+export type OutputFormat = 'text' | 'json' | 'markdown';
 
 /**
  * Options for the structured `processDocument()` API.

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -102,6 +102,17 @@ describe('cli', () => {
     expect(out).toMatch(/\[Page 1\] \(chars: \d+, images: \d+, coverage: \d+%\)/);
   });
 
+  it('prints markdown when --format markdown is requested', async () => {
+    // Guards the CLI -> processFile -> formatMarkdown wiring against
+    // accidental fallbacks to text.
+    const r = await captureRun([SAMPLE_PDF, '--format', 'markdown', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    const out = r.stdout.join('\n');
+    expect(out).toMatch(/^# .*sample\.pdf/);
+    expect(out).toMatch(/## Page 1/);
+    expect(out).toContain('Hello pdfvision');
+  });
+
   it('rejects --render-output without --render', async () => {
     // --render-output only meaningfully writes when --render is requested.
     // Silent no-op would leave the user's empty directory looking like a

--- a/tests/core/processor.test.ts
+++ b/tests/core/processor.test.ts
@@ -29,6 +29,18 @@ describe('processFile', () => {
     expect(parsed.pages[0].text).toContain('Hello pdfvision');
   });
 
+  it('extracts text as markdown', async () => {
+    // Guard the format='markdown' wiring through processFile so the CLI
+    // path can't silently fall through to text on a typo in the switch.
+    const result = await processFile(SAMPLE_PDF, {
+      format: 'markdown',
+      noCache: true,
+    });
+    expect(result).toMatch(/^# .*sample\.pdf/);
+    expect(result).toMatch(/## Page 1/);
+    expect(result).toContain('Hello pdfvision');
+  });
+
   it('respects page range', async () => {
     const result = await processFile(SAMPLE_PDF, {
       pages: '1',

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { formatMarkdown } from '../../src/output/markdown.js';
+import type { DocumentResult } from '../../src/types/index.js';
+
+function makeResult(overrides: Partial<DocumentResult> = {}): DocumentResult {
+  return {
+    file: '/tmp/x.pdf',
+    totalPages: 1,
+    metadata: { title: null, author: null, subject: null, creator: null },
+    pages: [{ page: 1, text: 'hello world', charCount: 11, imageCount: 0, textCoverage: 0.123 }],
+    ...overrides,
+  };
+}
+
+describe('formatMarkdown', () => {
+  it('renders a top-level heading with the file path and a Pages bullet', () => {
+    const out = formatMarkdown(makeResult());
+    expect(out).toMatch(/^# \/tmp\/x\.pdf\n/);
+    expect(out).toMatch(/- \*\*Pages:\*\* 1/);
+  });
+
+  it('omits Title and Author bullets when both are absent', () => {
+    const out = formatMarkdown(makeResult());
+    expect(out).not.toMatch(/\*\*Title:\*\*/);
+    expect(out).not.toMatch(/\*\*Author:\*\*/);
+  });
+
+  it('includes Title and Author bullets when both are present', () => {
+    const out = formatMarkdown(
+      makeResult({
+        metadata: { title: 'My Doc', author: 'Alice', subject: null, creator: null },
+      }),
+    );
+    expect(out).toMatch(/- \*\*Title:\*\* My Doc/);
+    expect(out).toMatch(/- \*\*Author:\*\* Alice/);
+  });
+
+  it('renders each page as ## Page N with a density signal line and the text body', () => {
+    const out = formatMarkdown(makeResult());
+    expect(out).toMatch(/## Page 1/);
+    // Coverage 0.123 → 12% (rounded). Density line uses italic + middle dot
+    // so agents can pattern-match without colliding with normal page text.
+    expect(out).toMatch(/_chars: 11 · images: 0 · coverage: 12%_/);
+    expect(out).toMatch(/\nhello world$/);
+  });
+
+  it('emits a Markdown image link when the page has a rendered PNG path', () => {
+    const out = formatMarkdown(
+      makeResult({
+        pages: [{ page: 1, text: 't', charCount: 1, imageCount: 0, textCoverage: 0, image: '/tmp/p.png' }],
+      }),
+    );
+    expect(out).toMatch(/!\[Page 1\]\(<\/tmp\/p\.png>\)/);
+  });
+
+  it('keeps image links intact when the path contains spaces or parentheses', () => {
+    // --render-output may point at a directory like "./my (drafts)/", and
+    // the unescaped `(` inside `![...](...)` would otherwise terminate the
+    // link destination early. The angle-bracket form must survive that.
+    const out = formatMarkdown(
+      makeResult({
+        pages: [
+          {
+            page: 1,
+            text: 't',
+            charCount: 1,
+            imageCount: 0,
+            textCoverage: 0,
+            image: '/tmp/my (drafts)/page 1.png',
+          },
+        ],
+      }),
+    );
+    expect(out).toContain('![Page 1](</tmp/my (drafts)/page 1.png>)');
+  });
+
+  it('separates pages with --- so multi-page docs stay readable', () => {
+    const out = formatMarkdown(
+      makeResult({
+        totalPages: 2,
+        pages: [
+          { page: 1, text: 'one', charCount: 3, imageCount: 0, textCoverage: 0 },
+          { page: 2, text: 'two', charCount: 3, imageCount: 0, textCoverage: 0 },
+        ],
+      }),
+    );
+    // Two page sections separated by a horizontal rule.
+    expect(out.match(/^---$/gm)?.length).toBe(2);
+    expect(out.indexOf('## Page 1')).toBeLessThan(out.indexOf('## Page 2'));
+  });
+
+  it('skips the text body for pages that had no extractable text', () => {
+    // Image-only pages should still render the heading + density line so the
+    // agent can see "this page had 0 chars and 3 images" instead of a silent gap.
+    const out = formatMarkdown(
+      makeResult({
+        pages: [{ page: 1, text: '', charCount: 0, imageCount: 3, textCoverage: 0 }],
+      }),
+    );
+    expect(out).toMatch(/## Page 1/);
+    expect(out).toMatch(/images: 3/);
+  });
+});

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -25,14 +25,18 @@ describe('formatMarkdown', () => {
     expect(out).not.toMatch(/\*\*Author:\*\*/);
   });
 
-  it('includes Title and Author bullets when both are present', () => {
+  it('includes every metadata bullet that is present', () => {
+    // Markdown is targeted at agent context where more metadata = more
+    // grounding, so all four DocumentMetadata fields surface as bullets.
     const out = formatMarkdown(
       makeResult({
-        metadata: { title: 'My Doc', author: 'Alice', subject: null, creator: null },
+        metadata: { title: 'My Doc', author: 'Alice', subject: 'Quarterly review', creator: 'LaTeX' },
       }),
     );
     expect(out).toMatch(/- \*\*Title:\*\* My Doc/);
     expect(out).toMatch(/- \*\*Author:\*\* Alice/);
+    expect(out).toMatch(/- \*\*Subject:\*\* Quarterly review/);
+    expect(out).toMatch(/- \*\*Creator:\*\* LaTeX/);
   });
 
   it('renders each page as ## Page N with a density signal line and the text body', () => {


### PR DESCRIPTION
## Summary
- New `formatMarkdown()` formatter renders each page as `## Page N` with the chars/images/coverage density signal as a single italic line
- Wired through `OutputFormat`, CLI `--format` validator, and `HELP_TEXT`
- Image links use the angle-bracket form `![Page N](<path>)` so paths with spaces or parentheses (e.g. `--render-output ./my (drafts)/`) survive

## Why
Agents that already speak Markdown (Claude / Cursor / chat UIs) can drop the output straight into a conversation without parsing JSON or stripping the bespoke `text` header. Per-page headings let them chunk by page; the density line keeps silent-failure detection visible.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 73 tests pass (3 new: formatter unit, processFile wiring, CLI wiring)
- [x] Smoke test: `pdfvision sample.pdf -f markdown`, multi-page Japanese PDF, and `-r -f markdown`
- [x] Codex review loop (2 iterations): blocker 0 / remaining concerns intentionally skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)