### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^0.1.97",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Bumps `package.json` to `0.6.0` ahead of the next npm publish.

## Highlights since v0.5.0

### Features

- **`--ocr` / `--ocr-lang`** (#18) — opt-in OCR fallback via tesseract.js (`optionalDependencies`). Adds `pages[].ocr` (`{ text, confidence, lang }`) without overwriting the pdfjs-derived `pages[].text`, so agents can compare native vs OCR. Whitespace-normalised lang strings, traineddata cached under `<cacheRoot>/ocr-data/` with `0700` perms.
- **Page-level parallelism** (#19) — per-page extraction (text / spans / op list / imageBoxes / layout) and `--render` rasterisation now run concurrently with a work-stealing runner capped at `min(availableParallelism, 8)`. Output order preserved; OCR stays serial through one tesseract worker.

### Docs

- README refocus on agent-vs-existing-tools differentiation (#17)
- Real Mozilla TraceMonkey URL in the `--remote` example so copy-paste works (#21)
- Emoji on `📖 Usage` / `💾 Caching` headings for visual consistency (#20)
- npm download badge switched to total (#16)

## Release plan

1. Merge this PR
2. Tag `v0.6.0` on `main`
3. `workflow_dispatch` on `npm-publish` (Trusted Publisher / OIDC + provenance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)