### PR TITLE
docs(readme): add emoji to Usage and Caching headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install -g pdfvision
 pdfvision document.pdf
 ```
 
-## Usage
+## 📖 Usage
 
 ```
 pdfvision <file.pdf> [options]
@@ -121,7 +121,7 @@ for (const page of result.pages) {
 
 Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`, `renderPages`, `getCacheDir`, `getCached`, `setCache`, plus full type definitions for `DocumentResult` / `PageResult` / `PageOverview` / `DocumentMetadata` / `ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` / `LayoutBlock` / `LayoutLine` / `PageLayout` / `ImageBox` / `PageOcr`.
 
-## Caching
+## 💾 Caching
 
 Results land under `<os-tmp>/pdfvision/<sha256-prefix>/` keyed by file content. POSIX `0700` / `0600` permissions, symlink/TOCTOU defences. Override the location with `PDFVISION_CACHE_DIR=/path` or wipe everything with `pdfvision --clear-cache`.
 


### PR DESCRIPTION
## Summary

- Align the two unicorn-less H2 headings (`Usage`, `Caching`) with the rest of the README so the section nav reads consistently.
- `Usage` → `📖 Usage`
- `Caching` → `💾 Caching`

No content changes; emoji-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)