### PR TITLE
docs(readme): switch npm download badge from monthly to total

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <hr />
 
 [![npm](https://img.shields.io/npm/v/pdfvision.svg?maxAge=1000)](https://www.npmjs.com/package/pdfvision)
-[![npm downloads](https://img.shields.io/npm/dm/pdfvision)](https://www.npmjs.com/package/pdfvision)
+[![npm downloads](https://img.shields.io/npm/dt/pdfvision)](https://www.npmjs.com/package/pdfvision)
 [![CI](https://github.com/yamadashy/pdfvision/actions/workflows/ci.yml/badge.svg)](https://github.com/yamadashy/pdfvision/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/yamadashy/pdfvision/graph/badge.svg?token=GUBUU47DW2)](https://codecov.io/gh/yamadashy/pdfvision)
 [![License](https://img.shields.io/npm/l/pdfvision)](LICENSE)


### PR DESCRIPTION
## Summary

Switch the npm downloads badge from \`dm\` (monthly) to \`dt\` (total / cumulative). Monthly counts on a young package swing too widely to be a useful at-a-glance signal; cumulative is the metric we actually want to track for adoption.

## Test plan

- [x] Badge URL renders to a cumulative count