### PR TITLE
docs(readme): refocus on the agent-vs-existing-tools differentiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@
 
 ## 💡 Why pdfvision
 
-Most PDF tools were built for humans pasting into a Word doc. pdfvision is built for **agents that need every signal a PDF carries — and need to know when a PDF is hiding something.**
+PDF tooling has historically been built for humans copying text into a document. Agents need different things: to know whether the extraction actually captured the content, to hand visual pages to a vision model in the same step, and to receive raw structural signals rather than one pre-formatted answer they can't second-guess.
 
-| You want | `pdftotext` / `pdf-parse` | Pre-cooked tools (`marker`, `pymupdf4llm`) | **pdfvision** |
-| --- | :---: | :---: | :---: |
-| Know whether extraction *actually worked* | Empty output silently | Hidden behind opinionated Markdown | ✅ Per-page `charCount` / `imageCount` / `textCoverage` |
-| Hand pages to a vision LLM | Need a separate tool | Sometimes | ✅ `--render` writes PNG paths |
-| Multi-column reading order, headings, repeated chrome | ❌ | Baked into one answer | ✅ Raw blocks + `role` / `repeated` flags — agent picks |
-| Japanese / scientific compat codepoints (`⽬`, `Ａ`, `ﬁ`) | Pass through silently | Varies | ✅ NFKC normalised by default; raw form kept in `rawText` |
-| Re-read the same PDF many times | Re-parse every time | Re-parse every time | ✅ Cache-first: second read is ~30 ms |
-| Pull a PDF from a URL | `curl` + tempfile dance | `curl` + tempfile dance | ✅ `--remote https://…` |
-| Output an LLM can parse | Plain text | Markdown only | ✅ `markdown` / `json` / `xml` (tag-shaped, LLMs locate tags > nested keys) |
+pdfvision is built around that gap. The goal is to **deliver every signal a PDF carries, in a form the agent can act on, and never silently hide that the extraction came up short.**
 
-The design principle: **agent decides; pdfvision delivers raw signals.** No auto-detect heuristics that hide what the PDF actually contained.
+- **Silent-failure visibility.** Every page reports `charCount`, `imageCount`, and `textCoverage`, so an agent can tell at a glance that "this slide is an image, not text" — and decide to re-run with `--render` or fall back to OCR instead of trusting an empty string.
+- **Multimodal handoff in one step.** `--render` writes PNG paths the agent can pass straight to a vision model — no second tool, no temp-file plumbing.
+- **Raw structural signals.** `--layout` returns blocks with `role: 'heading'`, `repeated: true` for running headers and footers, and multi-column reading order. `--image-boxes` reports where each raster draw lands. The agent picks which signals matter; pdfvision doesn't bake one answer.
+- **Compatibility codepoints handled.** Japanese and scientific PDFs full of `⽬` / `Ａ` / `ﬁ` collapse to canonical forms by default. The pre-normalisation text stays available in `rawText` when a diff matters.
+- **Cache-first.** Same PDF, second read takes ~30 ms. Agents that revisit a PDF dozens of times across a session pay the parsing cost once.
+- **URLs are first-class.** `--remote https://…` downloads, caches, and extracts in one flag.
+- **Tag-shaped output too.** The `xml` format carries the same data as `json` but as `<page>` / `<text>` tags, which some LLMs locate more reliably than nested object keys.
+
+The design principle is **agent decides; pdfvision delivers raw signals.** No auto-detect heuristics that decide for the agent and hide what the PDF actually contained.
 
 ## 🚀 Quick Start
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/yamadashy/pdfvision/main/docs/logo.svg" alt="pdfvision" width="180" />
   <h1>pdfvision</h1>
   <p>
-    <b>See PDFs the way AI agents need them — text, layout, metadata, and page images, in one command.</b>
+    <b>Turn any PDF into AI-friendly output</b>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/yamadashy/pdfvision/main/docs/logo.svg" alt="pdfvision" width="180" />
   <h1>pdfvision</h1>
   <p>
