### PR TITLE
chore(ci): add Node.js 26 to CI matrix and adopt Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,21 +9,22 @@
   "labels": ["dependencies", "renovate"],
   "packageRules": [
     {
-      matchDepTypes: ["peerDependencies"],
-      enabled: false,
+      "matchDepTypes": ["peerDependencies"],
+      "enabled": false,
     },
-    // Single root package.json — group non-major and major separately so
-    // patch / minor bumps land in one PR per week and majors are easy to
-    // review one at a time.
+    // Single root package.json — group non-major bumps into one weekly
+    // PR and major bumps into a separate weekly PR so review can keep
+    // riskier changes (majors) cleanly isolated from routine minor /
+    // patch updates.
     {
-      matchFileNames: ["package.json"],
-      matchUpdateTypes: ["minor", "patch"],
-      groupName: "non-major dependencies",
+      "matchFileNames": ["package.json"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major dependencies",
     },
     {
-      matchFileNames: ["package.json"],
-      matchUpdateTypes: ["major"],
-      groupName: "major dependencies",
+      "matchFileNames": ["package.json"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "major dependencies",
     },
   ],
   "ignoreDeps": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+  ],
+  "schedule": ["before 9am on saturday"],
+  "rangeStrategy": "bump",
+  "dependencyDashboard": false,
+  "labels": ["dependencies", "renovate"],
+  "packageRules": [
+    {
+      matchDepTypes: ["peerDependencies"],
+      enabled: false,
+    },
+    // Single root package.json — group non-major and major separately so
+    // patch / minor bumps land in one PR per week and majors are easy to
+    // review one at a time.
+    {
+      matchFileNames: ["package.json"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "non-major dependencies",
+    },
+    {
+      matchFileNames: ["package.json"],
+      matchUpdateTypes: ["major"],
+      groupName: "major dependencies",
+    },
+  ],
+  "ignoreDeps": [
+    // Node engines are bumped intentionally alongside CI matrix changes.
+    "node",
+  ],
+  // Wait a week before opening a PR to dodge buggy initial releases that
+  // get yanked or hot-patched.
+  "minimumReleaseAge": "7 days",
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
@@ -127,7 +127,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -6,6 +6,7 @@ import { processDocument, processFile } from '../../src/core/processor.js';
 const SAMPLE_PDF = resolve(__dirname, '../fixtures/sample.pdf');
 const SAMPLE_JA_PDF = resolve(__dirname, '../fixtures/sample-ja.pdf');
 const SAMPLE_WITH_IMAGE_PDF = resolve(__dirname, '../fixtures/sample-with-image.pdf');
+const SAMPLE_TILED_PDF = resolve(__dirname, '../fixtures/sample-tiled.pdf');
 
 describe('processDocument', () => {
   it('returns a structured DocumentResult, no JSON parsing required', async () => {
@@ -141,13 +142,20 @@ describe('processDocument', () => {
     // it. The next call must detect the missing image, drop the stale
     // payload, and re-render instead of returning a path the caller can't
     // use. This exercises isUsableImage + the cache-eviction branch.
+    //
+    // Use SAMPLE_TILED_PDF rather than SAMPLE_PDF: SAMPLE_PDF's cache dir
+    // is contended by the corruption / chmod tests in processor.test.ts
+    // when those workers run in parallel under vitest, which can race
+    // this test's renderPage atomicWrite and produce flaky ENOENT
+    // failures on slower CI runners. SAMPLE_TILED_PDF's cache dir is
+    // otherwise idle (every other reference uses noCache: true).
     const { unlinkSync } = await import('node:fs');
-    const populated = await processDocument(SAMPLE_PDF, { render: true, noCache: false });
+    const populated = await processDocument(SAMPLE_TILED_PDF, { render: true, noCache: false });
     const imagePath = populated.pages[0].image as string;
     expect(existsSync(imagePath)).toBe(true);
     unlinkSync(imagePath);
 
-    const recovered = await processDocument(SAMPLE_PDF, { render: true, noCache: false });
+    const recovered = await processDocument(SAMPLE_TILED_PDF, { render: true, noCache: false });
     expect(recovered.pages[0].image).toBeTypeOf('string');
     expect(existsSync(recovered.pages[0].image as string)).toBe(true);
   });


### PR DESCRIPTION
## Summary

Two related housekeeping changes pulled into one PR:

- **Node.js 26**: add \`26.x\` to the \`test\` and \`build-and-run\` matrices. Node 22 stays as the engines floor; Node 20 was already off the matrix.
- **Renovate**: add \`.github/renovate.json5\`, modeled after the [repomix config](https://github.com/yamadashy/repomix/blob/main/.github/renovate.json5).

## Renovate config highlights

- Weekly run, before 9am Saturday
- \`rangeStrategy: bump\` (rewrites the version range)
- Non-major and major updates grouped into separate PRs (one PR per group per week)
- \`peerDependencies\` disabled
- \`minimumReleaseAge: 7 days\` to dodge yanked initial releases
- \`node\` in \`ignoreDeps\` — engines bumps stay a manual matrix change

Single root \`package.json\` so the per-folder rules from the repomix monorepo config don't apply here.

Renovate replaces ad-hoc Dependabot version-update PRs (Dependabot security alerts keep running — they don't depend on this config).

## Activation note

To start receiving Renovate PRs the [Renovate GitHub App](https://github.com/apps/renovate) needs to be installed on \`yamadashy/pdfvision\` — the config alone isn't enough. App install is a UI step, separate from this PR.

## Test plan

- [x] \`npm run lint\` clean
- [ ] CI matrix passes on all three Node versions across ubuntu / macos / windows (will verify on push)
- [ ] After merge: install Renovate App on the repo and confirm the first weekly PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)