### PR TITLE
docs(readme): use real Mozilla TraceMonkey URL in --remote example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The design principle is **agent decides; pdfvision delivers raw signals.** No au
 npx pdfvision document.pdf
 
 # Pull from a URL
-npx pdfvision --remote https://example.com/paper.pdf -f json
+npx pdfvision --remote https://raw.githubusercontent.com/mozilla/pdf.js-sample-files/master/tracemonkey.pdf -f json
 
 # Or install globally
 npm install -g pdfvision


### PR DESCRIPTION
## Summary

Replace the `https://example.com/paper.pdf` placeholder in the Quick Start with the URL that pdf.js itself uses as its canonical sample fixture — Mozilla's TraceMonkey paper, hosted in the official `mozilla/pdf.js-sample-files` repo.

A copy-paste of the README line now actually works end-to-end:

```bash
npx pdfvision --remote https://raw.githubusercontent.com/mozilla/pdf.js-sample-files/master/tracemonkey.pdf -f json
```

Why this URL:

- **License-clean** — Mozilla-published sample, used by pdf.js's own test suite.
- **Politically neutral** — technical paper on JIT compilation for dynamic languages.
- **Stable host** — `raw.githubusercontent.com` of a Mozilla-owned repo, not an arbitrary third-party CDN.
- **Lineage** — same paper already lives under `life/project/pdfvision/samples/misc/tiny-pdf-mozilla-tracemonkey.pdf` as a manual test fixture.

## Test plan

- [x] `curl -I` returns 200 OK
- [x] `pdfvision --remote <url> -p 1` extracts the abstract correctly (14 pages, 5021 chars on page 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)