### PR TITLE
feat(cli): --remote <url> for fetching PDFs and --clear-cache

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -39,6 +39,8 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         geometry: { type: 'boolean' },
         layout: { type: 'boolean' },
         'image-boxes': { type: 'boolean' },
+        remote: { type: 'string' },
+        'clear-cache': { type: 'boolean' },
       },
     });
     values = parsed.values as Record<string, string | boolean | undefined>;
@@ -52,13 +54,36 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     return;
   }
 
-  if (values.help || positionals.length === 0) {
+  if (values['clear-cache']) {
+    // --clear-cache is a side-effect operation that ignores everything
+    // else: no extraction runs, no positional needed, just nuke the
+    // shared pdfvision cache and exit. Lazy-import to keep the heavy
+    // node:fs surface out of --help / --version paths.
+    try {
+      const { clearAllCache } = await import('../core/cache.js');
+      const { path, removed } = clearAllCache();
+      console.log(removed ? `Cleared pdfvision cache: ${path}` : `Nothing to clear: ${path} does not exist`);
+      return;
+    } catch (error) {
+      exitWithError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  const remoteUrl = values.remote as string | undefined;
+  // --help is requested explicitly OR there's no input source at all
+  // (no positional and no --remote URL). Print help and bail.
+  if (values.help || (positionals.length === 0 && !remoteUrl)) {
     console.log(HELP_TEXT);
     return;
   }
 
   if (positionals.length > 1) {
     exitWithError(`Unexpected extra arguments: ${positionals.slice(1).join(' ')}`);
+  }
+  if (remoteUrl && positionals.length > 0) {
+    // Two input sources at once is almost certainly a mistake — bail
+    // rather than silently picking one over the other.
+    exitWithError('--remote and a file path are mutually exclusive');
   }
 
   const format = (values.format as string) ?? 'markdown';
@@ -74,12 +99,23 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     exitWithError('--render-output requires --render');
   }
 
-  const filePath = resolve(positionals[0]);
+  const noCache = (values['no-cache'] as boolean | undefined) ?? false;
 
-  try {
-    accessSync(filePath);
-  } catch {
-    exitWithError(`File not found: ${filePath}`);
+  let filePath: string;
+  if (remoteUrl) {
+    try {
+      const { downloadRemote } = await import('../core/remote.js');
+      filePath = await downloadRemote(remoteUrl, { noCache });
+    } catch (error) {
+      exitWithError(error instanceof Error ? error.message : String(error));
+    }
+  } else {
+    filePath = resolve(positionals[0]);
+    try {
+      accessSync(filePath);
+    } catch {
+      exitWithError(`File not found: ${filePath}`);
+    }
   }
 
   try {
@@ -92,7 +128,7 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
       format,
       render,
       renderOutput,
-      noCache: (values['no-cache'] as boolean | undefined) ?? false,
+      noCache,
       // NFKC normalization is on by default — agents almost always want
       // canonical Unicode. --no-normalize lets callers opt out for cases
       // where the raw pdf.js code points matter (forensics, glyph-level

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -10,6 +10,8 @@ export const HELP_TEXT = `pdfvision - Extract text, images, metadata, and layout
 
 Usage:
   pdfvision <file.pdf> [options]
+  pdfvision --remote <url> [options]
+  pdfvision --clear-cache
 
 Options
   -p, --pages <range>     Pages to extract: "1", "1-5", "1,3,5", "2-4,7". Default: all pages.
@@ -26,7 +28,12 @@ Options
                           reading order) from the same span data. Only -f json / -f xml.
       --image-boxes       Emit \`pages[].imageBoxes\` — bounding box of every raster image
                           draw on the page. Only -f json / -f xml.
-      --no-cache          Skip the on-disk cache.
+      --remote <url>      Download an http(s) URL to the on-disk cache and run extraction
+                          on it. Same URL → same cache slot; combine with --no-cache (or
+                          --clear-cache) to refresh.
+      --no-cache          Skip the on-disk cache (re-download / re-extract every run).
+      --clear-cache       Remove every cached extraction, rendered PNG, and downloaded
+                          remote PDF, then exit. No file argument required.
   -v, --version           Show version
   -h, --help              Show this help
 
@@ -41,7 +48,9 @@ Examples
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
   pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry -f json   # PNGs + spans for 3-5
   pdfvision slides.pdf -f xml --geometry                                       # layout / geometry as XML
+  pdfvision --remote https://example.com/paper.pdf -f json                     # fetch + extract JSON
+  pdfvision --clear-cache                                                      # wipe the on-disk cache
 
 Exit codes
   0  Success
-  1  Argument error, file not found, or extraction failure (error message on stderr)`;
+  1  Argument error, file not found, network error, or extraction failure (error message on stderr)`;

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -195,3 +195,41 @@ export function dropCached(cacheDir: string, key: string): void {
 // Exposed for renderer + processor so they apply the same hardened
 // directory creation policy as the cache helpers.
 export { ensurePrivateDir };
+
+/**
+ * Result of a `--clear-cache` pass. Both fields are present even when
+ * the cache directory was already absent, so the CLI can print a
+ * uniform "Cleared <path>" message regardless of whether the run did
+ * any actual work.
+ */
+export interface ClearCacheResult {
+  /** Absolute path that was (or would have been) cleared. */
+  path: string;
+  /** True when the directory existed and was removed; false on a no-op clear. */
+  removed: boolean;
+}
+
+/**
+ * Wipe the entire pdfvision cache root. Removes every result-cache
+ * subdirectory, every `--render` PNG, and every remote-download cache.
+ * Refuses to follow symlinks at the root path; if the path is a symlink
+ * the call throws so the user can investigate manually rather than
+ * having pdfvision delete arbitrary files.
+ *
+ * The optional `path` argument overrides the default cache root. The
+ * CLI never passes one (it always operates on the shared root); tests
+ * use it to clean an isolated temp directory without racing other
+ * vitest workers that are concurrently writing to the shared root.
+ */
+export function clearAllCache(path: string = CACHE_DIR): ClearCacheResult {
+  if (!existsSync(path)) return { path, removed: false };
+  // Refuse to traverse a symlink at the cache root — would let an
+  // attacker who plants /tmp/pdfvision -> /home/user redirect the
+  // cleanup outside the cache hierarchy.
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Refusing to clear cache at ${path}: path is a symlink`);
+  }
+  rmSync(path, { recursive: true, force: true });
+  return { path, removed: true };
+}

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -17,7 +17,16 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const CACHE_DIR = join(tmpdir(), 'pdfvision');
+/**
+ * Resolve the cache root afresh on every call so a test that sets
+ * `PDFVISION_CACHE_DIR` can isolate its writes from concurrent vitest
+ * workers without statically-baked-in module state. Production callers
+ * leave the env var unset and get the same `<tmpdir>/pdfvision/` they
+ * always have.
+ */
+function getCacheRoot(): string {
+  return process.env.PDFVISION_CACHE_DIR ?? join(tmpdir(), 'pdfvision');
+}
 
 // Cache files may contain extracted PDF text and rendered page images.
 // Restrict to the current user so other accounts on the same machine
@@ -98,8 +107,9 @@ function hashFileContent(filePath: string): string {
 
 export function getCacheDir(filePath: string): string {
   const key = hashFileContent(filePath);
-  ensurePrivateDir(CACHE_DIR);
-  const dir = join(CACHE_DIR, key);
+  const root = getCacheRoot();
+  ensurePrivateDir(root);
+  const dir = join(root, key);
   ensurePrivateDir(dir);
   return dir;
 }
@@ -221,7 +231,7 @@ export interface ClearCacheResult {
  * use it to clean an isolated temp directory without racing other
  * vitest workers that are concurrently writing to the shared root.
  */
-export function clearAllCache(path: string = CACHE_DIR): ClearCacheResult {
+export function clearAllCache(path: string = getCacheRoot()): ClearCacheResult {
   if (!existsSync(path)) return { path, removed: false };
   // Refuse to traverse a symlink at the cache root — would let an
   // attacker who plants /tmp/pdfvision -> /home/user redirect the

--- a/src/core/remote.ts
+++ b/src/core/remote.ts
@@ -1,0 +1,177 @@
+import { createHash } from 'node:crypto';
+import { existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { atomicWrite, ensurePrivateDir } from './cache.js';
+
+/**
+ * Root directory for downloaded remote PDFs. Sibling of the result-cache
+ * directory so a single `--clear-cache` clears both — `<tmpdir>/pdfvision/`
+ * is the one place we keep PDF-derived state on disk.
+ */
+const REMOTE_CACHE_ROOT = join(tmpdir(), 'pdfvision', 'remote');
+
+/** Default 100 MB. PDFs at this size are almost always intentionally pathological. */
+const DEFAULT_MAX_BYTES = 100 * 1024 * 1024;
+/** Default 60 s — enough for slow links, short enough that a hung server doesn't lock the CLI. */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface DownloadRemoteOptions {
+  /**
+   * If true, force a fresh download even when a previous cache hit exists.
+   * Mirrors the result-cache `--no-cache` flag so users have one knob.
+   */
+  noCache?: boolean;
+  /** Max bytes to accept. Defaults to 100 MB. */
+  maxBytes?: number;
+  /** Network timeout in milliseconds. Defaults to 60_000. */
+  timeoutMs?: number;
+  /**
+   * Override the global `fetch` for tests. Production callers leave this
+   * unset and pdfvision uses the platform fetch.
+   */
+  fetchImpl?: typeof globalThis.fetch;
+}
+
+/**
+ * Pull a basename out of a URL pathname that's safe to use as a filename.
+ * Falls back to a generic name when the URL has no path or only contains
+ * characters we'd refuse anyway. Keeps the ".pdf" extension whenever the
+ * server provides one because it makes the cache directory navigable.
+ */
+function safeBasenameFromUrl(url: URL): string {
+  const last = url.pathname.split('/').filter(Boolean).pop() ?? '';
+  // Strip path traversal / hidden file markers and anything beyond a
+  // narrow ASCII set. The decoded form is what we'd actually write to
+  // disk, so percent-encoded segments get expanded first.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(last);
+  } catch {
+    decoded = last;
+  }
+  const cleaned = decoded.replace(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+/, '');
+  if (cleaned.length === 0 || cleaned === '..') return 'document.pdf';
+  // Always end in .pdf so the cached file looks like a PDF when
+  // inspected manually — pdf.js doesn't actually check the extension.
+  return cleaned.toLowerCase().endsWith('.pdf') ? cleaned : `${cleaned}.pdf`;
+}
+
+/**
+ * Download a remote PDF and return the local path it was cached at.
+ *
+ * The cache directory is keyed by `sha256(url)` so the same URL always
+ * resolves to the same on-disk file; subsequent calls without
+ * `noCache: true` short-circuit and return the cached path. To pick up
+ * an updated remote PDF, pass `noCache: true` or run
+ * `pdfvision --clear-cache` to nuke the whole cache.
+ *
+ * Only `http:` and `https:` URLs are accepted — `file:`, `data:`,
+ * `ftp:`, etc. are rejected up front so a stray scheme can't escape
+ * the network-fetch path.
+ */
+export async function downloadRemote(rawUrl: string, options: DownloadRemoteOptions = {}): Promise<string> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid URL: ${rawUrl}`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Refusing to download non-http(s) URL: ${rawUrl}`);
+  }
+
+  const noCache = !!options.noCache;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+
+  // sha256(url) keeps two URLs that differ only by query string in
+  // separate cache slots, since they often point at different PDFs
+  // (signed-URL CDNs, version pins). 16 hex chars = 64 bits of
+  // collision resistance; plenty for a per-user cache.
+  const urlHash = createHash('sha256').update(rawUrl).digest('hex').slice(0, 16);
+  const cacheDir = join(REMOTE_CACHE_ROOT, urlHash);
+  const cachePath = join(cacheDir, safeBasenameFromUrl(url));
+
+  if (!noCache && existsSync(cachePath)) {
+    try {
+      if (statSync(cachePath).size > 0) return cachePath;
+    } catch {
+      // fall through and re-download
+    }
+  }
+
+  // Lay down the directory structure with the same hardening the result
+  // cache uses (0o700, owner-checked, no symlink-redirect).
+  ensurePrivateDir(join(tmpdir(), 'pdfvision'));
+  ensurePrivateDir(REMOTE_CACHE_ROOT);
+  ensurePrivateDir(cacheDir);
+
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(rawUrl, { signal: controller.signal, redirect: 'follow' });
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error(`Timed out after ${timeoutMs}ms downloading ${rawUrl}`);
+    }
+    throw new Error(`Network error downloading ${rawUrl}: ${(error as Error).message}`);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText} for ${rawUrl}`);
+  }
+
+  // Some servers send Content-Length up front; a 200 with a too-large
+  // declared length is rejected before we read a single byte. Servers
+  // that omit Content-Length still get capped during the streaming read
+  // below, so this is a fast-path optimisation rather than the only check.
+  const declaredLength = Number(response.headers.get('content-length') ?? '');
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new Error(`Remote PDF declares ${declaredLength} bytes, exceeds limit of ${maxBytes}`);
+  }
+
+  if (response.body === null) {
+    throw new Error(`Remote response has no body: ${rawUrl}`);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      total += value.length;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new Error(`Remote PDF exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const data = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+  // Defensive retry: another process running `--clear-cache` (or a
+  // concurrent test worker rmSync-ing the cache root) can race the
+  // ensurePrivateDir calls above and nuke the parent dir before we
+  // write. Recreate the dirs and try once more on ENOENT before
+  // surfacing the error.
+  try {
+    atomicWrite(cachePath, data);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    ensurePrivateDir(join(tmpdir(), 'pdfvision'));
+    ensurePrivateDir(REMOTE_CACHE_ROOT);
+    ensurePrivateDir(cacheDir);
+    atomicWrite(cachePath, data);
+  }
+  return cachePath;
+}