-    <b>See PDFs the way AI agents need them — text, metadata, and page images, in one command.</b>
+    <b>See PDFs the way AI agents need them — text, layout, metadata, and page images, in one command.</b>
   </p>
 </div>
 
@@ -14,44 +14,37 @@
 [![codecov](https://codecov.io/gh/yamadashy/pdfvision/graph/badge.svg?token=GUBUU47DW2)](https://codecov.io/gh/yamadashy/pdfvision)
 [![License](https://img.shields.io/npm/l/pdfvision)](LICENSE)
 
-🔍 **pdfvision** is a CLI and library that turns PDFs into AI-friendly output.
-It extracts text with original line breaks, pulls out metadata, and — when you need it — renders each page to a PNG so multimodal LLMs (Claude, GPT-4o, Gemini, ...) can _see_ the document, not just read it.
+🔍 **pdfvision** turns any PDF into AI-friendly output — text, metadata, structured layout, and rendered page images — in a single CLI / library built for agents.
 
-It's the missing piece between "I have a PDF" and "my AI agent can use it."
+> **Mission: any PDF, read accurately by an AI agent.** No silent gaps, no "looks fine but the body was an image" failures.
 
-> **Mission: any PDF, read accurately by an AI agent.**
-> Native text PDFs, slide decks with rasterised content, scanned reports, multi-column papers — pdfvision aims to deliver every piece of information a PDF carries to the agent, in a form the agent can actually use. No silent gaps, no "looks fine but the body was an image" failures.
+## 💡 Why pdfvision
 
-## 🌟 Features
+Most PDF tools were built for humans pasting into a Word doc. pdfvision is built for **agents that need every signal a PDF carries — and need to know when a PDF is hiding something.**
 
-- 📄 **Text extraction** with line breaks preserved (via [pdfjs-dist](https://github.com/mozilla/pdf.js))
-- 🌏 **Unicode NFKC normalization** by default, so compatibility codepoints (`⽬`, `Ａ`, `ｶﾅ`, `ﬁ`) collapse to canonical forms. Pre-normalization text surfaces in `rawText` when it differs.
-- 🏷️ **Metadata extraction** (title, author, subject, creator)
-- 🎯 **Page range selection** (`1-5`, `3`, `1,3,5`)
-- 🖼️ **Page rendering** to PNG (`--render`) for multimodal LLMs
-- 📐 **Per-text-item geometry** (`--geometry`) emits `spans[]` with bbox + font size in top-down coords, so agents can reconstruct headings, tables, and reading order
-- 🧱 **Layout reconstruction** (`--layout`) groups spans into lines and blocks (approximate reading order), and **image bboxes** (`--image-boxes`) report where each raster draw lands on the page
-- 📦 **Output formats**: agent-friendly `markdown` (default), structured `json`, and tag-shaped `xml`, each with a top-level density Overview for multi-page docs
-- ⚡ **Cache-first**: same PDF is parsed once, then served instantly from a `pdfvision/<hash>/` directory under the OS temp dir
-- 🛡️ **Hardened cache**: content-addressed, POSIX `0700/0600` permissions, symlink/TOCTOU defences
-- 🪶 **Small & fast**: ~11 KB tarball, ~30 ms warm startup for `--help`/`--version`
-- 🔧 **Library API too**: structured `processDocument()` returns a typed `DocumentResult` directly
+| You want | `pdftotext` / `pdf-parse` | Pre-cooked tools (`marker`, `pymupdf4llm`) | **pdfvision** |
+| --- | :---: | :---: | :---: |
+| Know whether extraction *actually worked* | Empty output silently | Hidden behind opinionated Markdown | ✅ Per-page `charCount` / `imageCount` / `textCoverage` |
+| Hand pages to a vision LLM | Need a separate tool | Sometimes | ✅ `--render` writes PNG paths |
+| Multi-column reading order, headings, repeated chrome | ❌ | Baked into one answer | ✅ Raw blocks + `role` / `repeated` flags — agent picks |
+| Japanese / scientific compat codepoints (`⽬`, `Ａ`, `ﬁ`) | Pass through silently | Varies | ✅ NFKC normalised by default; raw form kept in `rawText` |
+| Re-read the same PDF many times | Re-parse every time | Re-parse every time | ✅ Cache-first: second read is ~30 ms |
+| Pull a PDF from a URL | `curl` + tempfile dance | `curl` + tempfile dance | ✅ `--remote https://…` |
+| Output an LLM can parse | Plain text | Markdown only | ✅ `markdown` / `json` / `xml` (tag-shaped, LLMs locate tags > nested keys) |
+
+The design principle: **agent decides; pdfvision delivers raw signals.** No auto-detect heuristics that hide what the PDF actually contained.
 
 ## 🚀 Quick Start
 
-Run instantly without installing anything:
-
 ```bash
+# Try without installing
 npx pdfvision document.pdf
-```
 
-Or install globally:
+# Pull from a URL
+npx pdfvision --remote https://example.com/paper.pdf -f json
 
-```bash
-# Install
+# Or install globally
 npm install -g pdfvision
-
-# Then run anywhere
 pdfvision document.pdf
 ```
 
@@ -59,108 +52,51 @@ pdfvision document.pdf
 
 ```
 pdfvision <file.pdf> [options]
+pdfvision --remote <url> [options]
+pdfvision --clear-cache
 
 Options:
   -p, --pages <range>     Page range (e.g. "1-5", "3", "1,3,5")
   -f, --format <type>     Output format: markdown (default), json, xml
   -r, --render            Render pages as PNG images
       --render-output <dir>
-                          Directory for rendered PNGs (requires --render).
-      --no-cache          Skip cache
-      --no-normalize      Disable Unicode NFKC normalization (default: on)
-      --layout            Reconstruct lines + blocks in pages[].layout
+                          Directory for rendered PNGs (requires --render)
+      --geometry          Emit per-text-item bbox + font size in pages[].spans (json/xml)
+      --layout            Reconstruct lines + blocks (with role / repeated flags) in pages[].layout
       --image-boxes       Emit per-image bbox in pages[].imageBoxes
-      --geometry          Emit per-text-item bbox + font size in pages[].spans.
-                          Surfaced in json / xml output; ignored by markdown.
+      --remote <url>      Download an http(s) PDF into the cache, then extract
+      --no-cache          Skip the on-disk cache
+      --no-normalize      Disable Unicode NFKC normalization (default: on)
+      --clear-cache       Wipe every cached extraction, render, and remote download, then exit
   -v, --version           Show version
   -h, --help              Show this help
 ```
 
 ### Output formats
 
-- **`markdown` (default)** — agent-friendly. Each page becomes a `## Page N` section with a density Overview table at the top and rendered image links inline. Best for handing PDFs to an LLM in a chat / IDE / notebook context.
-- **`json`** — programmatic. Full `DocumentResult` schema, including `width`/`height`, `rawText` (when normalization changed text), `overview` (multi-page docs), and `spans[]` (when `--geometry` is on). Best when another tool will parse the output.
-- **`xml`** — LLM-friendly tag variant of `json`. Same fields, but as `<document>`/`<page>`/`<text>`/`<spans>` tags that LLMs locate more reliably than nested object keys. Useful when feeding output into a vision/chat model that doesn't always parse JSON faithfully.
-
-### Layout / image bboxes
-
-`--layout` and `--image-boxes` are independent opt-ins that surface in `json` and `xml` output. Layout reconstructs `pages[].layout = { blocks: [{ text, x, y, width, height, lines: [...] }] }` from spans (line clustering by y, block clustering by gap and font size); the block array is in approximate top-down reading order. Image bboxes emit `pages[].imageBoxes` — one entry per raster draw, in the same top-down coordinate system as spans, so an agent can ask "what got rasterised on this page" without having to render the whole page.
+- **`markdown` (default)** — per-page sections, density Overview table, image links inline. For LLM context windows.
+- **`json`** — full `DocumentResult` schema. For programmatic consumers.
+- **`xml`** — same data as JSON but tag-shaped. For LLMs that locate `<page>` / `<text>` tags more reliably than nested object keys.
 
 ### Examples
 
 ```bash
-# Extract all text
-pdfvision document.pdf
+# Specific pages as JSON
+pdfvision document.pdf -p 1-3 -f json
 
-# Extract specific pages
-pdfvision document.pdf -p 1-3
-pdfvision document.pdf -p 1,3,5
+# Render PNGs into ./images for a multimodal LLM
+pdfvision document.pdf -r --render-output ./images
 
-# Render pages as PNG (paths are returned in the output)
-pdfvision document.pdf -r -p 1-5
+# Layout + image bboxes — agent reconstructs reading order itself
+pdfvision document.pdf --layout --image-boxes -f json
 
-# Markdown is the default — each page becomes ## Page N with a density Overview and image links
-pdfvision document.pdf
-
-# Switch to JSON for programmatic consumers
-pdfvision document.pdf -f json
-
-# XML-flavoured output for LLMs that parse tags more reliably than JSON
-pdfvision document.pdf -f xml
-
-# Emit per-text-item geometry (bbox + font size) for layout analysis
+# Per-text-item geometry (bbox + fontSize per glyph run)
 pdfvision document.pdf -f json --geometry
 ```
 
-### Geometry / coordinates
-
-`--geometry` adds `pages[].spans` to the JSON output. Each entry is one
-`pdfjs` text run:
-
-```json
-{
-  "text": "Hello pdfvision",
-  "x": 100, "y": 68, "width": 156.05, "height": 24,
-  "fontSize": 24,
-  "fontName": "g_d0_f1"
-}
-```
-
-Coordinates use a **top-down origin** (0,0 at the top-left, y grows
-downward) in PDF user-space points. This matches the rendered PNG
-orientation, so callers can overlay spans directly. Note that the
-rendered PNG is produced at a higher pixel density than the PDF page —
-multiply span coordinates by `image.width / page.width` (and the same
-for height) to map onto pixels. Whitespace-only items are filtered out;
-the aggregate `text` field still contains all spaces.
-
-### Caching
-
-Results are cached under `<os-tmp>/pdfvision/<sha256-prefix>/` keyed by file content
-(e.g. `/tmp/pdfvision/...` on Linux, `/var/folders/.../T/pdfvision/...` on macOS).
-The cache key further factors in the page range and render flag, so different
-invocations on the same PDF stay independent. The cached payload is the
-structured result, so switching `--format text` ↔ `--format json` between runs
-reuses the cache. On POSIX systems, cache directories are created with mode `0700` and
-files with `0600` so other local users can't read your extracted text
-or images. Windows doesn't honour those mode bits — if multi-user
-isolation matters there, restrict NTFS ACLs on the cache root yourself,
-or pass `--no-cache`. `--no-cache` bypasses the cache entirely.
-
-## 💡 Why pdfvision
-
-Most PDF CLIs are built for humans. pdfvision is built for AI agents, with one simple goal: **any PDF, read accurately**.
-
-- **Structured output** that LLMs can consume directly (JSON or annotated text)
-- **Multimodal-ready**: `--render` produces PNGs so visual information (charts, layouts, scanned pages) can be passed to vision-capable models
-- **Per-page density signal**: every page reports `chars`, `images`, and `coverage` so agents can detect "looks fine but the real content was rasterised" pages and re-extract with `--render`
-- **Re-read friendly**: agents often inspect the same PDF many times — the cache keeps the second read instant
+Coordinates use a **top-down origin** (0,0 at the top-left, y grows downward) in PDF user-space points so callers can overlay spans / image bboxes directly on the rendered PNG. Multiply by `image.width / page.width` to map onto pixels.
 
 ## 📚 Library API
-
-The recommended entry point for library consumers is **`processDocument()`**,
-which returns a typed `DocumentResult` directly. Use it when you want to
-walk pages, inspect metadata, or feed data into your own pipeline:
 
 ```ts
 import { processDocument } from 'pdfvision';
@@ -171,34 +107,22 @@ console.log(result.totalPages);          // number
 console.log(result.metadata.title);      // string | null
 for (const page of result.pages) {
   console.log(page.page, page.text);     // typed access, no JSON.parse
-  if (page.image) {
-    // PNG path on disk, only set when `render: true`
-    console.log(page.image);
-  }
+  if (page.image) console.log(page.image); // PNG path on disk when render: true
 }
 ```
 
-If you want the same string output the CLI prints (e.g. to pipe into another
-process or a log), use **`processFile()`**:
+`processFile()` returns the same string output the CLI prints (`markdown` / `json` / `xml`).
 
-```ts
-import { processFile } from 'pdfvision';
+Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`, `renderPages`, `getCacheDir`, `getCached`, `setCache`, plus full type definitions for `DocumentResult` / `PageResult` / `PageOverview` / `DocumentMetadata` / `ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` / `LayoutBlock` / `LayoutLine` / `PageLayout` / `ImageBox`.
 
-const md = await processFile('./document.pdf', {
-  format: 'markdown',       // or 'json' / 'xml'
-  noCache: false,
-});
-```
+## Caching
 
-Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`,
-`renderPages`, `getCacheDir`, `getCached`, `setCache`, plus the
-`DocumentResult` / `PageResult` / `PageOverview` / `DocumentMetadata` /
-`ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` types.
+Results land under `<os-tmp>/pdfvision/<sha256-prefix>/` keyed by file content. POSIX `0700` / `0600` permissions, symlink/TOCTOU defences. Override the location with `PDFVISION_CACHE_DIR=/path` or wipe everything with `pdfvision --clear-cache`.
 
 ## 🛠️ Requirements
 
-- Node.js >= 22.13.0 (matches the floor required by `pdfjs-dist@5.7+`)
-- Native dependency: `@napi-rs/canvas` (installed automatically; ships prebuilt binaries for common platforms)
+- Node.js >= 22.13.0
+- `@napi-rs/canvas` (installed automatically; ships prebuilt binaries for common platforms)
 
 ## 📜 License
 


### PR DESCRIPTION
## Summary

Reshape the README so the value prop hits the reader before they scroll past Quick Start.

### What changed

- **Why pdfvision moved above Quick Start.** The previous order buried it 4 sections deep behind Features / Quick Start / Usage / Examples / Caching.
- **Features list (12 bullets) deleted.** Replaced by a 7-row comparison table that maps each pdfvision capability to a real failure mode of the tools agents actually weigh us against (\`pdftotext\`, \`pdf-parse\`, \`marker\`, \`pymupdf4llm\`).
- **Quick Start now shows \`--remote\`** alongside the local-file path so the network case is one glance away.
- **Usage block synced to v0.5** (\`--remote\` / \`--clear-cache\` / \`--layout\` / \`--image-boxes\` documented).
- **Geometry / Coordinates** folded into a one-paragraph note inside Examples instead of its own section.
- **Caching** trimmed to a 1-paragraph block with \`PDFVISION_CACHE_DIR\` documented.
- **Library API exports** list now matches what \`src/index.ts\` actually exposes — no aspirational \`clearAllCache\` / \`downloadRemote\` until they're promoted (separate follow-up if we want to).

README dropped from **205 → 129 lines** (-37%).

## Test plan

- [x] \`npm run lint\` clean
- [ ] Visual scan on github.com confirms the comparison table renders cleanly and Why-before-QS reads naturally