### PR TITLE
feat(skills): ship bundled pdfvision agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`, `rend
 
 ## 🤖 Agent Skill
 
-pdfvision ships a bundled agent skill at [`skills/pdfvision/`](skills/pdfvision/) (a `SKILL.md` plus a small `references/` set) so a Claude Code, Codex, or Cursor session knows when to reach for the CLI and how to pick flags. Install it with [`npx skills`](https://github.com/vercel-labs/skills):
+pdfvision ships a bundled agent skill at [`skills/pdfvision/`](https://github.com/yamadashy/pdfvision/tree/main/skills/pdfvision/) (a `SKILL.md` plus a small `references/` set) so a Claude Code, Codex, or Cursor session knows when to reach for the CLI and how to pick flags. Install it with [`npx skills`](https://github.com/vercel-labs/skills):
 
 ```bash
 # Project install (default) — drops the skill into <cwd>/.claude/skills/pdfvision/

--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ for (const page of result.pages) {
 
 Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`, `renderPages`, `getCacheDir`, `getCached`, `setCache`, plus full type definitions for `DocumentResult` / `PageResult` / `PageOverview` / `DocumentMetadata` / `ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` / `LayoutBlock` / `LayoutLine` / `PageLayout` / `ImageBox` / `PageOcr`.
 
+## 🤖 Agent Skill
+
+pdfvision ships a bundled agent skill at [`skills/pdfvision/`](skills/pdfvision/) (a `SKILL.md` plus a small `references/` set) so a Claude Code, Codex, or Cursor session knows when to reach for the CLI and how to pick flags. Install it with [`npx skills`](https://github.com/vercel-labs/skills):
+
+```bash
+# Project install (default) — drops the skill into <cwd>/.claude/skills/pdfvision/
+npx skills add yamadashy/pdfvision
+
+# Global install — drops it into ~/.claude/skills/pdfvision/ instead
+npx skills add yamadashy/pdfvision -g
+```
+
+The skill covers the daily extraction flow, the density-Overview-based silent-failure detection, and points at `references/structured-output.md` (full `DocumentResult` schema for programmatic consumers) and `references/ocr.md` (multi-language OCR, traineddata, troubleshooting) only when those specific cases apply.
+
 ## 💾 Caching
 
 Results land under `<os-tmp>/pdfvision/<sha256-prefix>/` keyed by file content. POSIX `0700` / `0600` permissions, symlink/TOCTOU defences. Override the location with `PDFVISION_CACHE_DIR=/path` or wipe everything with `pdfvision --clear-cache`.

--- a/skills/pdfvision/SKILL.md
+++ b/skills/pdfvision/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: pdfvision
+description: "Extract text, metadata, per-page density signals, structural layout, image bounding boxes, optional OCR, and rendered page PNGs from a PDF using the pdfvision CLI. Use when the input is a `.pdf` URL, a local PDF path, or another agent skill produced a PDF that still needs structured extraction. Triggers on: 'read this pdf', 'extract from <file>.pdf', '.pdf', 'scan / slide / paper / form contents'."
+---
+
+# pdfvision
+
+[pdfvision](https://github.com/yamadashy/pdfvision) extracts text + metadata + per-page density signals from any PDF, with opt-in OCR (`--ocr`), layout reconstruction (`--layout`), image bounding boxes (`--image-boxes`), per-text-item geometry (`--geometry`), and PNG rendering (`--render`). Cached by content hash, so the second read of the same PDF returns in ~30 ms.
+
+## Prerequisite
+
+```bash
+npx pdfvision --version
+```
+
+Requires Node.js >= 22.13. Install globally with `npm install -g pdfvision` if used repeatedly.
+
+**Always run `npx pdfvision --help` once before reaching for non-obvious flags** — the flag set evolves (OCR, remote URLs, layout, geometry, image-boxes, render output) and the help text is the source of truth for what the installed version supports.
+
+## Quick reference
+
+```bash
+# Local PDF, markdown to stdout (per-page sections + density Overview table)
+npx pdfvision /path/to/doc.pdf
+
+# Fetch a PDF over http(s) — downloads to cache, then extracts
+npx pdfvision --remote https://example.org/paper.pdf
+
+# Page subset
+npx pdfvision doc.pdf -p 1-5
+npx pdfvision doc.pdf -p 1,3,5
+
+# Programmatic / structured consumers
+npx pdfvision doc.pdf -f json
+npx pdfvision doc.pdf -f xml          # tag-shaped, some LLMs locate <page> faster than JSON keys
+
+# Image-flattened / scanned page — two options:
+npx pdfvision scan.pdf --ocr -f json                     # tesseract.js OCR
+npx pdfvision scan.pdf --render --render-output ./images # PNG for vision LLM
+
+# Wipe the on-disk cache
+npx pdfvision --clear-cache
+```
+
+Format choice (`markdown` / `json` / `xml`) does **not** change the cache slot — the structured payload is shared and only re-formatted on output.
+
+## Picking the right flags
+
+The default extraction is enough for most native-text PDFs (papers, exports from Word / Pages / Markdown tooling). Reach for opt-ins only when the default isn't enough.
+
+| Goal | Flag | When to reach for it |
+|---|---|---|
+| Reconstruct reading order, find headings | `--layout` | Multi-column papers, slides where the agent must process blocks in order |
+| Know where images sit on the page | `--image-boxes` | Bbox overlay on rendered PNG, figure detection |
+| Per-glyph bbox + fontSize | `--geometry` | Heading detection by font-size, custom layout heuristics |
+| Page is an image — get text from raster | `--ocr` + `--ocr-lang` | `coverage: 0%` in the Overview (see below). Details in `references/ocr.md` |
+| Hand the page to a vision model | `--render` + `--render-output <dir>` | Multimodal flows. Density Overview already flagged the page as low-text |
+| Skip the on-disk cache | `--no-cache` | Forced re-extraction. Default behaviour is cache-on |
+
+## Detecting silent failures with the density Overview
+
+When `result.pages.length > 1`, the markdown output starts with an Overview table that reports `Chars / Images / Coverage / Size` per page. The JSON / XML output carries the same data in `overview[]`. Use it before scrolling the body:
+
+- `coverage: 0%` + `imageCount > 0` → the page body is a rasterised image. The text stream is empty. Re-run with `--ocr` or `--render`.
+- `charCount: 0` but `imageCount: 0` → genuinely blank page (separator, end matter).
+- Sudden drop in coverage on a single page in an otherwise text-dense doc → that page is likely a figure / scan / chart. Inspect with `--render`.
+
+The density signal is the reason to prefer pdfvision over reading a PDF directly — silent failures (empty `text` that looks fine to a downstream consumer) become visible up front.
+
+## Caching
+
+- Cache root: `<os-tmp>/pdfvision/<content-sha>/` — macOS `/var/folders/.../T/pdfvision/`, Linux `/tmp/pdfvision/`. Override with `PDFVISION_CACHE_DIR=/path`.
+- Keyed by **PDF content hash + flag combination**. Same PDF + same flags → ~30 ms on the second call. Different flags (e.g. add `--layout` later) → different slot, fresh extraction.
+- Wipe everything (cached extractions, rendered PNGs, downloaded remote PDFs, OCR traineddata) with `npx pdfvision --clear-cache`.
+
+## Typical agent flow
+
+1. Run `npx pdfvision doc.pdf -f json` — gets text + density Overview.
+2. Read the `overview[]` to find low-coverage pages.
+3. For low-coverage pages: re-run with `--ocr` if text is needed, or `--render` if a vision model will look at the rasterised page.
+4. For structured / multi-column docs: re-run with `--layout` (and `--image-boxes` when figure positions matter).
+5. Cache means steps 3–4 only re-pay the cost of the new flag combination on the affected page subset, not the whole extract.
+
+## When to read `references/`
+
+The base of this file already covers daily extraction. Open a reference file **only** in one of these specific cases — they are not always-on context, do not load speculatively.
+
+| Read this file | When |
+|---|---|
+| `references/structured-output.md` | You are about to programmatically consume `-f json` / `-f xml` output and need the full `DocumentResult` / `PageResult` / `LayoutBlock` / `ImageBox` / `TextSpan` field reference, including coordinate-system semantics. |
+| `references/ocr.md` | You are about to run `--ocr` and the user's text is non-English, or OCR confidence is unexpectedly low, or the optional `tesseract.js` install needs to be diagnosed. Covers lang code combinations, traineddata cache location, and primary-language ordering. |

--- a/skills/pdfvision/SKILL.md
+++ b/skills/pdfvision/SKILL.md
@@ -53,17 +53,17 @@ The default extraction is enough for most native-text PDFs (papers, exports from
 | Reconstruct reading order, find headings | `--layout` | Multi-column papers, slides where the agent must process blocks in order |
 | Know where images sit on the page | `--image-boxes` | Bbox overlay on rendered PNG, figure detection |
 | Per-glyph bbox + fontSize | `--geometry` | Heading detection by font-size, custom layout heuristics |
-| Page is an image — get text from raster | `--ocr` + `--ocr-lang` | `coverage: 0%` in the Overview (see below). Details in `references/ocr.md` |
+| Page is an image — get text from raster | `--ocr` + `--ocr-lang` | `coverage: 0%` in the Overview (see below). **For non-English text, language order matters** — primary language goes first (`jpn+eng` for Japanese-dominant, `eng+jpn` for English-dominant). Full lang combinations and confidence semantics in `references/ocr.md`. |
 | Hand the page to a vision model | `--render` + `--render-output <dir>` | Multimodal flows. Density Overview already flagged the page as low-text |
 | Skip the on-disk cache | `--no-cache` | Forced re-extraction. Default behaviour is cache-on |
 
 ## Detecting silent failures with the density Overview
 
-When `result.pages.length > 1`, the markdown output starts with an Overview table that reports `Chars / Images / Coverage / Size` per page. The JSON / XML output carries the same data in `overview[]`. Use it before scrolling the body:
+When `result.pages.length > 1`, the markdown output starts with an Overview table that reports `Chars / Images / Coverage / Size` per page. The JSON / XML output carries the same data in `overview[]` with field names `charCount` / `imageCount` / `textCoverage` / `width` / `height` — use the field names directly when grepping or filtering in code. Use the Overview before scrolling the body:
 
-- `coverage: 0%` + `imageCount > 0` → the page body is a rasterised image. The text stream is empty. Re-run with `--ocr` or `--render`.
+- `textCoverage: 0` (rendered as `coverage: 0%` in markdown) + `imageCount > 0` → the page body is a rasterised image. The text stream is empty. Re-run with `--ocr` or `--render`.
 - `charCount: 0` but `imageCount: 0` → genuinely blank page (separator, end matter).
-- Sudden drop in coverage on a single page in an otherwise text-dense doc → that page is likely a figure / scan / chart. Inspect with `--render`.
+- Sudden drop in `textCoverage` on a single page in an otherwise text-dense doc → that page is likely a figure / scan / chart. Inspect with `--render`.
 
 The density signal is the reason to prefer pdfvision over reading a PDF directly — silent failures (empty `text` that looks fine to a downstream consumer) become visible up front.
 
@@ -75,8 +75,12 @@ The density signal is the reason to prefer pdfvision over reading a PDF directly
 
 ## Typical agent flow
 
-1. Run `npx pdfvision doc.pdf -f json` — gets text + density Overview.
-2. Read the `overview[]` to find low-coverage pages.
+**Inherit the user's scope first.** If the user already named a specific page or range ("page 2", "chapter 3", "the last few pages"), pass `-p` from step 1 — the density Overview works per page, so there's no need to scan a 100-page doc when the user pointed at page 2. Only run unscoped when the user genuinely asked about the whole document. Sections with conventional locations also help: "abstract" → `-p 1`, "conclusion" → `-p <last-few>`, "TOC" → `-p 1-3`.
+
+**Pick a format that matches the consumer.** If the consumer is the LLM itself reading text inline (the typical "user asks me to read this PDF" case), the markdown default is already optimal — no flag needed. Switch to `-f json` only when a downstream programmatic step needs structured field access (`overview[]`, `pages[].layout`, `pages[].ocr`, etc.). XML when the LLM downstream parses tags more reliably than nested JSON.
+
+1. Run `npx pdfvision doc.pdf` (add `-p <range>` per the scope note, and `-f json` only when you'll consume structured fields) — gets text + density Overview for the selected pages.
+2. Read the density signals (the markdown Overview table, or `overview[]` / `pages[].textCoverage` / `imageCount` / `charCount` in JSON) to find low-coverage pages.
 3. For low-coverage pages: re-run with `--ocr` if text is needed, or `--render` if a vision model will look at the rasterised page.
 4. For structured / multi-column docs: re-run with `--layout` (and `--image-boxes` when figure positions matter).
 5. Cache means steps 3–4 only re-pay the cost of the new flag combination on the affected page subset, not the whole extract.
@@ -85,7 +89,9 @@ The density signal is the reason to prefer pdfvision over reading a PDF directly
 
 The base of this file already covers daily extraction. Open a reference file **only** in one of these specific cases — they are not always-on context, do not load speculatively.
 
-| Read this file | When |
-|---|---|
-| `references/structured-output.md` | You are about to programmatically consume `-f json` / `-f xml` output and need the full `DocumentResult` / `PageResult` / `LayoutBlock` / `ImageBox` / `TextSpan` field reference, including coordinate-system semantics. |
-| `references/ocr.md` | You are about to run `--ocr` and the user's text is non-English, or OCR confidence is unexpectedly low, or the optional `tesseract.js` install needs to be diagnosed. Covers lang code combinations, traineddata cache location, and primary-language ordering. |
+Each entry is tagged as **mandatory** (read before producing the deliverable; this file doesn't carry enough on its own for the case) or **escalation** (read only if the basic guidance above isn't enough for the situation).
+
+| Read this file | Gate | When |
+|---|---|---|
+| `references/structured-output.md` | **mandatory** when you're consuming `--layout`, `--image-boxes`, `--geometry`, `--ocr`, or any other structured JSON / XML field whose schema isn't fully described in this file. SKILL.md only names the flags — the field-by-field shape lives in the reference. | Programmatic consumers of `-f json` / `-f xml`. Covers `DocumentResult` / `PageResult` / `LayoutBlock` / `ImageBox` / `TextSpan` / `PageOcr` schemas and coordinate-system semantics. |
+| `references/ocr.md` | **escalation** for the easy cases (English-only, expected confidence). **Mandatory** when the user's text is non-English (lang ordering affects results), confidence is unexpectedly low, or the `tesseract.js` install / stderr is misbehaving. | Lang code combinations, primary-language ordering, traineddata cache, install diagnostics, troubleshooting (low confidence, blank PNG, stderr noise). |

--- a/skills/pdfvision/references/ocr.md
+++ b/skills/pdfvision/references/ocr.md
@@ -1,0 +1,140 @@
+# OCR reference
+
+Detail on the `--ocr` flag — when to reach for it, multi-language behaviour, confidence semantics, install / cache requirements, and troubleshooting. Read this when running `--ocr` on non-English text, when the confidence comes back unexpectedly low, or when `tesseract.js` install needs diagnosing.
+
+For the basic flow ("page is image-flattened, run `--ocr -f json`"), the top-level SKILL.md is enough.
+
+## When to run OCR
+
+The trigger is the density Overview, not the page content itself. Look for:
+
+- `coverage: 0%` (or near-zero) with `imageCount > 0` — page body is rasterised
+- `text` is empty or garbled (a few stray characters like `r rv`) — PDF font tables are broken
+- The whole document looks fine but one page comes back empty — likely a slide / figure / scan
+
+`pdfvision` never auto-triggers OCR. The agent decides per page after reading the density signal. OCR cost is ~0.5–2 s per page (CPU-bound) plus a one-time worker boot of a few seconds; running it on every page of a 100-page paper is rarely worth it.
+
+## Lang codes and ordering
+
+`--ocr-lang` takes the tesseract.js plus-separated form: one or more 3-letter (or `chi_sim` style) codes joined with `+`.
+
+```bash
+npx pdfvision doc.pdf --ocr --ocr-lang eng         # English only (default)
+npx pdfvision doc.pdf --ocr --ocr-lang eng+jpn     # English + Japanese
+npx pdfvision doc.pdf --ocr --ocr-lang chi_sim     # Simplified Chinese
+npx pdfvision doc.pdf --ocr --ocr-lang eng+chi_sim+chi_tra
+```
+
+**Order matters.** Tesseract treats the first language as the primary recogniser; later languages act as additional candidate dictionaries. `eng+jpn` favours English glyph recognition and falls back to Japanese; `jpn+eng` does the opposite. Empirically:
+
+- For mostly-Japanese slides with English headers / labels: `jpn+eng`
+- For English documentation with sparse Japanese terms: `eng+jpn`
+- When unsure, run both and compare `confidence` and `text`
+
+pdfvision normalises whitespace in the lang string before keying the cache (` eng + jpn ` and `eng+jpn` share a slot) but **preserves order** — `eng+jpn` and `jpn+eng` are genuinely different recognisers and intentionally land in different cache slots.
+
+The echoed `pages[].ocr.lang` returns the whitespace-normalised, order-preserved form (`'eng+jpn'`, not `' eng + jpn '`).
+
+## Confidence semantics
+
+`pages[].ocr.confidence` is `0..1` (rounded to 3dp). Tesseract reports `0..100` internally; pdfvision divides by 100 to match the existing `textCoverage` convention.
+
+Rough interpretation, treat as heuristic:
+
+- `>= 0.8` — high confidence, OCR text is usable as-is for most agent purposes
+- `0.5–0.8` — usable but verify on important entities (numbers, names, code identifiers)
+- `< 0.5` — partial recognition. Either wrong `--ocr-lang`, low-resolution scan, or stylised typography. Compare with the rendered PNG via `--render` before trusting the text.
+
+A `confidence: 0` with an empty `ocr.text` usually means the rasterise step produced a blank page (see "Troubleshooting" below) rather than OCR genuinely finding nothing.
+
+## Output shape
+
+```ts
+interface PageOcr {
+  text: string;        // trimmed of trailing whitespace, line breaks preserved
+  confidence: number;  // 0..1, page-level mean
+  lang: string;        // whitespace-normalised, order-preserved
+}
+```
+
+`pages[].text` (pdfjs-derived) is **never overwritten** by OCR — both signals coexist on the same page object so the agent can diff and decide. A scanned PDF typically shows empty `text` with populated `ocr.text`; a mixed-content PDF shows native text in `text` and an alternative OCR-derived reading in `ocr.text` (useful sanity check for ambiguous glyphs).
+
+In XML output, OCR surfaces as `<ocr lang="..." confidence="...">...</ocr>`. Self-closing `<ocr lang="..." confidence="0"/>` means OCR ran and produced no text — distinct from the tag being absent (OCR wasn't requested).
+
+## Install requirements
+
+`tesseract.js` is declared in `optionalDependencies`. Default `npm install pdfvision` pulls it in (~30 MB worker bundle); `npm install --omit=optional` skips it.
+
+When `--ocr` is requested without `tesseract.js` installed, pdfvision throws:
+
+```
+--ocr requires the optional dependency "tesseract.js" (not installed).
+Install it with: npm install tesseract.js
+```
+
+Other import-time errors (broken native binding, transitive syntax error) surface the real error message, not the install hint — so the agent can diagnose without false leads.
+
+## Traineddata cache
+
+Tesseract downloads per-language `*.traineddata` files (~10–15 MB each) on first use:
+
+- `eng.traineddata` ≈ 10 MB
+- `jpn.traineddata` ≈ 13 MB
+- `chi_sim.traineddata` ≈ 16 MB
+
+pdfvision points tesseract.js at `<cache-root>/ocr-data/` (POSIX 0700) so:
+
+- The data lands under pdfvision's own cache hierarchy (consistent perms, single place)
+- `npx pdfvision --clear-cache` wipes traineddata alongside extraction caches
+- The download happens once per language; subsequent runs are offline
+
+First `--ocr` invocation against a new language takes a few extra seconds for the download. Subsequent invocations of the same language are instant on the boot step (still ~1–2 s for the worker init).
+
+## Troubleshooting
+
+### "OCR ran but `text` is empty and `confidence: 0`"
+
+Most likely the rasterise step produced a blank page, not an actual OCR failure. Common cause: the PDF uses an image format pdfjs + `@napi-rs/canvas` can't decode (notably JPEG2000 / JPX, common in Internet Archive scans). Verify by:
+
+```bash
+npx pdfvision doc.pdf -p <page> --render --render-output /tmp/dbg
+# Inspect /tmp/dbg/page-<n>.png — if it's blank, OCR has nothing to chew on.
+```
+
+This is a known limitation tracked separately from OCR. Workaround: source a different copy of the PDF, or pre-decode the JPX stream with a wasm decoder before invoking pdfvision.
+
+### "Confidence is moderate but text has obvious garbage"
+
+Most often a `--ocr-lang` mismatch — the page contains a language not listed in the spec, or the order is wrong (Japanese-dominant page run with `eng+jpn` instead of `jpn+eng`). Try the alternative ordering and compare.
+
+Second most common: low resolution. pdfvision renders at 2× by default. For genuinely fine print, render to PNG manually at higher scale and feed through tesseract.js directly via the library API (the CLI doesn't currently expose a scale flag for OCR).
+
+### "OCR is slow — N pages × M seconds is unbearable"
+
+- Restrict the page range: `-p <range>` to OCR only the pages that need it (use the density Overview to pick).
+- The single worker is reused across pages within one invocation, so a 10-page OCR run pays the boot cost once and per-page cost N times. Splitting across invocations would re-pay the boot cost on each.
+- pdfvision's page-level parallelism does **not** apply to OCR (single worker by design). Spawning multiple workers would multiply memory by ~30 MB / language without a meaningful win.
+
+### "I want OCR to overwrite `text` so my downstream consumer doesn't have to choose"
+
+By design, no. The agent / downstream is the one to decide which signal to use. If a consumer wants a single field, it can pick at consumption time:
+
+```ts
+const effectiveText = page.text || page.ocr?.text || '';
+```
+
+Keeping both signals available means a sanity check (compare native vs OCR for ambiguity) is always possible.
+
+## Examples
+
+```bash
+# Japanese slide deck, eng-dominant titles
+npx pdfvision slides.pdf --ocr --ocr-lang jpn+eng -f json
+
+# English paper with embedded Chinese citations
+npx pdfvision paper.pdf --ocr --ocr-lang eng+chi_sim -f json
+
+# Scanned book, English only
+npx pdfvision scan.pdf -p 1-20 --ocr -f json | \
+  jq '.pages[] | {page, conf: .ocr.confidence, head: .ocr.text[0:120]}'
+```

--- a/skills/pdfvision/references/ocr.md
+++ b/skills/pdfvision/references/ocr.md
@@ -92,6 +92,17 @@ First `--ocr` invocation against a new language takes a few extra seconds for th
 
 ## Troubleshooting
 
+### Benign stderr noise on the first --ocr run
+
+When `--ocr` boots tesseract.js for the first time in a session, you may see stderr lines like:
+
+```
+Error opening data file ./.traineddata
+Failed loading language ''
+```
+
+These are **harmless pre-load probes** from tesseract.js's internal boot sequence, not fatal errors. The recogniser then honors the `--ocr-lang` you actually passed. Confirm by checking `pages[].ocr.confidence` in the JSON output — if it's `> 0` and `pages[].ocr.text` is populated, OCR succeeded. Do not interpret these stderr lines as a reason to abort.
+
 ### "OCR ran but `text` is empty and `confidence: 0`"
 
 Most likely the rasterise step produced a blank page, not an actual OCR failure. Common cause: the PDF uses an image format pdfjs + `@napi-rs/canvas` can't decode (notably JPEG2000 / JPX, common in Internet Archive scans). Verify by:

--- a/skills/pdfvision/references/ocr.md
+++ b/skills/pdfvision/references/ocr.md
@@ -67,7 +67,7 @@ In XML output, OCR surfaces as `<ocr lang="..." confidence="...">...</ocr>`. Sel
 
 When `--ocr` is requested without `tesseract.js` installed, pdfvision throws:
 
-```
+```text
 --ocr requires the optional dependency "tesseract.js" (not installed).
 Install it with: npm install tesseract.js
 ```
@@ -96,7 +96,7 @@ First `--ocr` invocation against a new language takes a few extra seconds for th
 
 When `--ocr` boots tesseract.js for the first time in a session, you may see stderr lines like:
 
-```
+```text
 Error opening data file ./.traineddata
 Failed loading language ''
 ```

--- a/skills/pdfvision/references/structured-output.md
+++ b/skills/pdfvision/references/structured-output.md
@@ -31,7 +31,7 @@ interface PageOverview {
 }
 ```
 
-`overview[]` is the first thing to inspect for silent-failure detection. `imageCount > 0 && coverage ≈ 0` is the signature of an image-flattened page.
+`overview[]` is the first thing to inspect for silent-failure detection. `imageCount > 0 && textCoverage ≈ 0` is the signature of an image-flattened page.
 
 ## PageResult (per page)
 
@@ -93,7 +93,7 @@ One entry per drawn instance — a tiled hero image yields multiple entries. `im
 
 ```ts
 interface TextSpan {
-  text: string;              // normalized when --normalize is on (default)
+  text: string;              // normalized by default (disable with --no-normalize)
   x: number; y: number;      // top-left in PDF points
   width: number; height: number;
   fontSize: number;          // max of horizontal / vertical text-matrix scales

--- a/skills/pdfvision/references/structured-output.md
+++ b/skills/pdfvision/references/structured-output.md
@@ -1,0 +1,201 @@
+# Structured output schema
+
+Reference for `-f json` and `-f xml` consumers. Read this when an agent or tooling consumes the structured payload programmatically and needs to know every field, its shape, and its coordinate convention.
+
+The shape of `-f json` is the `DocumentResult` interface exported by the `pdfvision` package. `-f xml` carries the same data as `<document>` / `<page>` / nested tags. The two are isomorphic — pick whichever is easier for the consumer to parse.
+
+## DocumentResult (top level)
+
+```ts
+interface DocumentResult {
+  file: string;                // path the CLI was invoked with (or cache path for --remote)
+  totalPages: number;          // total in the source PDF, not in the selection
+  metadata: DocumentMetadata;  // title / author / subject / creator (all string | null)
+  overview?: PageOverview[];   // per-page density summary; present iff pages.length > 1
+  pages: PageResult[];         // one entry per selected page, in page-number order
+}
+```
+
+`file` is patched on cache hit to the current invocation's path, so a downstream consumer sees a meaningful path even when the cached entry came from a different invocation that touched the same content hash.
+
+## PageOverview (density summary)
+
+```ts
+interface PageOverview {
+  page: number;
+  charCount: number;
+  imageCount: number;     // raster image draws (XObject + inline + mask), per drawn instance
+  textCoverage: number;   // 0..1, fraction of page area covered by text glyph bboxes
+  width: number;          // PDF user-space points
+  height: number;
+}
+```
+
+`overview[]` is the first thing to inspect for silent-failure detection. `imageCount > 0 && coverage ≈ 0` is the signature of an image-flattened page.
+
+## PageResult (per page)
+
+```ts
+interface PageResult {
+  page: number;
+  text: string;                  // NFKC-normalized unless --no-normalize
+  rawText?: string;              // pre-normalization text — only present when normalization changed it
+  charCount: number;
+  imageCount: number;
+  textCoverage: number;
+  width: number;
+  height: number;
+  image?: string;                // absolute PNG path — present iff --render
+  spans?: TextSpan[];            // present iff --geometry
+  layout?: PageLayout;           // present iff --layout
+  imageBoxes?: ImageBox[];       // present iff --image-boxes
+  ocr?: PageOcr;                 // present iff --ocr
+}
+```
+
+`text` is the pdfjs-derived text stream. `ocr.text` (when `--ocr` is on) is the OCR result alongside, **never overwriting `text`** — consumers diff or pick whichever signal looks better for the page.
+
+## Layout (`--layout`)
+
+```ts
+interface PageLayout {
+  blocks: LayoutBlock[];     // in approximate reading order (multi-column aware)
+}
+
+interface LayoutBlock {
+  text: string;              // line texts joined with \n
+  x: number; y: number; width: number; height: number;
+  lines: LayoutLine[];
+  role?: 'heading';          // dominant fontSize ≥ 1.25× page body
+  repeated?: boolean;        // chrome (running header / footer / page number / watermark) detected across pages
+}
+
+interface LayoutLine {
+  text: string;
+  x: number; y: number; width: number; height: number;
+  fontSize: number;          // most common fontSize across the spans in this line
+}
+```
+
+Multi-column reading order: `blocks[]` reads top-to-bottom of the left column before the right column. Standalone headings act as column separators. Block clustering is still heuristic — table cells may merge into a single block.
+
+## Image boxes (`--image-boxes`)
+
+```ts
+interface ImageBox {
+  x: number; y: number; width: number; height: number;
+}
+```
+
+One entry per drawn instance — a tiled hero image yields multiple entries. `imageCount === imageBoxes.length` is an invariant on every page. Form XObject CTM tracking ensures images drawn inside a form land at the correct page-space position.
+
+## Spans (`--geometry`)
+
+```ts
+interface TextSpan {
+  text: string;              // normalized when --normalize is on (default)
+  x: number; y: number;      // top-left in PDF points
+  width: number; height: number;
+  fontSize: number;          // max of horizontal / vertical text-matrix scales
+  fontName?: string;         // pdf.js internal name e.g. "g_d0_f1"
+}
+```
+
+Whitespace-only spans are filtered out — pdf.js emits a span per positioned space, which would double the array length without adding information.
+
+## OCR (`--ocr`)
+
+```ts
+interface PageOcr {
+  text: string;              // OCR-derived text, trimmed
+  confidence: number;        // 0..1 (rounded to 3dp). Tesseract reports 0..100 internally; pdfvision normalises.
+  lang: string;              // canonicalised lang spec — whitespace-trimmed, order preserved
+}
+```
+
+`lang` echoes the caller's `--ocr-lang` after whitespace normalization but preserves token order. `eng+jpn` and `jpn+eng` produce different recognisers (tesseract treats the first language as primary) and therefore land in different cache slots and different `lang` echoes.
+
+## Coordinate system
+
+All coordinates (spans, layout blocks, image boxes) use a **top-down origin** in PDF user-space points: `(0, 0)` at the top-left of the page, `y` grows downward. This matches the rendered PNG convention, so a consumer can overlay any of the geometry signals onto `image` (when `--render` is on) without flipping.
+
+To map PDF points onto rendered PNG pixels:
+
+```ts
+const sx = image.width / page.width;
+const sy = image.height / page.height;
+const pixelBox = { x: box.x * sx, y: box.y * sy, width: box.width * sx, height: box.height * sy };
+```
+
+## XML output shape
+
+`-f xml` mirrors the JSON shape one-for-one:
+
+```xml
+<document file="..." totalPages="14">
+  <metadata>
+    <title>...</title>
+    <author>...</author>
+  </metadata>
+  <overview>
+    <page no="1" charCount="..." imageCount="..." textCoverage="..." width="..." height="..."/>
+    ...
+  </overview>
+  <pages>
+    <page no="1" charCount="..." imageCount="..." textCoverage="..." width="..." height="..." image="...">
+      <spans>
+        <span text="..." x="..." y="..." width="..." height="..." fontSize="..." fontName="..."/>
+        ...
+      </spans>
+      <layout>
+        <block x="..." y="..." width="..." height="..." role="heading" repeated="true">
+          <line x="..." y="..." width="..." height="..." fontSize="...">...</line>
+          ...
+        </block>
+        ...
+      </layout>
+      <imageBoxes>
+        <imageBox x="..." y="..." width="..." height="..."/>
+        ...
+      </imageBoxes>
+      <text>
+...page text body...
+      </text>
+      <rawText>
+...pre-normalization text, when normalization changed it...
+      </rawText>
+      <ocr lang="eng" confidence="0.91">
+...OCR text...
+      </ocr>
+    </page>
+    ...
+  </pages>
+</document>
+```
+
+Empty `<layout/>`, `<imageBoxes/>`, and `<ocr/>` (self-closing) mean "the pass ran and found nothing", which is distinct from the tag being absent (the pass wasn't requested).
+
+## Library API (Node.js consumers)
+
+If the consumer is itself a Node.js process, prefer the library API over invoking the CLI:
+
+```ts
+import { processDocument } from 'pdfvision';
+
+const result = await processDocument('./doc.pdf', {
+  pages: '1-3',
+  layout: true,
+  imageBoxes: true,
+  ocr: true,
+  ocrLang: 'eng+jpn',
+});
+
+// `result` is a typed DocumentResult — no JSON.parse, no string formatting.
+for (const page of result.pages) {
+  if (page.ocr) console.log(page.ocr.text);
+}
+```
+
+`processFile()` returns the formatted string output (`markdown` / `json` / `xml`). `processDocument()` returns the structured object directly.
+
+Exported types: `DocumentResult`, `DocumentMetadata`, `PageOverview`, `PageResult`, `LayoutBlock`, `LayoutLine`, `PageLayout`, `ImageBox`, `TextSpan`, `PageOcr`, `OutputFormat`, `ProcessDocumentOptions`, `ProcessOptions`.


### PR DESCRIPTION
## Summary

Adds `skills/pdfvision/` (a `SKILL.md` plus a `references/` set) so agent runtimes installing the skill via [`npx skills`](https://github.com/vercel-labs/skills) get a self-contained spec for invoking the pdfvision CLI. Mirrors the layout used by [agent-carnet](https://github.com/yamadashy/agent-carnet).

```bash
# Project install
npx skills add yamadashy/pdfvision

# Global install
npx skills add yamadashy/pdfvision -g
```

## Layout

```
skills/pdfvision/
├── SKILL.md
└── references/
    ├── structured-output.md
    └── ocr.md
```

- **`SKILL.md`** — daily extraction flow (basic / `--remote` / `-p` / `-f`), density-Overview-based silent-failure detection, flag-picking table, caching, typical agent flow. Points at `npx pdfvision --help` as the **source of truth** for the installed flag set so the skill doesn't drift behind CLI changes.
- **`references/structured-output.md`** — full `DocumentResult` / `PageResult` / `LayoutBlock` / `LayoutLine` / `ImageBox` / `TextSpan` / `PageOcr` schema for programmatic consumers, coordinate-system semantics (top-down, in PDF points; multiply by `image.width / page.width` to map onto pixels), XML output shape, library API snippet.
- **`references/ocr.md`** — multi-language OCR (primary-language ordering of `eng+jpn` vs `jpn+eng`), confidence semantics (`0..1`, rounded to 3dp), traineddata cache location, install diagnostics, troubleshooting for blank-PNG / low-confidence / `--ocr-lang` mismatch cases.

The references/ are intentionally **not always-on context** — `SKILL.md`'s "When to read references/" table tells the agent which specific case warrants opening each file (matching the agent-carnet discipline).

## README

Adds a "🤖 Agent Skill" section between Library API and Caching with the `npx skills add` install snippet.

## Out of scope

- npm tarball does not include `skills/` — `npx skills` reads from GitHub, so there's no need to bloat the published package.
- biome / oxlint / tsgo / secretlint configs already exclude `skills/` (only `src/**` / `tests/**` / `.github/**` / config files are included), so no lint changes needed.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — 184 / 184 passing (unchanged)
- [x] Manually inspected SKILL.md frontmatter — name + description, description includes trigger phrases (".pdf", "extract from <file>.pdf", "scan / slide / paper / form contents") matching the agent-carnet style

🤖 Generated with [Claude Code](https://claude.com/claude-code)