--- a/src/core/remote.ts
+++ b/src/core/remote.ts
@@ -165,7 +165,7 @@ export async function downloadRemote(rawUrl: string, options: DownloadRemoteOpti
     reader.releaseLock();
   }
 
-  const data = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+  const data = Buffer.concat(chunks);
   // Defensive retry: another process running `--clear-cache` (or a
   // concurrent test worker rmSync-ing the cache root) can race the
   // ensurePrivateDir calls above and nuke the parent dir before we

--- a/src/core/remote.ts
+++ b/src/core/remote.ts
@@ -7,9 +7,16 @@ import { atomicWrite, ensurePrivateDir } from './cache.js';
 /**
  * Root directory for downloaded remote PDFs. Sibling of the result-cache
  * directory so a single `--clear-cache` clears both — `<tmpdir>/pdfvision/`
- * is the one place we keep PDF-derived state on disk.
+ * is the one place we keep PDF-derived state on disk. Honours the same
+ * `PDFVISION_CACHE_DIR` override the rest of cache.ts uses, so tests can
+ * isolate the entire cache hierarchy in a temp directory.
  */
-const REMOTE_CACHE_ROOT = join(tmpdir(), 'pdfvision', 'remote');
+function cacheRoot(): string {
+  return process.env.PDFVISION_CACHE_DIR ?? join(tmpdir(), 'pdfvision');
+}
+function remoteCacheRoot(): string {
+  return join(cacheRoot(), 'remote');
+}
 
 /** Default 100 MB. PDFs at this size are almost always intentionally pathological. */
 const DEFAULT_MAX_BYTES = 100 * 1024 * 1024;
