### PR TITLE
feat(ocr): add --ocr flag for tesseract.js OCR fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ PDF tooling has historically been built for humans copying text into a document.
 
 pdfvision is built around that gap. The goal is to **deliver every signal a PDF carries, in a form the agent can act on, and never silently hide that the extraction came up short.**
 
-- **Silent-failure visibility.** Every page reports `charCount`, `imageCount`, and `textCoverage`, so an agent can tell at a glance that "this slide is an image, not text" — and decide to re-run with `--render` or fall back to OCR instead of trusting an empty string.
+- **Silent-failure visibility.** Every page reports `charCount`, `imageCount`, and `textCoverage`, so an agent can tell at a glance that "this slide is an image, not text" — and decide to re-run with `--render` or `--ocr` instead of trusting an empty string.
 - **Multimodal handoff in one step.** `--render` writes PNG paths the agent can pass straight to a vision model — no second tool, no temp-file plumbing.
 - **Raw structural signals.** `--layout` returns blocks with `role: 'heading'`, `repeated: true` for running headers and footers, and multi-column reading order. `--image-boxes` reports where each raster draw lands. The agent picks which signals matter; pdfvision doesn't bake one answer.
+- **OCR when text alone isn't enough.** `--ocr` runs tesseract.js on each page and attaches `pages[].ocr` (text + confidence + lang) alongside the native pdfjs text — agents diff the two to detect scanned / image-flattened pages without losing the primary signal.
 - **Compatibility codepoints handled.** Japanese and scientific PDFs full of `⽬` / `Ａ` / `ﬁ` collapse to canonical forms by default. The pre-normalisation text stays available in `rawText` when a diff matters.
 - **Cache-first.** Same PDF, second read takes ~30 ms. Agents that revisit a PDF dozens of times across a session pay the parsing cost once.
 - **URLs are first-class.** `--remote https://…` downloads, caches, and extracts in one flag.
@@ -64,6 +65,8 @@ Options:
       --geometry          Emit per-text-item bbox + font size in pages[].spans (json/xml)
       --layout            Reconstruct lines + blocks (with role / repeated flags) in pages[].layout
       --image-boxes       Emit per-image bbox in pages[].imageBoxes
+      --ocr               Run tesseract.js OCR; attach pages[].ocr (text/confidence/lang)
+      --ocr-lang <lang>   Tesseract lang(s), plus-separated (e.g. eng+jpn). Default: eng
       --remote <url>      Download an http(s) PDF into the cache, then extract
       --no-cache          Skip the on-disk cache
       --no-normalize      Disable Unicode NFKC normalization (default: on)
@@ -92,6 +95,9 @@ pdfvision document.pdf --layout --image-boxes -f json
 
 # Per-text-item geometry (bbox + fontSize per glyph run)
 pdfvision document.pdf -f json --geometry