@@ -91,7 +98,7 @@ export async function downloadRemote(rawUrl: string, options: DownloadRemoteOpti
   // (signed-URL CDNs, version pins). 16 hex chars = 64 bits of
   // collision resistance; plenty for a per-user cache.
   const urlHash = createHash('sha256').update(rawUrl).digest('hex').slice(0, 16);
-  const cacheDir = join(REMOTE_CACHE_ROOT, urlHash);
+  const cacheDir = join(remoteCacheRoot(), urlHash);
   const cachePath = join(cacheDir, safeBasenameFromUrl(url));
 
   if (!noCache && existsSync(cachePath)) {
@@ -104,8 +111,8 @@ export async function downloadRemote(rawUrl: string, options: DownloadRemoteOpti
 
   // Lay down the directory structure with the same hardening the result
   // cache uses (0o700, owner-checked, no symlink-redirect).
-  ensurePrivateDir(join(tmpdir(), 'pdfvision'));
-  ensurePrivateDir(REMOTE_CACHE_ROOT);
+  ensurePrivateDir(cacheRoot());
+  ensurePrivateDir(remoteCacheRoot());
   ensurePrivateDir(cacheDir);
 
   const controller = new AbortController();
@@ -168,8 +175,8 @@ export async function downloadRemote(rawUrl: string, options: DownloadRemoteOpti
     atomicWrite(cachePath, data);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-    ensurePrivateDir(join(tmpdir(), 'pdfvision'));
-    ensurePrivateDir(REMOTE_CACHE_ROOT);
+    ensurePrivateDir(cacheRoot());
+    ensurePrivateDir(remoteCacheRoot());
     ensurePrivateDir(cacheDir);
     atomicWrite(cachePath, data);
   }

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { run } from '../../src/cli/cli.js';
@@ -128,4 +130,42 @@ describe('cli', () => {
     expect(r.exitCode).toBe(1);
     expect(r.stderr.join('\n')).toMatch(/positive integer|invalid|Error/i);
   });
+
+  it('rejects --remote and a positional file at the same time', async () => {
+    // Two input sources is almost always a typo; refuse rather than
+    // silently picking one.
+    const r = await captureRun(['--remote', 'http://127.0.0.1:0/x.pdf', SAMPLE_PDF]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--remote and a file path are mutually exclusive/);
+  });
+
+  it('downloads a remote PDF and runs extraction against it', async () => {
+    // Spin up a one-off http server that serves the existing sample
+    // fixture, point --remote at it, and assert the markdown body
+    // matches what we'd get from running locally on the same bytes.
+    const fixtureBytes = await import('node:fs').then(({ readFileSync }) => readFileSync(SAMPLE_PDF));
+    const server = createServer((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/pdf');
+      res.end(fixtureBytes);
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const r = await captureRun(['--remote', `http://127.0.0.1:${port}/doc.pdf`, '--no-cache']);
+      expect(r.exitCode).toBeNull();
+      expect(r.stdout.join('\n')).toContain('Hello pdfvision');
+    } finally {
+      await new Promise<void>((resolveClose, reject) => server.close((err) => (err ? reject(err) : resolveClose())));
+    }
+  });
 });
+
+// --clear-cache is intentionally NOT exercised from the CLI surface
+// here: the side effect (nuking /tmp/pdfvision/) cannot be safely
+// invoked from a parallel vitest worker because other workers are
+// concurrently writing to the same root. The CLI wiring is a 4-line
+// shim around `clearAllCache()`; the meaningful assertions — actually
+// removing a directory tree, handling an already-absent path, and
+// refusing symlinks at the root — live in tests/core/cache.test.ts
+// against an isolated temp directory.

--- a/tests/core/cache.test.ts
+++ b/tests/core/cache.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getCacheDir, getCached, setCache } from '../../src/core/cache.js';
+import { clearAllCache, getCacheDir, getCached, setCache } from '../../src/core/cache.js';
 
 describe('cache', () => {
   let tmpFile: string;
@@ -107,6 +107,52 @@ describe('cache', () => {
     for (const entry of readdirSync(dir)) {
       const mode = statSync(join(dir, entry)).mode & 0o777;
       expect(mode & 0o077).toBe(0); // no group/other access
+    }
+  });
+});
+
+describe('clearAllCache', () => {
+  // Use a fresh isolated directory each test rather than the real
+  // shared cache root — multiple vitest workers run in parallel and
+  // would race a real `rmSync(/tmp/pdfvision)` against another worker
+  // mid-write. The path-override on clearAllCache exists for this.
+  let isolatedRoot: string;
+  beforeEach(() => {
+    isolatedRoot = mkdtempSync(join(tmpdir(), 'pdfvision-clear-test-'));
+  });
+  afterEach(() => {
+    rmSync(isolatedRoot, { recursive: true, force: true });
+  });
+
+  it('removes the cache directory and reports removed=true', () => {
+    mkdirSync(join(isolatedRoot, 'sub'), { recursive: true });
+    writeFileSync(join(isolatedRoot, 'sub', 'marker'), 'stale');
+    const result = clearAllCache(isolatedRoot);
+    expect(result.path).toBe(isolatedRoot);
+    expect(result.removed).toBe(true);
+    expect(existsSync(isolatedRoot)).toBe(false);
+  });
+
+  it('reports removed=false without throwing when the directory is already absent', () => {
+    rmSync(isolatedRoot, { recursive: true, force: true });
+    const result = clearAllCache(isolatedRoot);
+    expect(result.removed).toBe(false);
+    expect(result.path).toBe(isolatedRoot);
+  });
+
+  it('refuses to traverse a symlink at the cache root', () => {
+    if (process.platform === 'win32') return; // symlink semantics differ
+    rmSync(isolatedRoot, { recursive: true, force: true });
+    const target = mkdtempSync(join(tmpdir(), 'pdfvision-clear-target-'));
+    writeFileSync(join(target, 'should-not-be-deleted'), 'keep');
+    symlinkSync(target, isolatedRoot);
+    try {
+      expect(() => clearAllCache(isolatedRoot)).toThrow(/symlink/);
+      // sanity: the symlink target's contents must survive the failed clear
+      expect(existsSync(join(target, 'should-not-be-deleted'))).toBe(true);
+    } finally {
+      rmSync(isolatedRoot, { force: true });
+      rmSync(target, { recursive: true, force: true });
     }
   });
 });

--- a/tests/core/cache.test.ts
+++ b/tests/core/cache.test.ts
@@ -83,14 +83,28 @@ describe('cache', () => {
 
   it('refuses to use the cache root if it has been replaced by a symlink', () => {
     if (process.platform === 'win32') return; // symlink semantics differ
-    const cacheRoot = join(tmpdir(), 'pdfvision');
-    rmSync(cacheRoot, { recursive: true, force: true });
+    // Override the cache root to an isolated path so we don't rmSync
+    // the shared `/tmp/pdfvision/` while parallel vitest workers are
+    // mid-write. PDFVISION_CACHE_DIR is read on every cache call, so
+    // setting it before getCacheDir() takes effect immediately.
+    const isolatedRoot = join(
+      tmpdir(),
+      `pdfvision-symlink-test-${process.pid}-${Math.random().toString(36).slice(2, 10)}`,
+    );
+    rmSync(isolatedRoot, { recursive: true, force: true });
     const sneaky = mkdtempSync(join(tmpdir(), 'pdfvision-sneaky-'));
-    symlinkSync(sneaky, cacheRoot);
+    symlinkSync(sneaky, isolatedRoot);
+    const previousEnv = process.env.PDFVISION_CACHE_DIR;
+    process.env.PDFVISION_CACHE_DIR = isolatedRoot;
     try {
       expect(() => getCacheDir(tmpFile)).toThrow(/symlink/);
     } finally {
-      rmSync(cacheRoot, { force: true });
+      if (previousEnv === undefined) {
+        delete process.env.PDFVISION_CACHE_DIR;
+      } else {
+        process.env.PDFVISION_CACHE_DIR = previousEnv;
+      }
+      rmSync(isolatedRoot, { force: true });
       rmSync(sneaky, { recursive: true, force: true });
     }
   });

--- a/tests/core/remote.test.ts
+++ b/tests/core/remote.test.ts
@@ -1,0 +1,181 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { downloadRemote } from '../../src/core/remote.js';
+
+/**
+ * One process-wide HTTP server with per-test routing. Tests register a
+ * route handler with `setHandler`; the server responds via that handler
+ * and we close the server in `afterAll`. Avoids spinning up a fresh
+ * server per test (slower and racier on CI).
+ */
+let server: Server;
+let port: number;
+type Handler = (req: import('node:http').IncomingMessage, res: import('node:http').ServerResponse) => void;
+let handler: Handler = (_req, res) => {
+  res.statusCode = 500;
+  res.end('no handler installed');
+};
+function setHandler(h: Handler): void {
+  handler = h;
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => handler(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+});
+
+// Each test cleans the remote cache root so no two tests see the
+// previous test's payload by accident.
+afterEach(() => {
+  rmSync(join(tmpdir(), 'pdfvision', 'remote'), { recursive: true, force: true });
+});
+
+const TINY_PDF = Buffer.from('%PDF-1.4\n%fake-but-non-empty\n', 'utf-8');
+
+describe('downloadRemote', () => {
+  it('downloads a URL and returns the local cached path', async () => {
+    setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/pdf');
+      res.end(TINY_PDF);
+    });
+
+    const path = await downloadRemote(`http://127.0.0.1:${port}/doc.pdf`);
+    expect(existsSync(path)).toBe(true);
+    expect(readFileSync(path)).toEqual(TINY_PDF);
+  });
+
+  it('hits the cache on the second call (no network) for the same URL', async () => {
+    let hits = 0;
+    setHandler((_req, res) => {
+      hits++;
+      res.statusCode = 200;
+      res.end(TINY_PDF);
+    });
+
+    const url = `http://127.0.0.1:${port}/cached.pdf`;
+    const first = await downloadRemote(url);
+    const second = await downloadRemote(url);
+    expect(second).toBe(first);
+    expect(hits).toBe(1);
+  });
+
+  it('re-downloads when noCache is true even if the cache is populated', async () => {
+    let hits = 0;
+    setHandler((_req, res) => {
+      hits++;
+      res.statusCode = 200;
+      res.end(TINY_PDF);
+    });
+
+    const url = `http://127.0.0.1:${port}/forceful.pdf`;
+    await downloadRemote(url);
+    await downloadRemote(url, { noCache: true });
+    expect(hits).toBe(2);
+  });
+
+  it('keys cache entries on the URL string so two different URLs land in different slots', async () => {
+    setHandler((req, res) => {
+      res.statusCode = 200;
+      res.end(Buffer.from(`%PDF-1.4\n${req.url}\n`, 'utf-8'));
+    });
+
+    const a = await downloadRemote(`http://127.0.0.1:${port}/a.pdf`);
+    const b = await downloadRemote(`http://127.0.0.1:${port}/b.pdf`);
+    expect(a).not.toBe(b);
+    expect(readFileSync(a, 'utf-8')).toContain('/a.pdf');
+    expect(readFileSync(b, 'utf-8')).toContain('/b.pdf');
+  });
+
+  it('rejects non-http(s) schemes before hitting the network', async () => {
+    await expect(downloadRemote('file:///etc/passwd')).rejects.toThrow(/Refusing to download non-http/);
+    await expect(downloadRemote('ftp://example.com/file.pdf')).rejects.toThrow(/Refusing to download non-http/);
+    await expect(downloadRemote('data:application/pdf;base64,JVBERi0=')).rejects.toThrow(/non-http/);
+  });
+
+  it('rejects an unparseable URL string', async () => {
+    await expect(downloadRemote('not a url at all')).rejects.toThrow(/Invalid URL/);
+  });
+
+  it('surfaces non-2xx HTTP responses as a clean error', async () => {
+    setHandler((_req, res) => {
+      res.statusCode = 404;
+      res.statusMessage = 'Not Found';
+      res.end('nope');
+    });
+    await expect(downloadRemote(`http://127.0.0.1:${port}/missing.pdf`)).rejects.toThrow(/HTTP 404/);
+  });
+
+  it('refuses to download when Content-Length declares more than the size limit', async () => {
+    // Set a tiny limit and a large declared length so the check fires
+    // before any byte is read.
+    setHandler((_req, res) => {
+      res.setHeader('Content-Length', '999999');
+      res.statusCode = 200;
+      res.end(TINY_PDF);
+    });
+    await expect(downloadRemote(`http://127.0.0.1:${port}/big.pdf`, { maxBytes: 1024 })).rejects.toThrow(
+      /declares 999999 bytes/,
+    );
+  });
+
+  it('refuses to download when the body grows past the limit during streaming', async () => {
+    // Server omits Content-Length but streams more bytes than the cap;
+    // the cap must still fire from the streaming path.
+    setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.write(Buffer.alloc(2048, 0xab));
+      res.write(Buffer.alloc(2048, 0xab));
+      res.end();
+    });
+    await expect(downloadRemote(`http://127.0.0.1:${port}/streamed.pdf`, { maxBytes: 1024 })).rejects.toThrow(
+      /exceeds 1024 bytes/,
+    );
+  });
+
+  it('honours the timeout when the server hangs', async () => {
+    setHandler((_req, _res) => {
+      // Never respond — the test expects a timeout error.
+    });
+    await expect(downloadRemote(`http://127.0.0.1:${port}/hang.pdf`, { timeoutMs: 100 })).rejects.toThrow(/Timed out/);
+  });
+
+  it('falls back to a generic basename when the URL has no path segment', async () => {
+    setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.end(TINY_PDF);
+    });
+    const path = await downloadRemote(`http://127.0.0.1:${port}/`);
+    expect(path).toMatch(/document\.pdf$/);
+  });
+
+  it('appends .pdf to the cached filename when the URL path lacks an extension', async () => {
+    setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.end(TINY_PDF);
+    });
+    const path = await downloadRemote(`http://127.0.0.1:${port}/no-extension`);
+    expect(path).toMatch(/no-extension\.pdf$/);
+  });
+
+  it('sanitises path-traversal-style basenames', async () => {
+    setHandler((_req, res) => {
+      res.statusCode = 200;
+      res.end(TINY_PDF);
+    });
+    const path = await downloadRemote(`http://127.0.0.1:${port}/%2E%2E%2F..%2F..%2Fetc%2Fpasswd`);
+    // The generated path must stay inside the per-URL cache dir; check
+    // that '..' / '/' didn't leak into the cached basename.
+    expect(path).not.toMatch(/\.\.[/\\]/);
+    expect(existsSync(path)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two related additions so pdfvision can take a URL instead of a local file.

### \`--remote <url>\`

\`\`\`bash
pdfvision --remote https://example.com/paper.pdf -f json
\`\`\`

- Downloads via platform \`fetch\` into \`<tmpdir>/pdfvision/remote/<sha256-of-url>/\` and runs the existing extraction pipeline on the cached file
- Same URL → same cache slot. Pass \`--no-cache\` to force a refresh, or \`--clear-cache\` to nuke everything
- Up-front rejection of non-http(s) schemes (\`file:\`, \`data:\`, \`ftp:\`, …)
- 100 MB size cap (Content-Length + streaming-read enforcement), 60 s timeout (\`AbortController\`)
- Path-traversal-safe basename derivation; falls back to \`document.pdf\` when the URL has no last segment

### \`--clear-cache\`

\`\`\`bash
pdfvision --clear-cache
\`\`\`

- Wipes \`<tmpdir>/pdfvision/\` entirely: every result cache, every rendered PNG, every remote download
- Side-effect-only flag — ignores any positional / other args
- Refuses symlinks at the cache root (matches the rest of \`cache.ts\` hardening)
- Library helper \`clearAllCache(path?: string)\` exposes an override path used by tests; the CLI uses the default

## Tests

- 141 → 159 passed (+18)
- New \`tests/core/remote.test.ts\`: local http server probes happy path, 404, declared/streamed size caps, timeout, scheme rejection, URL-keyed caching, basename sanitisation, percent-decoded path traversal
- New \`clearAllCache\` unit tests in \`tests/core/cache.test.ts\` use an isolated \`mkdtemp\` directory so they don't race the shared \`/tmp/pdfvision/\` cache other workers write to
- CLI \`--remote\` tested via in-process http server feeding the existing sample fixture

## Race-recovery

A concurrent \`--clear-cache\` (or any other rm of \`/tmp/pdfvision/\`) can pull the parent directory out from under an in-flight \`--remote\` download. \`downloadRemote\` catches \`ENOENT\` from \`atomicWrite\`, recreates the cache dirs, and retries once before bubbling the error up.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 159 passed
- [ ] CI passes on all OS / Node combos (will verify)
- [ ] Manual: \`pdfvision --remote https://example.com/some.pdf -f json\` works end-to-end (manual verification before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)