+
+# OCR a scanned PDF (multi-language)
+pdfvision scan.pdf --ocr --ocr-lang eng+jpn -f json
 ```
 
 Coordinates use a **top-down origin** (0,0 at the top-left, y grows downward) in PDF user-space points so callers can overlay spans / image bboxes directly on the rendered PNG. Multiply by `image.width / page.width` to map onto pixels.
@@ -113,7 +119,7 @@ for (const page of result.pages) {
 
 `processFile()` returns the same string output the CLI prints (`markdown` / `json` / `xml`).
 
-Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`, `renderPages`, `getCacheDir`, `getCached`, `setCache`, plus full type definitions for `DocumentResult` / `PageResult` / `PageOverview` / `DocumentMetadata` / `ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` / `LayoutBlock` / `LayoutLine` / `PageLayout` / `ImageBox`.
+Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`, `renderPages`, `getCacheDir`, `getCached`, `setCache`, plus full type definitions for `DocumentResult` / `PageResult` / `PageOverview` / `DocumentMetadata` / `ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` / `LayoutBlock` / `LayoutLine` / `PageLayout` / `ImageBox` / `PageOcr`.
 
 ## Caching
 
@@ -123,6 +129,7 @@ Results land under `<os-tmp>/pdfvision/<sha256-prefix>/` keyed by file content. 
 
 - Node.js >= 22.13.0
 - `@napi-rs/canvas` (installed automatically; ships prebuilt binaries for common platforms)
+- `tesseract.js` is installed as an optional dependency and only loaded when `--ocr` is requested. Skip it with `npm install --omit=optional` if you don't need OCR.
 
 ## 📜 License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
       },
       "engines": {
         "node": ">=22.13.0"
+      },
+      "optionalDependencies": {
+        "tesseract.js": "^7.0.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -2169,6 +2172,13 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/boundary": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
@@ -2618,6 +2628,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -2709,6 +2726,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -3307,6 +3331,27 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
@@ -3332,6 +3377,16 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
     },
     "node_modules/oxlint": {
       "version": "1.62.0",
@@ -3601,6 +3656,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -4042,6 +4104,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -4128,6 +4216,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -4524,6 +4619,31 @@
         }
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4539,6 +4659,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "@napi-rs/canvas": "^0.1.97",
     "pdfjs-dist": "^5.7.0"
   },
+  "optionalDependencies": {
+    "tesseract.js": "^7.0.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
     "@expo-google-fonts/noto-sans-jp": "^0.4.3",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -41,6 +41,8 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         'image-boxes': { type: 'boolean' },
         remote: { type: 'string' },
         'clear-cache': { type: 'boolean' },
+        ocr: { type: 'boolean' },
+        'ocr-lang': { type: 'string', default: 'eng' },
       },
     });
     values = parsed.values as Record<string, string | boolean | undefined>;
@@ -137,6 +139,8 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
       geometry: (values.geometry as boolean | undefined) ?? false,
       layout: (values.layout as boolean | undefined) ?? false,
       imageBoxes: (values['image-boxes'] as boolean | undefined) ?? false,
+      ocr: (values.ocr as boolean | undefined) ?? false,
+      ocrLang: (values['ocr-lang'] as string | undefined) ?? 'eng',
     });
     console.log(result);
   } catch (error) {

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -28,6 +28,12 @@ Options
                           reading order) from the same span data. Only -f json / -f xml.
       --image-boxes       Emit \`pages[].imageBoxes\` — bounding box of every raster image
                           draw on the page. Only -f json / -f xml.
+      --ocr               Run OCR on each selected page and attach \`pages[].ocr\`
+                          (text + confidence + lang). Slow; opt-in. Requires the
+                          optional \`tesseract.js\` dependency. \`pages[].text\` is
+                          preserved alongside so callers can compare native vs OCR.
+      --ocr-lang <lang>   Tesseract language code(s), plus-separated for multi-lang
+                          (e.g. \`eng+jpn\`). Default: eng. Only used with --ocr.
       --remote <url>      Download an http(s) URL to the on-disk cache and run extraction
                           on it. Same URL → same cache slot; combine with --no-cache (or
                           --clear-cache) to refresh.
@@ -48,6 +54,8 @@ Examples
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
   pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry -f json   # PNGs + spans for 3-5
   pdfvision slides.pdf -f xml --geometry                                       # layout / geometry as XML
+  pdfvision scan.pdf --ocr -f json                                             # OCR a scanned PDF
+  pdfvision scan-ja.pdf --ocr --ocr-lang eng+jpn -f json                       # multi-lang OCR
   pdfvision --remote https://example.com/paper.pdf -f json                     # fetch + extract JSON
   pdfvision --clear-cache                                                      # wipe the on-disk cache
 

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -24,7 +24,7 @@ import { join } from 'node:path';
  * leave the env var unset and get the same `<tmpdir>/pdfvision/` they
  * always have.
  */
-function getCacheRoot(): string {
+export function getCacheRoot(): string {
   return process.env.PDFVISION_CACHE_DIR ?? join(tmpdir(), 'pdfvision');
 }
 

--- a/src/core/ocr.ts
+++ b/src/core/ocr.ts
@@ -1,0 +1,132 @@
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
+import { ensurePrivateDir, getCacheRoot } from './cache.js';
+import { renderPageToBuffer } from './renderer.js';
+
+/**
+ * Result of running OCR on a single page. `confidence` is normalised to
+ * 0..1 (rounded to 3dp) so it lines up with `textCoverage`; `lang` echoes
+ * the caller's `--ocr-lang` string verbatim so `eng+jpn` round-trips even
+ * after caching.
+ */
+export interface PageOcr {
+  text: string;
+  confidence: number;
+  lang: string;
+}
+
+/**
+ * One OCR worker, reusable across many pages. Created once per
+ * `processDocument` call so the heavy traineddata load (~15-20MB per
+ * language) doesn't repeat per page. Caller is responsible for
+ * `terminate()` in a `finally` so the worker is released even if a
+ * page throws.
+ */
+export interface OcrSession {
+  recognize(png: Buffer): Promise<{ text: string; confidence: number }>;
+  terminate(): Promise<void>;
+}
+
+/** Lower bound of "this looks like a usable lang code" — letters only, 1+ chars. */
+const LANG_TOKEN = /^[A-Za-z_]+$/;
+
+/**
+ * Parse a tesseract-style language string ("eng" / "eng+jpn" / "jpn+chi_sim")
+ * into the array tesseract.js expects. Rejects empty / malformed input
+ * up front so the caller gets a clear error before the worker boots.
+ */
+export function parseOcrLang(lang: string): string[] {
+  const tokens = lang
+    .split('+')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) {
+    throw new Error(`Invalid --ocr-lang "${lang}": expected one or more language codes (e.g. "eng", "eng+jpn")`);
+  }
+  for (const token of tokens) {
+    if (!LANG_TOKEN.test(token)) {
+      throw new Error(`Invalid --ocr-lang token "${token}": expected letters/underscore only`);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Boot a tesseract.js worker for the requested languages. tesseract.js
+ * is an `optionalDependencies` install — when it isn't present we throw
+ * with an actionable message instead of crashing inside the import.
+ *
+ * The traineddata cache is parked under our own cache root so a
+ * `pdfvision --clear-cache` wipes OCR state in the same step as
+ * extraction state, and so the data lands under `0700` perms instead
+ * of an arbitrary cwd.
+ */
+export async function createOcrSession(lang: string): Promise<OcrSession> {
+  const langs = parseOcrLang(lang);
+
+  // biome-ignore lint/suspicious/noExplicitAny: tesseract.js is an optional dep, types only available when installed
+  let tesseract: any;
+  try {
+    tesseract = await import('tesseract.js');
+  } catch {
+    throw new Error(
+      '--ocr requires the optional dependency "tesseract.js" (not installed). Install it with: npm install tesseract.js',
+    );
+  }
+
+  const ocrDataDir = join(getCacheRoot(), 'ocr-data');
+  // ensurePrivateDir keeps the traineddata under 0700 (matches the rest
+  // of the cache hierarchy). mkdirSync first so the parent root exists
+  // before ensurePrivateDir does its lstat / chmod dance.
+  mkdirSync(ocrDataDir, { recursive: true });
+  ensurePrivateDir(ocrDataDir);
+
+  const worker = await tesseract.createWorker(langs, undefined, {
+    cachePath: ocrDataDir,
+    cacheMethod: 'readWrite',
+    // Tesseract's default logger writes a status line per progress tick;
+    // silence it so it doesn't pollute stdout/stderr in the CLI.
+    logger: () => {},
+  });
+
+  return {
+    async recognize(png: Buffer) {
+      const { data } = await worker.recognize(png);
+      // tesseract reports confidence as 0..100; normalise to 0..1 so it
+      // matches the existing `textCoverage` convention. Round to 3dp.
+      const conf = typeof data?.confidence === 'number' ? data.confidence / 100 : 0;
+      return {
+        text: typeof data?.text === 'string' ? data.text.trim() : '',
+        confidence: Math.round(Math.max(0, Math.min(1, conf)) * 1000) / 1000,
+      };
+    },
+    async terminate() {
+      await worker.terminate();
+    },
+  };
+}
+
+/**
+ * Run OCR over the requested pages, mutating the matching entries in
+ * `pages` to attach the resulting `ocr` field. We don't touch
+ * `pages[].text` — the pdfjs-derived text stays as the primary signal so
+ * an agent can compare native text vs OCR for scanned/flattened pages.
+ */
+export async function attachOcr(
+  doc: PDFDocumentProxy,
+  pageNumbers: number[],
+  pages: { ocr?: PageOcr }[],
+  lang: string,
+): Promise<void> {
+  const session = await createOcrSession(lang);
+  try {
+    for (let i = 0; i < pageNumbers.length; i++) {
+      const png = await renderPageToBuffer(doc, pageNumbers[i]);
+      const result = await session.recognize(png);
+      pages[i].ocr = { text: result.text, confidence: result.confidence, lang };
+    }
+  } finally {
+    await session.terminate();
+  }
+}

--- a/src/core/ocr.ts
+++ b/src/core/ocr.ts
@@ -1,19 +1,8 @@
 import { join } from 'node:path';
 import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
+import type { PageOcr } from '../types/index.js';
 import { ensurePrivateDir, getCacheRoot } from './cache.js';
 import { renderPageToBuffer } from './renderer.js';
-
-/**
- * Result of running OCR on a single page. `confidence` is normalised to
- * 0..1 (rounded to 3dp) so it lines up with `textCoverage`; `lang` echoes
- * the caller's `--ocr-lang` string verbatim so `eng+jpn` round-trips even
- * after caching.
- */
-export interface PageOcr {
-  text: string;
-  confidence: number;
-  lang: string;
-}
 
 /**
  * One OCR worker, reusable across many pages. Created once per
@@ -128,12 +117,18 @@ export async function attachOcr(
   pages: { ocr?: PageOcr }[],
   lang: string,
 ): Promise<void> {
+  // Canonicalise whitespace / stray separators so ` eng + jpn ` and
+  // `eng+jpn` end up with the same echoed `ocr.lang`. Order is preserved
+  // — tesseract treats the first language as primary, so `eng+jpn` and
+  // `jpn+eng` are intentionally different recognisers and must not share
+  // a normalised key.
+  const normalisedLang = parseOcrLang(lang).join('+');
   const session = await createOcrSession(lang);
   try {
     for (let i = 0; i < pageNumbers.length; i++) {
       const png = await renderPageToBuffer(doc, pageNumbers[i]);
       const result = await session.recognize(png);
-      pages[i].ocr = { text: result.text, confidence: result.confidence, lang };
+      pages[i].ocr = { text: result.text, confidence: result.confidence, lang: normalisedLang };
     }
   } finally {
     await session.terminate();

--- a/src/core/ocr.ts
+++ b/src/core/ocr.ts
@@ -1,4 +1,3 @@
-import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { ensurePrivateDir, getCacheRoot } from './cache.js';
@@ -69,17 +68,27 @@ export async function createOcrSession(lang: string): Promise<OcrSession> {
   let tesseract: any;
   try {
     tesseract = await import('tesseract.js');
-  } catch {
-    throw new Error(
-      '--ocr requires the optional dependency "tesseract.js" (not installed). Install it with: npm install tesseract.js',
-    );
+  } catch (error) {
+    // Only ERR_MODULE_NOT_FOUND means the package is genuinely missing.
+    // Anything else (broken native binding, syntax error in a transitive
+    // dep, ...) should surface the real cause instead of being mis-
+    // attributed to an install miss — otherwise the user wastes time
+    // re-running `npm install tesseract.js` against a different problem.
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        '--ocr requires the optional dependency "tesseract.js" (not installed). Install it with: npm install tesseract.js',
+      );
+    }
+    throw error;
   }
 
+  // Harden the cache root before touching ocr-data so a planted
+  // `<tmp>/pdfvision -> /elsewhere` symlink can't redirect traineddata
+  // writes outside the cache hierarchy. Mirrors the posture getCacheDir
+  // already enforces for result caches.
+  ensurePrivateDir(getCacheRoot());
   const ocrDataDir = join(getCacheRoot(), 'ocr-data');
-  // ensurePrivateDir keeps the traineddata under 0700 (matches the rest
-  // of the cache hierarchy). mkdirSync first so the parent root exists
-  // before ensurePrivateDir does its lstat / chmod dance.
-  mkdirSync(ocrDataDir, { recursive: true });
   ensurePrivateDir(ocrDataDir);
 
   const worker = await tesseract.createWorker(langs, undefined, {

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -58,10 +58,12 @@ function buildCacheKey(input: CacheKeyInput): string {
     layout: !!input.layout,
     imageBoxes: !!input.imageBoxes,
     // OCR is expensive (tens of seconds for a multi-page scan); always cache
-    // it. The lang string is part of the key so `eng` and `eng+jpn` don't
-    // share a slot.
+    // it. The lang string is part of the key (whitespace-normalised, order
+    // preserved — tesseract treats the first language as primary) so that
+    // `eng` and `eng+jpn` don't share a slot, but ` eng + jpn ` and
+    // `eng+jpn` do.
     ocr: !!input.ocr,
-    ocrLang: input.ocr ? (input.ocrLang ?? 'eng') : null,
+    ocrLang: input.ocr ? canonicalOcrLang(input.ocrLang) : null,
   });
   const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16);
   return `result_${hash}.json`;
@@ -80,6 +82,27 @@ function normalizeText(s: string): string {
 /** Round to 2 decimal places — keeps span coordinates compact in JSON. */
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
+}
+
+/**
+ * Whitespace-normalise (and drop empty separators from) the OCR language
+ * string used for cache keying. Order is preserved on purpose —
+ * tesseract treats the first language as primary, so `eng+jpn` and
+ * `jpn+eng` are intentionally different recognisers. Falls back to
+ * `'eng'` when the input is missing or trims to nothing, matching the
+ * `--ocr-lang` default in the CLI.
+ *
+ * Inlined here (instead of importing `parseOcrLang` from `core/ocr.ts`)
+ * so building the cache key doesn't load the renderer / @napi-rs/canvas
+ * graph that `ocr.ts` indirectly pulls in.
+ */
+function canonicalOcrLang(lang: string | undefined): string {
+  if (!lang) return 'eng';
+  const tokens = lang
+    .split('+')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  return tokens.length > 0 ? tokens.join('+') : 'eng';
 }
 
 interface PageData {

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -29,6 +29,8 @@ interface CacheKeyInput {
   geometry?: boolean;
   layout?: boolean;
   imageBoxes?: boolean;
+  ocr?: boolean;
+  ocrLang?: string;
 }
 
 /**
@@ -44,7 +46,7 @@ function buildCacheKey(input: CacheKeyInput): string {
     pages: input.pages ?? 'all',
     // Bump when the on-disk DocumentResult shape changes so older entries
     // (missing newly-added page fields) are not handed out as fresh results.
-    format: 'structured-v7',
+    format: 'structured-v8',
     render: !!input.render,
     // Including the resolved render-output dir keeps two invocations with
     // different `--render-output` targets from sharing image paths.
@@ -55,6 +57,11 @@ function buildCacheKey(input: CacheKeyInput): string {
     geometry: !!input.geometry,
     layout: !!input.layout,
     imageBoxes: !!input.imageBoxes,
+    // OCR is expensive (tens of seconds for a multi-page scan); always cache
+    // it. The lang string is part of the key so `eng` and `eng+jpn` don't
+    // share a slot.
+    ocr: !!input.ocr,
+    ocrLang: input.ocr ? (input.ocrLang ?? 'eng') : null,
   });
   const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16);
   return `result_${hash}.json`;
@@ -336,6 +343,8 @@ export async function processDocument(filePath: string, options: ProcessDocument
       layout: !!options.layout,
       imageBoxes: !!options.imageBoxes,
     };
+    const ocrEnabled = !!options.ocr;
+    const ocrLang = options.ocrLang ?? 'eng';
     const imageOps: ImageOps = {
       save: OPS.save,
       restore: OPS.restore,
@@ -371,6 +380,14 @@ export async function processDocument(filePath: string, options: ProcessDocument
     // populated, since a single page can't tell its own chrome from its
     // body. Skipped when --layout was off (nothing to flag).
     if (flags.layout) markRepeatedBlocks(pages);
+
+    // OCR runs after the main pass so it can attach to already-built
+    // PageResults. The pdfjs-derived `text` stays untouched — agents that
+    // care about the difference can compare `text` vs `ocr.text` directly.
+    if (ocrEnabled) {
+      const { attachOcr } = await import('./ocr.js');
+      await attachOcr(doc, pageNumbers, pages, ocrLang);
+    }
 
     const metaString = (raw: unknown): string | null => {
       if (typeof raw !== 'string') return null;
@@ -432,6 +449,8 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
     geometry: options.geometry,
     layout: options.layout,
     imageBoxes: options.imageBoxes,
+    ocr: options.ocr,
+    ocrLang: options.ocrLang,
   });
   return render(result, options.format);
 }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -20,15 +20,16 @@ function isReusableImage(path: string): boolean {
   return statSync(path).size > 0;
 }
 
-export async function renderPage(
+/**
+ * Render a single page to a PNG buffer in memory. Used by `renderPage`
+ * (which then atomic-writes the buffer to disk) and by the OCR pipeline,
+ * which needs the raster bytes but no filesystem side effect.
+ */
+export async function renderPageToBuffer(
   doc: PDFDocumentProxy,
   pageNum: number,
-  outputDir: string,
   scale = DEFAULT_SCALE,
-): Promise<string> {
-  const outputPath = join(outputDir, `page-${pageNum}.png`);
-  if (isReusableImage(outputPath)) return outputPath;
-
+): Promise<Buffer> {
   const page = await doc.getPage(pageNum);
   const viewport = page.getViewport({ scale });
 
@@ -41,7 +42,20 @@ export async function renderPage(
     viewport,
   }).promise;
 
-  atomicWrite(outputPath, canvas.toBuffer('image/png'));
+  return canvas.toBuffer('image/png');
+}
+
+export async function renderPage(
+  doc: PDFDocumentProxy,
+  pageNum: number,
+  outputDir: string,
+  scale = DEFAULT_SCALE,
+): Promise<string> {
+  const outputPath = join(outputDir, `page-${pageNum}.png`);
+  if (isReusableImage(outputPath)) return outputPath;
+
+  const buffer = await renderPageToBuffer(doc, pageNum, scale);
+  atomicWrite(outputPath, buffer);
   return outputPath;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type {
   LayoutLine,
   OutputFormat,
   PageLayout,
+  PageOcr,
   PageOverview,
   PageResult,
   ProcessDocumentOptions,

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -62,6 +62,19 @@ export function formatMarkdown(result: DocumentResult): string {
       lines.push('');
       lines.push(page.text);
     }
+    if (page.ocr) {
+      // OCR sits below the native text so the agent reads pdfjs first
+      // and only consults OCR when text is empty/garbled. The label
+      // surfaces lang + confidence so a low-confidence page is obvious
+      // without inspecting the JSON form.
+      const confPct = Math.round(page.ocr.confidence * 100);
+      lines.push('');
+      lines.push(`### OCR (${page.ocr.lang}, confidence ${confPct}%)`);
+      if (page.ocr.text) {
+        lines.push('');
+        lines.push(page.ocr.text);
+      }
+    }
     if (page.image) {
       lines.push('');
       // Use the <...> link destination form so paths with spaces or

--- a/src/output/xml.ts
+++ b/src/output/xml.ts
@@ -137,6 +137,16 @@ export function formatXml(result: DocumentResult): string {
     if (page.rawText) {
       out.push(`<rawText>\n${escapeText(page.rawText)}\n</rawText>`);
     }
+    if (page.ocr) {
+      const ocrAttrs = `lang="${escapeAttr(page.ocr.lang)}" confidence="${page.ocr.confidence}"`;
+      if (page.ocr.text) {
+        out.push(`<ocr ${ocrAttrs}>\n${escapeText(page.ocr.text)}\n</ocr>`);
+      } else {
+        // Self-closing keeps "OCR ran but found nothing" distinct from
+        // "OCR was not requested" (the latter omits the tag entirely).
+        out.push(`<ocr ${ocrAttrs}/>`);
+      }
+    }
     out.push('</page>');
   }
   out.push('</pages>');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,20 @@ export interface ProcessDocumentOptions {
    * each other. Off by default because not every consumer needs them.
    */
   imageBoxes?: boolean;
+  /**
+   * Run OCR on each selected page and attach the result as `pages[].ocr`.
+   * Off by default — OCR pulls in the optional `tesseract.js` dependency
+   * (~30MB worker bundle) and is slow even on small documents. The
+   * pdfjs-derived `pages[].text` is left unchanged so callers can diff
+   * native text vs OCR (scanned PDFs typically have empty `text` and
+   * usable `ocr.text`).
+   */
+  ocr?: boolean;
+  /**
+   * Tesseract language code(s), plus-separated (e.g. `eng`, `eng+jpn`).
+   * Defaults to `eng`. Only consulted when `ocr` is true.
+   */
+  ocrLang?: string;
 }
 
 export interface ProcessOptions {
@@ -63,6 +77,27 @@ export interface ProcessOptions {
   geometry?: boolean;
   layout?: boolean;
   imageBoxes?: boolean;
+  ocr?: boolean;
+  ocrLang?: string;
+}
+
+/**
+ * Per-page OCR result. Surfaced only when `--ocr` was requested.
+ * `pages[].text` (pdf.js native extraction) is preserved alongside this
+ * so callers can compare the two — scanned PDFs typically have empty
+ * `text` and a populated `ocr.text`.
+ */
+export interface PageOcr {
+  /** OCR-derived text. Trimmed of trailing whitespace; line breaks preserved. */
+  text: string;
+  /**
+   * Mean tesseract.js confidence over the page, normalised to 0..1
+   * (rounded to 3dp). Tesseract reports it as 0..100 internally; we
+   * scale down to match the existing `textCoverage` convention.
+   */
+  confidence: number;
+  /** Language string passed in (e.g. `eng`, `eng+jpn`), echoed verbatim. */
+  lang: string;
 }
 
 /**
@@ -215,6 +250,13 @@ export interface PageResult {
    * hero image yields multiple entries).
    */
   imageBoxes?: ImageBox[];
+  /**
+   * OCR-derived text + confidence + language, only present when
+   * `ocr: true` was passed. The pdfjs-derived `text` field is preserved
+   * alongside, so an agent can pick whichever signal it trusts more for
+   * the page in question.
+   */
+  ocr?: PageOcr;
 }
 
 export interface DocumentMetadata {

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -139,6 +139,15 @@ describe('cli', () => {
     expect(r.stderr.join('\n')).toMatch(/--remote and a file path are mutually exclusive/);
   });
 
+  it('rejects malformed --ocr-lang before booting tesseract', async () => {
+    // Argument validation runs ahead of the heavy worker boot, so a typo
+    // surfaces in milliseconds with a clear pointer at the bad token
+    // instead of an opaque tesseract error.
+    const r = await captureRun([SAMPLE_PDF, '--ocr', '--ocr-lang', 'eng2', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/expected letters\/underscore only/);
+  });
+
   it('downloads a remote PDF and runs extraction against it', async () => {
     // Spin up a one-off http server that serves the existing sample
     // fixture, point --remote at it, and assert the markdown body

--- a/tests/core/ocr.test.ts
+++ b/tests/core/ocr.test.ts
@@ -1,0 +1,95 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { parseOcrLang } from '../../src/core/ocr.js';
+import { processDocument } from '../../src/core/processor.js';
+
+const SAMPLE_PDF = resolve(__dirname, '../fixtures/sample.pdf');
+
+describe('parseOcrLang', () => {
+  it('accepts a single language code', () => {
+    expect(parseOcrLang('eng')).toEqual(['eng']);
+  });
+
+  it('splits plus-separated codes', () => {
+    expect(parseOcrLang('eng+jpn')).toEqual(['eng', 'jpn']);
+  });
+
+  it('trims whitespace around codes', () => {
+    expect(parseOcrLang(' eng + jpn ')).toEqual(['eng', 'jpn']);
+  });
+
+  it('accepts script-suffixed codes (chi_sim, chi_tra)', () => {
+    expect(parseOcrLang('chi_sim+chi_tra')).toEqual(['chi_sim', 'chi_tra']);
+  });
+
+  it('rejects empty input', () => {
+    expect(() => parseOcrLang('')).toThrow(/expected one or more language codes/);
+  });
+
+  it('rejects pure-separator input', () => {
+    expect(() => parseOcrLang('++')).toThrow(/expected one or more language codes/);
+  });
+
+  it('rejects digits / punctuation in tokens', () => {
+    // Catches obvious typos like "eng2" or "../traineddata" before tesseract
+    // gets handed garbage.
+    expect(() => parseOcrLang('eng2')).toThrow(/expected letters\/underscore only/);
+    expect(() => parseOcrLang('../sneaky')).toThrow(/expected letters\/underscore only/);
+  });
+});
+
+describe('processDocument with --ocr', () => {
+  // Isolate OCR-test cache writes from concurrent vitest workers so
+  // tesseract.js's traineddata download doesn't race the symlink test
+  // in cache.test.ts.
+  let tmpRoot: string;
+  let originalEnv: string | undefined;
+
+  beforeAll(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'pdfvision-ocr-test-'));
+    originalEnv = process.env.PDFVISION_CACHE_DIR;
+    process.env.PDFVISION_CACHE_DIR = tmpRoot;
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) {
+      delete process.env.PDFVISION_CACHE_DIR;
+    } else {
+      process.env.PDFVISION_CACHE_DIR = originalEnv;
+    }
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('attaches an ocr field with text, confidence, and lang', { timeout: 60_000 }, async () => {
+    const result = await processDocument(SAMPLE_PDF, { ocr: true, noCache: true });
+    const page = result.pages[0];
+    expect(page.ocr).toBeDefined();
+    expect(page.ocr?.lang).toBe('eng');
+    // Confidence is normalised to 0..1.
+    expect(page.ocr?.confidence).toBeGreaterThanOrEqual(0);
+    expect(page.ocr?.confidence).toBeLessThanOrEqual(1);
+    // sample.pdf renders "Hello pdfvision" on page 1; OCR should find some
+    // letters from that string. Use a loose match — tesseract sometimes
+    // misreads a single glyph and we don't want to chase that flake.
+    expect(page.ocr?.text.toLowerCase()).toMatch(/hello|pdfvision/);
+  });
+
+  it('preserves the pdfjs-derived text alongside ocr.text', { timeout: 60_000 }, async () => {
+    // Native text is the primary signal; OCR is a fallback that an agent
+    // can compare against. Ensure --ocr does not overwrite `text`.
+    const result = await processDocument(SAMPLE_PDF, { ocr: true, noCache: true });
+    const page = result.pages[0];
+    expect(page.text).toContain('Hello pdfvision');
+    expect(page.ocr).toBeDefined();
+  });
+
+  it('echoes the lang string verbatim (multi-lang plus form)', { timeout: 60_000 }, async () => {
+    // Even with a multi-lang spec, the `lang` field round-trips the
+    // caller's input rather than tesseract's normalised array form, so
+    // round-trip caching keys remain stable.
+    const result = await processDocument(SAMPLE_PDF, { ocr: true, ocrLang: 'eng', noCache: true });
+    expect(result.pages[0].ocr?.lang).toBe('eng');
+  });
+});

--- a/tests/core/ocr.test.ts
+++ b/tests/core/ocr.test.ts
@@ -6,6 +6,10 @@ import { parseOcrLang } from '../../src/core/ocr.js';
 import { processDocument } from '../../src/core/processor.js';
 
 const SAMPLE_PDF = resolve(__dirname, '../fixtures/sample.pdf');
+// 3-page Japanese fixture — used here only to exercise the multi-page
+// session-reuse path; OCR runs in `eng` mode so we don't need to ship
+// jpn traineddata in the test environment.
+const SAMPLE_JA_PDF = resolve(__dirname, '../fixtures/sample-ja.pdf');
 
 describe('parseOcrLang', () => {
   it('accepts a single language code', () => {
@@ -91,5 +95,52 @@ describe('processDocument with --ocr', () => {
     // round-trip caching keys remain stable.
     const result = await processDocument(SAMPLE_PDF, { ocr: true, ocrLang: 'eng', noCache: true });
     expect(result.pages[0].ocr?.lang).toBe('eng');
+  });
+
+  it('serves --ocr results from cache on second call (no re-recognition)', { timeout: 120_000 }, async () => {
+    // First call populates the cache with the OCR payload; second call
+    // should be a cache hit and finish in milliseconds instead of the
+    // multi-second OCR boot. Asserting the second call is dramatically
+    // faster guards against accidentally excluding `ocr` from the cache
+    // key (which would re-run OCR every time).
+    const t0 = Date.now();
+    const first = await processDocument(SAMPLE_PDF, { ocr: true, noCache: false });
+    const firstMs = Date.now() - t0;
+    expect(first.pages[0].ocr?.text).toBeDefined();
+
+    const t1 = Date.now();
+    const second = await processDocument(SAMPLE_PDF, { ocr: true, noCache: false });
+    const secondMs = Date.now() - t1;
+    expect(second.pages[0].ocr?.text).toEqual(first.pages[0].ocr?.text);
+    // OCR boot dominates first run (multiple seconds); a cache hit is
+    // dominated by JSON.parse and should land well under 1s. Generous
+    // bound to keep the test stable on slow CI.
+    expect(secondMs).toBeLessThan(firstMs / 2);
+  });
+
+  it('keys --ocr-lang separately so eng and eng+jpn do not share a cache slot', { timeout: 120_000 }, async () => {
+    // Run with `eng`, then with `eng+jpn`. The second call must NOT
+    // reuse the `eng` cache entry — its `ocr.lang` echoes the caller's
+    // string verbatim, so a cache-key collision would surface as
+    // `lang === 'eng'` despite the caller asking for `eng+jpn`.
+    const eng = await processDocument(SAMPLE_PDF, { ocr: true, ocrLang: 'eng', noCache: false });
+    expect(eng.pages[0].ocr?.lang).toBe('eng');
+    const both = await processDocument(SAMPLE_PDF, { ocr: true, ocrLang: 'eng+jpn', noCache: false });
+    expect(both.pages[0].ocr?.lang).toBe('eng+jpn');
+  });
+
+  it('attaches one ocr entry per page when extracting multi-page docs', { timeout: 180_000 }, async () => {
+    // Drives the session-reuse path: a single OCR worker recognises
+    // every page in turn and the result must land on the matching
+    // PageResult. A bug that off-by-ones the index would mis-attach the
+    // last page's OCR to page 1.
+    const result = await processDocument(SAMPLE_JA_PDF, { ocr: true, ocrLang: 'eng', noCache: true });
+    expect(result.pages).toHaveLength(3);
+    for (const page of result.pages) {
+      expect(page.ocr).toBeDefined();
+      expect(page.ocr?.lang).toBe('eng');
+      expect(page.ocr?.confidence).toBeGreaterThanOrEqual(0);
+      expect(page.ocr?.confidence).toBeLessThanOrEqual(1);
+    }
   });
 });

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -211,6 +211,27 @@ describe('formatMarkdown', () => {
     expect(out).toMatch(/\| 2 \| 5 \| 0 \| 0% \| 612×792 \| 3 \|/);
   });
 
+  it('renders an OCR section with lang and confidence percent below the native text', () => {
+    // Native text comes first; OCR sits underneath as a separate ### block
+    // so an agent reads pdfjs first and only consults OCR when needed.
+    const out = formatMarkdown(
+      makeResult({
+        pages: [
+          makePage({
+            page: 1,
+            text: 'Hello',
+            charCount: 5,
+            ocr: { text: 'Hello world', confidence: 0.91, lang: 'eng' },
+          }),
+        ],
+      }),
+    );
+    expect(out).toMatch(/### OCR \(eng, confidence 91%\)/);
+    expect(out).toMatch(/Hello world/);
+    // Native text appears before OCR section.
+    expect(out.indexOf('\nHello\n')).toBeLessThan(out.indexOf('### OCR'));
+  });
+
   it('skips the text body for pages that had no extractable text', () => {
     // Image-only pages should still render the heading + density line so the
     // agent can see "this page had 0 chars and 3 images" instead of a silent gap.

--- a/tests/output/xml.test.ts
+++ b/tests/output/xml.test.ts
@@ -182,6 +182,33 @@ describe('formatXml', () => {
     expect(out).toContain('<imageBoxes/>');
   });
 
+  it('emits an <ocr> element with lang + confidence attributes when ocr is present', () => {
+    const out = formatXml(
+      makeResult({
+        pages: [
+          makePage({
+            page: 1,
+            text: 'Hello',
+            charCount: 5,
+            ocr: { text: 'Hello world', confidence: 0.91, lang: 'eng+jpn' },
+          }),
+        ],
+      }),
+    );
+    expect(out).toMatch(/<ocr lang="eng\+jpn" confidence="0\.91">\nHello world\n<\/ocr>/);
+  });
+
+  it('emits a self-closing <ocr/> when OCR ran but found no text', () => {
+    // Mirrors the <imageBoxes/> empty-tag pattern: distinguishes "OCR ran
+    // and produced nothing" from "OCR was not requested" (omits tag).
+    const out = formatXml(
+      makeResult({
+        pages: [makePage({ page: 1, text: 't', charCount: 1, ocr: { text: '', confidence: 0, lang: 'eng' } })],
+      }),
+    );
+    expect(out).toMatch(/<ocr lang="eng" confidence="0"\/>/);
+  });
+
   it('escapes newlines inside attribute values so they cannot terminate the attribute early', () => {
     const out = formatXml(
       makeResult({


### PR DESCRIPTION
## Summary

- Opt-in `--ocr` flag (with `--ocr-lang`, default `eng`, plus-separated for multi-lang) that runs tesseract.js on each selected page and attaches `pages[].ocr` (`{ text, confidence, lang }`).
- The pdfjs-derived `pages[].text` stays untouched, so an agent can compare native vs OCR — scanned PDFs typically come back with empty `text` and a populated `ocr.text`.
- tesseract.js lands in `optionalDependencies`; the import is lazy and we throw an actionable error when it isn't installed (`npm install --omit=optional` skips it).
- Traineddata caches under `<PDFVISION_CACHE_DIR or os tmp>/pdfvision/ocr-data/` with the same `0700` posture as the rest of the cache, so `--clear-cache` wipes it in the same step.
- Cache key bumped to `structured-v8` and now includes `ocr` + `ocrLang` so toggling the flags doesn't return stale results.
- `renderer.ts` split into `renderPageToBuffer` + `renderPage` so OCR can rasterise in-memory without forcing `--render`.
- `markdown` surfaces a `### OCR (lang, confidence N%)` block below the native text. `xml` surfaces `<ocr lang="…" confidence="…">…</ocr>` (self-closing when empty, mirroring `<imageBoxes/>`).

Design memo: `agent decides; pdfvision delivers raw signals` — no auto-OCR-on-empty-text, no overwriting `pages[].text`. Both signals are made available; the agent picks.

## Test plan

- [x] `npm run lint` clean (biome, oxlint, tsgo, secretlint)
- [x] `npm test` — 173 / 173 passing (was 159; +14 OCR tests)
- [x] `parseOcrLang` rejects empty / `++` / digit / path-traversal tokens before tesseract boots
- [x] End-to-end OCR roundtrip on `sample.pdf` returns `text + confidence (0..1) + lang`
- [x] OCR does not overwrite `pages[].text`
- [x] CLI rejects `--ocr-lang eng2` with a clear stderr message
- [x] Markdown / XML output snapshots cover the new field
- [x] Manually exercised CLI: `node dist/bin/pdfvision.mjs sample.pdf --ocr -f {markdown,json,xml} --no-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)