### PR TITLE
feat: close the silent-failure gaps in PDF reading (cMap, blank scan, quality)

### DIFF
--- a/skills/pdfvision/SKILL.md
+++ b/skills/pdfvision/SKILL.md
@@ -59,13 +59,30 @@ The default extraction is enough for most native-text PDFs (papers, exports from
 
 ## Detecting silent failures with the density Overview
 
-When `result.pages.length > 1`, the markdown output starts with an Overview table that reports `Chars / Images / Coverage / Size` per page (plus `NonPrint` when any page has non-zero non-printable ratio, and `Blocks` when `--layout` was on). The JSON / XML output carries the same data in `overview[]` with field names `charCount` / `imageCount` / `textCoverage` / `nonPrintableRatio` / `width` / `height` — use the field names directly when grepping or filtering in code. Use the Overview before scrolling the body:
+When `result.pages.length > 1`, the markdown output starts with an Overview table that reports `Chars / Images / Coverage / Size` per page (plus `NonPrint` when any page has non-zero non-printable ratio, and `Blocks` when `--layout` was on). The JSON / XML output carries the same data in `overview[]` with field names `charCount` / `imageCount` / `textCoverage` / `nonPrintableRatio` / `nonPrintableCount` / `width` / `height` / `quality` — use the field names directly when grepping or filtering in code. Use the Overview before scrolling the body.
+
+### One-shot dispatch: `pages[].quality`
+
+Each page (and each overview row) carries a derived `quality` field that classifies the page from the raw signals so agents don't have to reimplement the threshold logic:
+
+- `quality.nativeTextStatus`:
+  - `ok` — usable native text.
+  - `unusable_glyph_indices` — `nonPrintableRatio >= 0.05`. Text is binary garbage even though `charCount` looks healthy. Fall back to `--render` or `--ocr`.
+  - `empty_but_visual_content` — no native text, but the page carries images or non-blank pixels. Re-run with `--ocr` (or read the rendered PNG via `--render`).
+  - `empty` — no text, no detected visual content. Likely a genuinely blank page (or a render failure — combine with `visualStatus` below).
+- `quality.visualStatus` (present only when `--render` or `--ocr` ran):
+  - `ok` — renderer drew real content.
+  - `blank` — page came out effectively blank against its own dominant background. Render-pipeline failure or genuinely blank page.
+
+pdfvision deliberately stops at observation: it does **not** recommend an action. The action is the agent's call based on the two statuses + the raw signals below.
+
+### Raw signals (the inputs to `quality`)
 
 - `textCoverage: 0` (rendered as `coverage: 0%` in markdown) + `imageCount > 0` → the page body is a rasterised image. The text stream is empty. Re-run with `--ocr` or `--render`.
-- `nonPrintableRatio >= 0.05` → pdf.js fell back to raw glyph indices because the PDF's fonts lack a ToUnicode CMap (common with Hebrew, older CJK, custom symbol fonts). `text` reads as full coverage but is binary garbage. Do **not** trust native text on these pages — re-run with `--render` to look at the page visually, or `--ocr` to extract via raster. Values `>= 0.3` are pathological; `< 0.01` is normal.
+- `nonPrintableRatio >= 0.05` → pdf.js fell back to raw glyph indices because the PDF's fonts lack a ToUnicode CMap (common with Hebrew, older CJK, custom symbol fonts). `text` reads as full coverage but is binary garbage. Values `>= 0.3` are pathological; `< 0.01` is normal. The raw count is in `nonPrintableCount` — when the 3dp ratio rounds to 0 the count still tells you whether any non-printable code points slipped through (useful for "is there ANY garbage in this page?" filters).
 - `charCount: 0` but `imageCount: 0` → genuinely blank page (separator, end matter).
 - Sudden drop in `textCoverage` on a single page in an otherwise text-dense doc → that page is likely a figure / scan / chart. Inspect with `--render`.
-- `renderContentRatio <= 0.001` (when `--render` or `--ocr` was on) → the rasterised page came out blank. Likely a render-pipeline failure (pdf.js + @napi-rs/canvas can't decode JPEG2000 image streams, or the font has no resolvable glyphs). OCR on this page returns `confidence: 0` not because OCR failed but because the input was a white image — distinguish this from a real OCR miss before trusting "no text".
+- `renderContentRatio <= 0.001` (when `--render` or `--ocr` was on) → the rasterised page came out blank **against its own dominant background**. Likely a render-pipeline failure (pdf.js + @napi-rs/canvas can't decode JPEG2000 image streams, or the font has no resolvable glyphs). The ratio is background-aware — dark book covers and beige scan paper don't false-trip it. OCR on this page returns `confidence: 0` not because OCR failed but because the input was a near-uniform image.
 
 The density signal is the reason to prefer pdfvision over reading a PDF directly — silent failures (empty `text` that looks fine to a downstream consumer, or full `text` that is actually NUL bytes) become visible up front.
 

--- a/skills/pdfvision/references/structured-output.md
+++ b/skills/pdfvision/references/structured-output.md
@@ -27,16 +27,18 @@ interface PageOverview {
   imageCount: number;             // raster image draws (XObject + inline + mask), per drawn instance
   textCoverage: number;           // 0..1, fraction of page area covered by text glyph bboxes
   nonPrintableRatio: number;      // 0..1, fraction of `text` that is NUL / control / noncharacter
-  renderContentRatio?: number;    // 0..1, fraction of non-blank pixels in the raster (present iff --render or --ocr)
+  nonPrintableCount: number;      // raw count — stays discriminable when the 3dp ratio rounds to 0
+  renderContentRatio?: number;    // 0..1, fraction of pixels differing from the page's dominant background (present iff --render or --ocr)
+  quality: PageQuality;           // derived classification — see below
   width: number;                  // PDF user-space points
   height: number;
 }
 ```
 
-`overview[]` is the first thing to inspect for silent-failure detection. Signatures:
+`overview[]` is the first thing to inspect for silent-failure detection. The `quality` field gives a one-shot classification; the raw signals below let agents combine signals their own way:
 - `imageCount > 0 && textCoverage ≈ 0` → image-flattened page; the text stream is empty.
-- `nonPrintableRatio >= 0.05` → ToUnicode CMap missing; the text stream is full of raw glyph indices (NUL + control chars) even though `textCoverage` looks fine. Native text is unusable; fall back to `--render` or `--ocr`.
-- `renderContentRatio <= 0.001` → rasterised page is effectively blank (only meaningful when `--render` or `--ocr` was on). Catches render-pipeline failures pdfvision can't otherwise surface: pdf.js + @napi-rs/canvas can't decode JPEG2000 image streams (common in Internet Archive scans), and PDFs whose fonts have no resolvable glyphs draw nothing. When OCR runs against this, `confidence: 0` is *not* an OCR miss — the input was a white image.
+- `nonPrintableRatio >= 0.05` → ToUnicode CMap missing; the text stream is full of raw glyph indices (NUL + control chars) even though `textCoverage` looks fine. Native text is unusable; fall back to `--render` or `--ocr`. Maps to `quality.nativeTextStatus === 'unusable_glyph_indices'`.
+- `renderContentRatio <= 0.001` → rasterised page is effectively blank against its own dominant background (only meaningful when `--render` or `--ocr` was on). Background-aware so dark covers and beige scans don't false-trip it. Catches render-pipeline failures pdfvision can't otherwise surface: pdf.js + @napi-rs/canvas can't decode JPEG2000 image streams (common in Internet Archive scans), and PDFs whose fonts have no resolvable glyphs draw nothing. When OCR runs against this, `confidence: 0` is *not* an OCR miss — the input was a near-uniform image. Maps to `quality.visualStatus === 'blank'`.
 
 ## PageResult (per page)
 
@@ -49,7 +51,9 @@ interface PageResult {
   imageCount: number;
   textCoverage: number;
   nonPrintableRatio: number;     // NUL / control / noncharacter ratio in `text`
-  renderContentRatio?: number;   // non-blank pixel fraction in the raster (present iff --render or --ocr)
+  nonPrintableCount: number;     // raw count alongside the ratio
+  renderContentRatio?: number;   // pixel fraction differing from the page's dominant background (present iff --render or --ocr)
+  quality: PageQuality;          // derived per-page classification — agent-side dispatch lives on this field
   width: number;
   height: number;
   image?: string;                // absolute PNG path — present iff --render
@@ -58,9 +62,22 @@ interface PageResult {
   imageBoxes?: ImageBox[];       // present iff --image-boxes
   ocr?: PageOcr;                 // present iff --ocr
 }
+
+interface PageQuality {
+  nativeTextStatus:
+    | 'ok'                       // usable native text
+    | 'unusable_glyph_indices'   // nonPrintableRatio >= 0.05 — fall back to --ocr / --render
+    | 'empty_but_visual_content' // no native text but the page has images / non-blank pixels
+    | 'empty';                   // no text, no detected visual content
+  visualStatus?:                 // present iff --render or --ocr triggered a raster
+    | 'ok'                       // renderContentRatio > 0.001 — renderer drew real content
+    | 'blank';                   // renderContentRatio <= 0.001 — effectively blank against the page's own background
+}
 ```
 
 `text` is the pdfjs-derived text stream. `ocr.text` (when `--ocr` is on) is the OCR result alongside, **never overwriting `text`** — consumers diff or pick whichever signal looks better for the page.
+
+`quality` is pure observation, not recommendation: pdfvision tells the agent what it saw, the agent picks what to do next.
 
 ## Layout (`--layout`)
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -141,6 +141,13 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
       imageBoxes: (values['image-boxes'] as boolean | undefined) ?? false,
       ocr: (values.ocr as boolean | undefined) ?? false,
       ocrLang: (values['ocr-lang'] as string | undefined) ?? 'eng',
+      // Library callers stay silent by default; the CLI wires warnings
+      // to stderr so users see them alongside the formatted output on
+      // stdout. Single-line "pdfvision: warning: ..." prefix matches
+      // the existing CLI error format from `exitWithError`.
+      onWarning: (msg) => {
+        process.stderr.write(`pdfvision: warning: ${msg}\n`);
+      },
     });
     console.log(result);
   } catch (error) {

--- a/src/core/nonPrintable.ts
+++ b/src/core/nonPrintable.ts
@@ -50,12 +50,15 @@ function isNonPrintableCodePoint(cp: number): boolean {
 }
 
 /**
- * Compute the non-printable ratio for a string, iterating by Unicode code
- * point (not UTF-16 code unit). Returns a value in [0, 1] rounded to 3dp,
- * matching `textCoverage`'s rounding so the two signals compare like-for-like.
+ * Compute non-printable counts for a string, iterating by Unicode code
+ * point (not UTF-16 code unit). Returns the raw count alongside the
+ * ratio so callers can still see sparse occurrences (e.g. 2 control
+ * chars in a 5000-char body page) that the 3dp ratio would round to 0.
+ * Ratio matches `textCoverage`'s rounding so the two signals compare
+ * like-for-like.
  */
-export function nonPrintableRatio(text: string): number {
-  if (text.length === 0) return 0;
+export function nonPrintableStats(text: string): { count: number; ratio: number } {
+  if (text.length === 0) return { count: 0, ratio: 0 };
   let total = 0;
   let bad = 0;
   // Manual codePointAt loop instead of `for (const ch of text)` — the
@@ -69,5 +72,14 @@ export function nonPrintableRatio(text: string): number {
     if (isNonPrintableCodePoint(cp)) bad++;
     i += cp > 0xffff ? 2 : 1;
   }
-  return Math.round((bad / total) * 1000) / 1000;
+  return { count: bad, ratio: Math.round((bad / total) * 1000) / 1000 };
+}
+
+/**
+ * Back-compat wrapper around {@link nonPrintableStats} — keeps the
+ * public 0..1 ratio function shape stable for library consumers that
+ * imported it directly.
+ */
+export function nonPrintableRatio(text: string): number {
+  return nonPrintableStats(text).ratio;
 }

--- a/src/core/pageRange.ts
+++ b/src/core/pageRange.ts
@@ -3,15 +3,35 @@ export function parsePageRange(range: string, totalPages: number): number[] {
 }
 
 /**
+ * Cap on how many out-of-range page numbers we enumerate in `skipped`.
+ * A user typing `--pages 1-1000000000` against a 30-page doc would
+ * otherwise OOM the process building a 10^9-entry Set; the cap stops
+ * that without losing the signal — the warning still shows the first
+ * N skipped numbers via `skipped` and tells the caller more were
+ * truncated via `skippedTruncated`.
+ */
+const MAX_TRACKED_SKIPPED = 100;
+
+/**
  * Same parse rules as {@link parsePageRange}, but also reports which
  * page numbers in the request fell outside `1..totalPages`. processor
- * uses the `skipped` list to emit a stderr warning so callers don't
- * silently miss the trailing pages of e.g. `--pages 1-3,5` against a
- * 4-page document. Pure parser — no side effects.
+ * uses the `skipped` list to emit a warning so callers don't silently
+ * miss the trailing pages of e.g. `--pages 1-3,5` against a 4-page
+ * document. Pure parser — no side effects.
+ *
+ * `skippedTruncated` is `true` when the request named more than
+ * {@link MAX_TRACKED_SKIPPED} out-of-range pages; in that case
+ * `skipped` carries the first {@link MAX_TRACKED_SKIPPED} only. This
+ * caps memory on adversarial inputs (`--pages 1-1000000000`) while
+ * still surfacing the head of the out-of-range run.
  */
-export function parsePageRangeWithSkipped(range: string, totalPages: number): { pages: number[]; skipped: number[] } {
+export function parsePageRangeWithSkipped(
+  range: string,
+  totalPages: number,
+): { pages: number[]; skipped: number[]; skippedTruncated: boolean } {
   const pages = new Set<number>();
   const skipped = new Set<number>();
+  let skippedTruncated = false;
 
   for (const part of range.split(',')) {
     const trimmed = part.trim();
@@ -29,17 +49,33 @@ export function parsePageRangeWithSkipped(range: string, totalPages: number): { 
       if (!Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < 1 || start > end) {
         throw new Error(`Invalid --pages "${range}": malformed range "${trimmed}"`);
       }
-      for (let i = start; i <= end; i++) {
-        if (i <= totalPages) pages.add(i);
-        else skipped.add(i);
+      // Enumerate in-range pages directly; for the out-of-range tail we
+      // stop as soon as the cap is hit so an absurd upper bound
+      // (`1-1000000000`) doesn't burn memory on numbers we'd never use.
+      const inRangeEnd = Math.min(end, totalPages);
+      for (let i = start; i <= inRangeEnd; i++) pages.add(i);
+      if (end > totalPages) {
+        const outRangeStart = Math.max(start, totalPages + 1);
+        for (let i = outRangeStart; i <= end; i++) {
+          if (skipped.size >= MAX_TRACKED_SKIPPED) {
+            skippedTruncated = true;
+            break;
+          }
+          skipped.add(i);
+        }
       }
     } else {
       const num = Number(trimmed);
       if (!Number.isInteger(num) || num < 1) {
         throw new Error(`Invalid --pages "${range}": "${trimmed}" is not a positive integer`);
       }
-      if (num <= totalPages) pages.add(num);
-      else skipped.add(num);
+      if (num <= totalPages) {
+        pages.add(num);
+      } else if (skipped.size >= MAX_TRACKED_SKIPPED) {
+        skippedTruncated = true;
+      } else {
+        skipped.add(num);
+      }
     }
   }
 
@@ -50,5 +86,6 @@ export function parsePageRangeWithSkipped(range: string, totalPages: number): { 
   return {
     pages: [...pages].sort((a, b) => a - b),
     skipped: [...skipped].sort((a, b) => a - b),
+    skippedTruncated,
   };
 }

--- a/src/core/pageRange.ts
+++ b/src/core/pageRange.ts
@@ -1,5 +1,17 @@
 export function parsePageRange(range: string, totalPages: number): number[] {
+  return parsePageRangeWithSkipped(range, totalPages).pages;
+}
+
+/**
+ * Same parse rules as {@link parsePageRange}, but also reports which
+ * page numbers in the request fell outside `1..totalPages`. processor
+ * uses the `skipped` list to emit a stderr warning so callers don't
+ * silently miss the trailing pages of e.g. `--pages 1-3,5` against a
+ * 4-page document. Pure parser — no side effects.
+ */
+export function parsePageRangeWithSkipped(range: string, totalPages: number): { pages: number[]; skipped: number[] } {
   const pages = new Set<number>();
+  const skipped = new Set<number>();
 
   for (const part of range.split(',')) {
     const trimmed = part.trim();
@@ -17,8 +29,9 @@ export function parsePageRange(range: string, totalPages: number): number[] {
       if (!Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < 1 || start > end) {
         throw new Error(`Invalid --pages "${range}": malformed range "${trimmed}"`);
       }
-      for (let i = start; i <= Math.min(end, totalPages); i++) {
-        pages.add(i);
+      for (let i = start; i <= end; i++) {
+        if (i <= totalPages) pages.add(i);
+        else skipped.add(i);
       }
     } else {
       const num = Number(trimmed);
@@ -26,6 +39,7 @@ export function parsePageRange(range: string, totalPages: number): number[] {
         throw new Error(`Invalid --pages "${range}": "${trimmed}" is not a positive integer`);
       }
       if (num <= totalPages) pages.add(num);
+      else skipped.add(num);
     }
   }
 
@@ -33,5 +47,8 @@ export function parsePageRange(range: string, totalPages: number): number[] {
     throw new Error(`Invalid --pages "${range}": no pages selected (document has ${totalPages} page(s))`);
   }
 
-  return [...pages].sort((a, b) => a - b);
+  return {
+    pages: [...pages].sort((a, b) => a - b),
+    skipped: [...skipped].sort((a, b) => a - b),
+  };
 }

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto';
 import { lstatSync, mkdirSync, mkdtempSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, dirname as pathDirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { formatJson } from '../output/json.js';
 import { formatMarkdown } from '../output/markdown.js';
@@ -335,32 +336,41 @@ export async function processDocument(filePath: string, options: ProcessDocument
     OPS.paintImageMaskXObject,
     OPS.paintInlineImageXObject,
   ]);
-  // Hand pdf.js the bundled OpenJPEG (JPX / JPEG2000) + JBIG2 wasm decoders.
-  // Without `wasmUrl` pdf.js 5.x silently renders pages whose image XObjects
-  // use JPX (typical of Internet Archive scans) as fully-white PNGs — OCR on
-  // that input returns confidence 0 and the agent has no way to tell
-  // render-pipeline failure from a genuine empty page. The wasm files ship
-  // inside pdfjs-dist, so resolving the installed package directory is
-  // enough; no extra dependency required. We intentionally do NOT set
-  // `iccUrl`: turning on ICC color management subtly shifts rendered pixel
-  // values on Linux, which makes tesseract misread otherwise clean glyphs
-  // (observed: `hello pdfvision` → `helb pdfvisdn` on ubuntu CI). JPX
-  // decoding does not require ICC, so we keep it off.
-  // Falls back silently to pre-wasm behaviour if resolution fails (the JPX
-  // page would have been blank either way, and non-JPX content still
-  // renders) rather than throwing on otherwise-readable PDFs.
+  // Hand pdf.js the bundled OpenJPEG (JPX / JPEG2000) + JBIG2 wasm decoders
+  // AND the predefined CJK CMap pack.
+  //   - `wasmUrl` lets pdf.js decode JPX image streams (Internet Archive
+  //     scans). Without it those pages render as solid blanks.
+  //   - `cMapUrl` + `cMapPacked: true` lets pdf.js resolve CJK glyphs that
+  //     reference predefined CMaps like `Adobe-Japan1-UCS2`. Without it
+  //     SpeakerDeck / Office Japanese exports come back with `text: ""`
+  //     and the agent has no way to tell native-text-empty from
+  //     image-only.
+  // We pass *plain filesystem paths* (no `file://` prefix). pdf.js's Node
+  // factory calls `fs.readFile(url)` directly, which silently fails on
+  // `file://` *strings* (only `URL` objects are accepted by fs); plain
+  // paths sidestep that mismatch entirely. pdf.js validates only the
+  // trailing slash, not the URL scheme.
+  // We intentionally do NOT set `iccUrl`: turning on ICC color management
+  // subtly shifts rendered pixel values on Linux, which makes tesseract
+  // misread otherwise clean glyphs (observed: `hello pdfvision` → `helb
+  // pdfvisdn` on ubuntu CI). JPX decoding does not require ICC.
+  // Best-effort: if pdfjs-dist resolution fails, fall back to pre-asset
+  // behaviour rather than failing the whole extraction.
   const docOptions: Record<string, unknown> = { url: filePath };
   try {
     // `import.meta.resolve` is sync since Node 20.6 and returns a file://
-    // URL string for an installed package. Deriving the wasm dir by URL
-    // arithmetic avoids reaching for createRequire + path helpers.
-    const pdfjsPkgUrl = new URL(import.meta.resolve('pdfjs-dist/package.json'));
-    // pdf.js expects a trailing slash on the directory URL so it can
-    // append filenames (`openjpeg.wasm`, etc.) directly.
-    docOptions.wasmUrl = new URL('wasm/', pdfjsPkgUrl).href;
+    // URL for an installed package; convert to a plain directory path so
+    // the resulting wasm/cmap dirs work with fs.readFile in Node.
+    const pdfjsPkgPath = fileURLToPath(import.meta.resolve('pdfjs-dist/package.json'));
+    const pdfjsPkgDir = pathDirname(pdfjsPkgPath);
+    // Trailing slash matters: pdf.js appends the filename to this value
+    // without an extra separator.
+    docOptions.wasmUrl = `${pdfjsPkgDir}/wasm/`;
+    docOptions.cMapUrl = `${pdfjsPkgDir}/cmaps/`;
+    docOptions.cMapPacked = true;
   } catch {
-    // Best-effort: keep going without the wasm asset URL rather than fail
-    // the whole extraction over a missing optional decoder.
+    // Best-effort: keep going without the wasm/cmap asset URLs rather
+    // than fail the whole extraction over a missing optional asset.
   }
   const doc = await getDocument(docOptions).promise;
   try {

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -11,6 +11,7 @@ import type {
   DocumentResult,
   ImageBox,
   PageLayout,
+  PageQuality,
   PageResult,
   ProcessDocumentOptions,
   ProcessOptions,
@@ -120,6 +121,39 @@ interface PageData {
   spans?: TextSpan[];
   layout?: PageLayout;
   imageBoxes?: ImageBox[];
+}
+
+/**
+ * Threshold above which `nonPrintableRatio` is taken to mean "pdf.js
+ * returned raw glyph codes" rather than "occasional control char in
+ * otherwise clean text". Matches the skill-doc guidance.
+ */
+const UNUSABLE_NPR_THRESHOLD = 0.05;
+/** Same blank threshold the skill doc publishes for `renderContentRatio`. */
+const BLANK_RENDER_THRESHOLD = 0.001;
+
+/**
+ * Derive {@link PageQuality} from the already-extracted signals.
+ * Pure function of the raw fields — invoked once per page after OCR
+ * has had a chance to attach its own `renderContentRatio`.
+ */
+function derivePageQuality(p: PageResult): PageQuality {
+  const hasVisualRender = p.renderContentRatio !== undefined && p.renderContentRatio > BLANK_RENDER_THRESHOLD;
+  let nativeTextStatus: PageQuality['nativeTextStatus'];
+  if (p.nonPrintableRatio >= UNUSABLE_NPR_THRESHOLD) {
+    nativeTextStatus = 'unusable_glyph_indices';
+  } else if (p.charCount > 0) {
+    nativeTextStatus = 'ok';
+  } else if (p.imageCount > 0 || hasVisualRender) {
+    nativeTextStatus = 'empty_but_visual_content';
+  } else {
+    nativeTextStatus = 'empty';
+  }
+  const quality: PageQuality = { nativeTextStatus };
+  if (p.renderContentRatio !== undefined) {
+    quality.visualStatus = p.renderContentRatio > BLANK_RENDER_THRESHOLD ? 'ok' : 'blank';
+  }
+  return quality;
 }
 
 interface PageFlags {
@@ -442,7 +476,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
     const pages: PageResult[] = await runParallel(pageNumbers, async (pageNum, i) => {
       const data = await extractPageData(doc, pageNum, imageOps, flags);
       const renderRatio = renderRatios[i];
-      return {
+      const page: PageResult = {
         page: pageNum,
         text: data.text,
         ...(data.rawText !== undefined && { rawText: data.rawText }),
@@ -457,7 +491,13 @@ export async function processDocument(filePath: string, options: ProcessDocument
         ...(data.spans !== undefined && { spans: data.spans }),
         ...(data.layout !== undefined && { layout: data.layout }),
         ...(data.imageBoxes !== undefined && { imageBoxes: data.imageBoxes }),
+        // Initial classification using whatever signals we have so far.
+        // OCR may attach a renderContentRatio below; the post-OCR pass
+        // overwrites this with the final classification.
+        quality: { nativeTextStatus: 'empty' },
       };
+      page.quality = derivePageQuality(page);
+      return page;
     });
 
     // Repeated-chrome detection has to wait until every selected page is
@@ -476,6 +516,13 @@ export async function processDocument(filePath: string, options: ProcessDocument
       // raster for any slot where the path is missing (no `--render`,
       // or a cache-hit slot that returned `contentRatio: undefined`).
       await attachOcr(doc, pageNumbers, pages, ocrLang, imagePaths ?? undefined);
+    }
+
+    // Compute the derived `quality` field *after* OCR so the OCR-only
+    // path's renderContentRatio is included in the empty_but_visual_content
+    // decision.
+    for (const p of pages) {
+      p.quality = derivePageQuality(p);
     }
 
     const metaString = (raw: unknown): string | null => {
@@ -500,6 +547,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
             // summary alone. Stays optional when neither --render nor --ocr
             // produced a raster.
             ...(p.renderContentRatio !== undefined && { renderContentRatio: p.renderContentRatio }),
+            quality: p.quality,
             width: p.width,
             height: p.height,
           }))

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -20,8 +20,8 @@ import type {
 import { dropCached, ensurePrivateDir, getCacheDir, getCached, setCache } from './cache.js';
 import { buildImageBoxes, type ImageOps } from './imageBoxes.js';
 import { buildLayout, markRepeatedBlocks } from './layout.js';
-import { nonPrintableRatio } from './nonPrintable.js';
-import { parsePageRange } from './pageRange.js';
+import { nonPrintableStats } from './nonPrintable.js';
+import { parsePageRangeWithSkipped } from './pageRange.js';
 import { runParallel } from './parallel.js';
 
 /** Inputs that determine which cached entry a request maps to. */
@@ -50,7 +50,7 @@ function buildCacheKey(input: CacheKeyInput): string {
     pages: input.pages ?? 'all',
     // Bump when the on-disk DocumentResult shape changes so older entries
     // (missing newly-added page fields) are not handed out as fresh results.
-    format: 'structured-v11',
+    format: 'structured-v12',
     render: !!input.render,
     // Including the resolved render-output dir keeps two invocations with
     // different `--render-output` targets from sharing image paths.
@@ -116,6 +116,7 @@ interface PageData {
   imageCount: number;
   textCoverage: number;
   nonPrintableRatio: number;
+  nonPrintableCount: number;
   width: number;
   height: number;
   spans?: TextSpan[];
@@ -261,18 +262,24 @@ async function extractPageData(
   // Build layout last so it always sees the final span list (post normalize).
   const layout = flags.layout ? buildLayout(spans, round2(width)) : undefined;
 
+  // Measured on the text we actually return (post-normalize) so the
+  // count + ratio match what an agent sees in `text`. Cheap (one
+  // string walk), so always on — this is the primary signal for
+  // catching ToUnicode-CMap-less PDFs that look 100% covered but emit
+  // raw glyph indices. Surfacing the raw count alongside the ratio
+  // keeps sparse occurrences (a handful of control chars in a long
+  // body page) discriminable from "zero" when the 3dp ratio rounds
+  // them down.
+  const npStats = nonPrintableStats(text);
+
   return {
     text,
     rawText: preservedRaw,
     charCount: text.length,
     imageCount,
     textCoverage: Math.round(textCoverage * 1000) / 1000,
-    // Measured on the text we actually return (post-normalize) so the
-    // ratio matches what an agent sees in `text`. Cheap (one string
-    // walk), so always on — this is the primary signal for catching
-    // ToUnicode-CMap-less PDFs that look 100% covered but emit raw
-    // glyph indices.
-    nonPrintableRatio: nonPrintableRatio(text),
+    nonPrintableRatio: npStats.ratio,
+    nonPrintableCount: npStats.count,
     // Round to 2dp; PDF dimensions are nominally integers (Letter 612×792,
     // A4 595×842) but encrypted/cropped PDFs can carry sub-point fractions.
     width: round2(width),
@@ -409,9 +416,24 @@ export async function processDocument(filePath: string, options: ProcessDocument
   const doc = await getDocument(docOptions).promise;
   try {
     const totalPages = doc.numPages;
-    const pageNumbers = options.pages
-      ? parsePageRange(options.pages, totalPages)
-      : Array.from({ length: totalPages }, (_, i) => i + 1);
+    let pageNumbers: number[];
+    if (options.pages) {
+      const parsed = parsePageRangeWithSkipped(options.pages, totalPages);
+      pageNumbers = parsed.pages;
+      // Warn (not throw) when the request named pages past the end. A
+      // hard error would over-rotate on the common case `--pages 1-50`
+      // for a 30-page doc; a silent drop lost real data (codex flagged
+      // this on the apple-10-k sample). The middle path lets the
+      // extraction succeed for the in-range pages while still telling
+      // the caller something got skipped.
+      if (parsed.skipped.length > 0) {
+        process.stderr.write(
+          `pdfvision: warning: --pages "${options.pages}" included page(s) past the end of the document (totalPages=${totalPages}); skipped: ${parsed.skipped.join(', ')}\n`,
+        );
+      }
+    } else {
+      pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
 
     const metadata = await doc.getMetadata();
     const info = metadata.info as Record<string, unknown> | null;
@@ -485,6 +507,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
         imageCount: data.imageCount,
         textCoverage: data.textCoverage,
         nonPrintableRatio: data.nonPrintableRatio,
+        nonPrintableCount: data.nonPrintableCount,
         ...(renderRatio !== undefined && { renderContentRatio: renderRatio }),
         width: data.width,
         height: data.height,
@@ -542,6 +565,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
             imageCount: p.imageCount,
             textCoverage: p.textCoverage,
             nonPrintableRatio: p.nonPrintableRatio,
+            nonPrintableCount: p.nonPrintableCount,
             // Mirror the per-page renderContentRatio onto the overview row
             // so an agent can spot blank-rendered pages from the top-level
             // summary alone. Stays optional when neither --render nor --ocr

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -405,9 +405,14 @@ export async function processDocument(filePath: string, options: ProcessDocument
     const pdfjsPkgPath = fileURLToPath(import.meta.resolve('pdfjs-dist/package.json'));
     const pdfjsPkgDir = pathDirname(pdfjsPkgPath);
     // Trailing slash matters: pdf.js appends the filename to this value
-    // without an extra separator.
-    docOptions.wasmUrl = `${pdfjsPkgDir}/wasm/`;
-    docOptions.cMapUrl = `${pdfjsPkgDir}/cmaps/`;
+    // without an extra separator. pdf.js's `getFactoryUrlProp` only
+    // accepts strings ending in `/`, so even on Windows we need to
+    // append `/` (not `path.sep`). Inside the path we use `path.join`
+    // for platform safety, then concatenate the literal forward slash
+    // to satisfy pdf.js's URL contract — Node's `fs.readFile` accepts
+    // mixed separators on Windows so this remains portable.
+    docOptions.wasmUrl = `${join(pdfjsPkgDir, 'wasm')}/`;
+    docOptions.cMapUrl = `${join(pdfjsPkgDir, 'cmaps')}/`;
     docOptions.cMapPacked = true;
   } catch {
     // Best-effort: keep going without the wasm/cmap asset URLs rather
@@ -426,9 +431,13 @@ export async function processDocument(filePath: string, options: ProcessDocument
       // this on the apple-10-k sample). The middle path lets the
       // extraction succeed for the in-range pages while still telling
       // the caller something got skipped.
-      if (parsed.skipped.length > 0) {
-        process.stderr.write(
-          `pdfvision: warning: --pages "${options.pages}" included page(s) past the end of the document (totalPages=${totalPages}); skipped: ${parsed.skipped.join(', ')}\n`,
+      // Library code must not write to stderr unsolicited; route the
+      // notice through the caller-supplied `onWarning` callback if any
+      // (the CLI passes one that prints to stderr).
+      if (parsed.skipped.length > 0 && options.onWarning) {
+        const more = parsed.skippedTruncated ? ` (+ more, truncated)` : '';
+        options.onWarning(
+          `--pages "${options.pages}" included page(s) past the end of the document (totalPages=${totalPages}); skipped: ${parsed.skipped.join(', ')}${more}`,
         );
       }
     } else {
@@ -618,6 +627,7 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
     imageBoxes: options.imageBoxes,
     ocr: options.ocr,
     ocrLang: options.ocrLang,
+    onWarning: options.onWarning,
   });
   return render(result, options.format);
 }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -8,17 +8,25 @@ import { runParallel } from './parallel.js';
 const DEFAULT_SCALE = 2;
 
 /**
- * RGB threshold above which a pixel counts as "near-white" (canvas
- * background or pure paper). Picked at 250 rather than 255 so faint
- * anti-aliasing on otherwise-blank pages doesn't flip the bucket.
- */
-const NEAR_WHITE_THRESHOLD = 250;
-/**
  * Alpha threshold below which a pixel counts as transparent. Some PDFs
  * render with translucent overlays whose alpha is very small but nonzero;
  * < 16 is a safe "effectively invisible" cutoff.
  */
 const ALPHA_THRESHOLD = 16;
+/**
+ * Luminance histogram bucket size used by {@link computeContentRatio}.
+ * 256 luminance levels / 16 = 16 buckets. Coarse enough that JPEG noise
+ * around a uniform background falls into the same bucket; fine enough
+ * that real text against that background lands in a different one.
+ */
+const LUM_BUCKET_SIZE = 16;
+/**
+ * How far a pixel's luminance must sit from the dominant-background
+ * bucket to count as content. Two full buckets apart keeps anti-aliasing
+ * fringes (which sit one bucket off) out of the count without losing
+ * real ink (which is many buckets darker / lighter).
+ */
+const CONTENT_LUM_DELTA = LUM_BUCKET_SIZE * 2;
 
 function isReusableImage(path: string): boolean {
   if (!existsSync(path)) return false;
@@ -35,35 +43,67 @@ function isReusableImage(path: string): boolean {
 }
 
 /**
- * Fraction of pixels in `rgba` that look like real content — alpha at
- * least {@link ALPHA_THRESHOLD} AND at least one of R/G/B below
- * {@link NEAR_WHITE_THRESHOLD}. Returns 0..1 rounded to 6dp; values
- * close to zero are the signal we care about, so coarser rounding would
- * lose discrimination between "0.0001 blank" and "0.005 sparse marks".
+ * Fraction of pixels in `rgba` that look like real content. Returns
+ * 0..1 rounded to 6dp; values close to zero are the signal we care
+ * about, so coarser rounding would lose discrimination between
+ * "0.0001 blank" and "0.005 sparse marks".
  *
- * 0.001 has been a useful "effectively blank" cutoff against JPEG2000
- * scans (renders to pure white) and CMap-less PDFs (renders to pure
- * white because no glyphs can be drawn). Threshold guidance lives in
- * the skill doc rather than this signal — pdfvision exposes the ratio
- * and the agent decides what to do.
+ * "Content" is defined relative to the page's own dominant luminance
+ * (the *background*) rather than a fixed near-white threshold. White
+ * paper, beige scans and dark book covers all converge on the same
+ * "near-zero = blank" semantic — without this, an Internet-Archive
+ * scan of a dark cover (dominant luminance ~50) reads as
+ * `renderContentRatio = 1` even though there is no ink on the page.
+ *
+ * Algorithm: build a coarse luminance histogram (16 buckets), call the
+ * heaviest bucket the background, count the non-transparent pixels
+ * whose luminance differs from the background bucket by at least
+ * {@link CONTENT_LUM_DELTA}. Luminance uses the perceptual ITU-R
+ * BT.601 weights (R*.299 + G*.587 + B*.114) so coloured backgrounds
+ * are weighted the way agents see them.
+ *
+ * 0.001 is still a useful "effectively blank" cutoff. Threshold
+ * guidance lives in the skill doc; pdfvision exposes the ratio and
+ * the agent decides what to do.
  */
 export function computeContentRatio(rgba: Uint8ClampedArray): number {
-  const total = rgba.length / 4;
-  if (total === 0) return 0;
-  let content = 0;
-  // Hot inner loop — keep destructured-pixel access pattern but avoid
-  // creating throwaway objects so a 5M-pixel page stays under ~20ms.
+  const totalPx = rgba.length / 4;
+  if (totalPx === 0) return 0;
+
+  // Pass 1: luminance histogram of non-transparent pixels.
+  const bucketCount = Math.ceil(256 / LUM_BUCKET_SIZE);
+  const hist = new Uint32Array(bucketCount);
+  let opaque = 0;
   for (let i = 0; i < rgba.length; i += 4) {
-    const a = rgba[i + 3];
-    if (a < ALPHA_THRESHOLD) continue;
-    const r = rgba[i];
-    const g = rgba[i + 1];
-    const b = rgba[i + 2];
-    if (r < NEAR_WHITE_THRESHOLD || g < NEAR_WHITE_THRESHOLD || b < NEAR_WHITE_THRESHOLD) {
-      content++;
+    if (rgba[i + 3] < ALPHA_THRESHOLD) continue;
+    // BT.601 luma; integer math keeps the hot loop branch-free.
+    const lum = (rgba[i] * 299 + rgba[i + 1] * 587 + rgba[i + 2] * 114) / 1000;
+    hist[Math.min(bucketCount - 1, lum / LUM_BUCKET_SIZE) | 0]++;
+    opaque++;
+  }
+  if (opaque === 0) return 0;
+
+  // Pick the heaviest bucket as background.
+  let bgBucket = 0;
+  let bgCount = hist[0];
+  for (let b = 1; b < bucketCount; b++) {
+    if (hist[b] > bgCount) {
+      bgCount = hist[b];
+      bgBucket = b;
     }
   }
-  return Math.round((content / total) * 1_000_000) / 1_000_000;
+  const bgLum = bgBucket * LUM_BUCKET_SIZE + LUM_BUCKET_SIZE / 2;
+
+  // Pass 2: count pixels whose luminance is at least
+  // CONTENT_LUM_DELTA away from background. Operating on totalPx (not
+  // opaque) keeps blank transparent canvases at 0 instead of NaN.
+  let content = 0;
+  for (let i = 0; i < rgba.length; i += 4) {
+    if (rgba[i + 3] < ALPHA_THRESHOLD) continue;
+    const lum = (rgba[i] * 299 + rgba[i + 1] * 587 + rgba[i + 2] * 114) / 1000;
+    if (Math.abs(lum - bgLum) >= CONTENT_LUM_DELTA) content++;
+  }
+  return Math.round((content / totalPx) * 1_000_000) / 1_000_000;
 }
 
 /**

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -34,10 +34,11 @@ export function formatMarkdown(result: DocumentResult): string {
     // a `layout` payload). Lets agents see at a glance how the doc breaks
     // down into structural pieces without scrolling into the body.
     const showBlocks = result.pages.some((p) => p.layout !== undefined);
-    // The NonPrint column appears only when at least one page has a
-    // non-zero ratio. Most PDFs are clean, so showing 0% on every row
-    // would clutter the table without helping any agent decision.
-    const showNonPrint = result.pages.some((p) => p.nonPrintableRatio > 0);
+    // The NonPrint column appears only when at least one page has any
+    // non-printable code points (count > 0). Reading `count` instead of
+    // `ratio` here catches sparse occurrences that would otherwise
+    // round to 0% and hide the column for the whole document.
+    const showNonPrint = result.pages.some((p) => p.nonPrintableCount > 0);
     // The Render column appears only when at least one page was rasterised
     // (--render or --ocr). Showing it on every doc would clutter the
     // overview with empty cells for the default text-only flow.
@@ -53,7 +54,14 @@ export function formatMarkdown(result: DocumentResult): string {
     );
     for (const page of result.pages) {
       const coveragePct = Math.round(page.textCoverage * 100);
-      const nonPrintCell = showNonPrint ? ` ${Math.round(page.nonPrintableRatio * 100)}% |` : '';
+      // Use `<1%` (instead of the rounded `0%`) when the page has *any*
+      // non-printable chars — otherwise sparse occurrences like 2 bad
+      // codepoints in a 5000-char body page silently render as `0%` and
+      // the column-trigger above looks inconsistent.
+      const nonPrintPct = Math.round(page.nonPrintableRatio * 100);
+      const nonPrintCell = showNonPrint
+        ? ` ${nonPrintPct === 0 && page.nonPrintableCount > 0 ? '<1%' : `${nonPrintPct}%`} |`
+        : '';
       const renderCell = showRender
         ? // Two decimals as a percent so the agent sees the difference
           // between blank (0.00%) and sparse-marks (0.10%) — three or more
@@ -74,11 +82,12 @@ export function formatMarkdown(result: DocumentResult): string {
     lines.push('');
     lines.push(`## Page ${page.page}`);
     lines.push('');
-    // Inline the nonPrint signal only when it's non-zero so clean PDFs
-    // don't pay a noisy "nonPrint: 0%" suffix on every page header. The
-    // ratio renders as a percent for parity with `coverage`.
-    const nonPrintFragment =
-      page.nonPrintableRatio > 0 ? ` · nonPrint: ${Math.round(page.nonPrintableRatio * 100)}%` : '';
+    // Inline the nonPrint signal only when the page actually has any
+    // non-printable code points (count > 0). Renders the rounded
+    // percent, except <1% when sparse so the agent can tell "0 bad
+    // chars" from "a few bad chars that round to 0%".
+    const npPct = Math.round(page.nonPrintableRatio * 100);
+    const nonPrintFragment = page.nonPrintableCount > 0 ? ` · nonPrint: ${npPct === 0 ? '<1%' : `${npPct}%`}` : '';
     // Inline the render-content ratio (when rasterised) so a single-page
     // run still surfaces it without the overview table. Two decimal
     // places match the column format above.

--- a/src/output/xml.ts
+++ b/src/output/xml.ts
@@ -60,8 +60,11 @@ export function formatXml(result: DocumentResult): string {
         `imageCount="${p.imageCount}"`,
         `textCoverage="${p.textCoverage}"`,
         `nonPrintableRatio="${p.nonPrintableRatio}"`,
+        `nonPrintableCount="${p.nonPrintableCount}"`,
       ];
       if (p.renderContentRatio !== undefined) ovAttrs.push(`renderContentRatio="${p.renderContentRatio}"`);
+      ovAttrs.push(`nativeTextStatus="${p.quality.nativeTextStatus}"`);
+      if (p.quality.visualStatus !== undefined) ovAttrs.push(`visualStatus="${p.quality.visualStatus}"`);
       ovAttrs.push(`width="${p.width}"`, `height="${p.height}"`);
       out.push(`<page ${ovAttrs.join(' ')}/>`);
     }
@@ -76,8 +79,11 @@ export function formatXml(result: DocumentResult): string {
       `imageCount="${page.imageCount}"`,
       `textCoverage="${page.textCoverage}"`,
       `nonPrintableRatio="${page.nonPrintableRatio}"`,
+      `nonPrintableCount="${page.nonPrintableCount}"`,
     ];
     if (page.renderContentRatio !== undefined) attrs.push(`renderContentRatio="${page.renderContentRatio}"`);
+    attrs.push(`nativeTextStatus="${page.quality.nativeTextStatus}"`);
+    if (page.quality.visualStatus !== undefined) attrs.push(`visualStatus="${page.quality.visualStatus}"`);
     attrs.push(`width="${page.width}"`, `height="${page.height}"`);
     if (page.image) attrs.push(`image="${escapeAttr(page.image)}"`);
     out.push(`<page ${attrs.join(' ')}>`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,15 @@ export interface ProcessDocumentOptions {
    * Defaults to `eng`. Only consulted when `ocr` is true.
    */
   ocrLang?: string;
+  /**
+   * Called once per non-fatal warning produced during extraction (e.g.
+   * `--pages` named pages past the end of the document). pdfvision is
+   * used both as a library and a CLI; the CLI passes a handler that
+   * writes to stderr, library callers can supply their own logger or
+   * leave the option unset to silence warnings entirely. Defaults to
+   * `undefined` (silent).
+   */
+  onWarning?: (message: string) => void;
 }
 
 export interface ProcessOptions {
@@ -79,6 +88,8 @@ export interface ProcessOptions {
   imageBoxes?: boolean;
   ocr?: boolean;
   ocrLang?: string;
+  /** See {@link ProcessDocumentOptions.onWarning}. */
+  onWarning?: (message: string) => void;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -256,11 +256,12 @@ export interface PageResult {
   nonPrintableRatio: number;
   /**
    * Fraction of pixels in the rasterised page (0–1, rounded to 6dp) that
-   * carry visible content — visible alpha (≥ 16 / 255) and not near-white.
-   * The ≥ 16 floor ignores near-transparent anti-aliasing fringes that
-   * would otherwise float the ratio on otherwise blank pages. Present
-   * only when `--render` or `--ocr` actually rasterised the page; absent
-   * when neither caused a raster.
+   * carry visible content — visible alpha (≥ 16 / 255) AND luminance
+   * meaningfully different from the page's own dominant background
+   * (measured against a 16-bucket luminance histogram so dark / beige /
+   * cream pages don't float the ratio). Present only when `--render` or
+   * `--ocr` actually rasterised the page; absent when neither caused a
+   * raster.
    *
    * Catches a class of silent failure the text-side signals miss: the
    * raster came out blank (or near-blank) even though pdfvision didn't
@@ -308,6 +309,54 @@ export interface PageResult {
    * the page in question.
    */
   ocr?: PageOcr;
+  /**
+   * Compact derived classification of the page's text and visual state,
+   * computed from the raw signals (`charCount`, `nonPrintableRatio`,
+   * `imageCount`, `renderContentRatio`) so agents can dispatch on a
+   * single field instead of re-implementing the threshold logic. Pure
+   * observation — pdfvision deliberately does NOT recommend an action
+   * (e.g. "rerun with --ocr"); that judgment stays with the agent.
+   *
+   * See {@link PageQuality} for the field semantics and the exact
+   * derivation rules.
+   */
+  quality: PageQuality;
+}
+
+/**
+ * Derived page-quality classification. The values are observational —
+ * they tell the agent what pdfvision saw, not what the agent should do
+ * about it.
+ */
+export interface PageQuality {
+  /**
+   * Native-text extraction outcome:
+   *   - `ok` — the page has usable native text (`charCount > 0` and
+   *     `nonPrintableRatio < 0.05`).
+   *   - `unusable_glyph_indices` — `nonPrintableRatio >= 0.05`. pdf.js
+   *     returned raw glyph codes (no usable ToUnicode CMap), so `text`
+   *     is binary garbage even though `charCount` may look healthy.
+   *   - `empty_but_visual_content` — `charCount === 0` AND the page has
+   *     visual content (`imageCount > 0`, or `renderContentRatio` is
+   *     above the blank threshold when --render/--ocr ran). Typical of
+   *     image-flattened slides and scans.
+   *   - `empty` — `charCount === 0` and no visual content detected.
+   *     Likely a genuinely blank page or a render failure (combine with
+   *     `visualStatus` to disambiguate).
+   */
+  nativeTextStatus: 'ok' | 'unusable_glyph_indices' | 'empty_but_visual_content' | 'empty';
+  /**
+   * Rasterisation outcome, present only when `--render` or `--ocr`
+   * actually rasterised the page:
+   *   - `ok` — `renderContentRatio > 0.001`. The renderer drew
+   *     meaningful content.
+   *   - `blank` — `renderContentRatio <= 0.001`. The page came out
+   *     effectively blank against its own dominant background;
+   *     typically a render-pipeline failure (unsupported image format,
+   *     missing fonts) or a genuinely blank page.
+   * Absent when neither `--render` nor `--ocr` triggered a raster.
+   */
+  visualStatus?: 'ok' | 'blank';
 }
 
 export interface DocumentMetadata {
@@ -343,6 +392,12 @@ export interface PageOverview {
    * `--ocr` triggered a raster on at least the corresponding page.
    */
   renderContentRatio?: number;
+  /**
+   * Mirror of {@link PageResult.quality} so the overview can flag
+   * unusable / blank pages at a glance without descending into
+   * `pages[]`.
+   */
+  quality: PageQuality;
   width: number;
   height: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -255,6 +255,14 @@ export interface PageResult {
    */
   nonPrintableRatio: number;
   /**
+   * Raw count of non-printable code points in `text`. Surfaced alongside
+   * the ratio so sparse occurrences (e.g. two stray control bytes inside
+   * an arxiv body page) stay discriminable from "zero" — the 3dp
+   * `nonPrintableRatio` rounds them down to 0 even though the agent
+   * may still want to know "is there ANY garbage?".
+   */
+  nonPrintableCount: number;
+  /**
    * Fraction of pixels in the rasterised page (0–1, rounded to 6dp) that
    * carry visible content — visible alpha (≥ 16 / 255) AND luminance
    * meaningfully different from the page's own dominant background
@@ -385,6 +393,8 @@ export interface PageOverview {
    * `pages[]`.
    */
   nonPrintableRatio: number;
+  /** Raw count companion to {@link nonPrintableRatio}; see PageResult. */
+  nonPrintableCount: number;
   /**
    * Same field as {@link PageResult.renderContentRatio} — mirrored on the
    * overview so an agent can spot blank-rendered pages from the top-level

--- a/tests/core/pageRange.test.ts
+++ b/tests/core/pageRange.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parsePageRange } from '../../src/core/pageRange.js';
+import { parsePageRange, parsePageRangeWithSkipped } from '../../src/core/pageRange.js';
 
 describe('parsePageRange', () => {
   it('parses a single page', () => {
@@ -54,5 +54,39 @@ describe('parsePageRange', () => {
     // segments.length !== 2 branch — three numbers separated by hyphens
     // is not a valid pdfvision range syntax.
     expect(() => parsePageRange('1-2-3', 10)).toThrow(/malformed range/);
+  });
+});
+
+describe('parsePageRangeWithSkipped', () => {
+  it('lists the in-range pages alongside the out-of-range skipped numbers', () => {
+    const r = parsePageRangeWithSkipped('1-3,5,99', 4);
+    expect(r.pages).toEqual([1, 2, 3]);
+    expect(r.skipped).toEqual([5, 99]);
+    expect(r.skippedTruncated).toBe(false);
+  });
+
+  it('returns an empty skipped list when nothing fell out of range', () => {
+    const r = parsePageRangeWithSkipped('1-3', 10);
+    expect(r.pages).toEqual([1, 2, 3]);
+    expect(r.skipped).toEqual([]);
+    expect(r.skippedTruncated).toBe(false);
+  });
+
+  it('caps `skipped` and flags truncation on adversarially large ranges', () => {
+    // `--pages 1-1000000000` against a small doc would otherwise OOM by
+    // enumerating 10^9 page numbers into the skipped Set. The cap stops
+    // the walk at MAX_TRACKED_SKIPPED (=100) entries; `skippedTruncated`
+    // tells the caller there were more, so the warning can hint at it.
+    const r = parsePageRangeWithSkipped('1-1000000000', 4);
+    expect(r.pages).toEqual([1, 2, 3, 4]);
+    expect(r.skipped.length).toBe(100);
+    expect(r.skipped[0]).toBe(5);
+    expect(r.skippedTruncated).toBe(true);
+  });
+
+  it('still throws when every requested page is out of range', () => {
+    // Behaviour preserved from parsePageRange — a request that matches
+    // nothing is a usage error, not a warning.
+    expect(() => parsePageRangeWithSkipped('11-20', 10)).toThrow(/no pages selected/);
   });
 });

--- a/tests/core/renderContentRatio.test.ts
+++ b/tests/core/renderContentRatio.test.ts
@@ -31,10 +31,23 @@ describe('computeContentRatio', () => {
     expect(computeContentRatio(fillRgba(100, 0, 0, 0, 0))).toBe(0);
   });
 
-  it('returns 1 for a pure-black opaque raster', () => {
-    // Every pixel has all-zero RGB (well below 250) and full alpha →
-    // 100% content. Black-on-white inversion test for the heuristic.
-    expect(computeContentRatio(fillRgba(100, 0, 0, 0, 255))).toBe(1);
+  it('returns 0 for a uniformly dark page — the Internet-Archive dark-cover signature', () => {
+    // Every pixel at black (luminance ~0): the dominant background IS
+    // that black, so nothing differs from background → 0% content.
+    // Previously this returned 1 because the heuristic was anchored at
+    // white; an Internet-Archive scan of a dark book cover therefore
+    // claimed `renderContentRatio = 1` despite carrying no ink. The
+    // semantic now is "different-from-page-background", not
+    // "different-from-white".
+    expect(computeContentRatio(fillRgba(100, 0, 0, 0, 255))).toBe(0);
+  });
+
+  it('returns 0 for a uniformly off-white / beige page (paper scan background)', () => {
+    // Old-paper scans render to a mid-cream luminance (~230). Without
+    // background-relative classification this would count as content;
+    // with histogram-relative classification it correctly reads as
+    // blank because that cream IS the background.
+    expect(computeContentRatio(fillRgba(100, 230, 220, 200, 255))).toBe(0);
   });
 
   it('keeps near-white pixels above the threshold (251+) classified as background', () => {
@@ -44,16 +57,10 @@ describe('computeContentRatio', () => {
     expect(computeContentRatio(fillRgba(100, 252, 252, 252, 255))).toBe(0);
   });
 
-  it('treats a single channel below the near-white threshold as content', () => {
-    // A pixel with R=249 G=255 B=255 has at least one channel below
-    // 250 → counts as content. Catches near-white-but-tinted text /
-    // backgrounds that the agent should see as "something drawn".
-    expect(computeContentRatio(fillRgba(100, 249, 255, 255, 255))).toBe(1);
-  });
-
   it('measures the fraction of content pixels across a mixed raster', () => {
-    // 30 black pixels + 70 white pixels = 30% content. Verifies the
-    // ratio is a real fraction, not just a boolean.
+    // 30 black pixels + 70 white pixels = 30% content. White is the
+    // dominant bucket so background is white; the 30 black pixels are
+    // far enough from white to count as content.
     const buf = new Uint8ClampedArray(100 * 4);
     for (let i = 0; i < 30 * 4; i += 4) {
       buf[i] = 0;
@@ -68,6 +75,29 @@ describe('computeContentRatio', () => {
       buf[i + 3] = 255;
     }
     expect(computeContentRatio(buf)).toBe(0.3);
+  });
+
+  it('measures content against a dark background — bright marks on a dark page', () => {
+    // 95 dark-grey pixels (dominant background) + 5 white "marks".
+    // Old heuristic anchored at white would count the 95 dark pixels
+    // as content (= 0.95) and miss the 5 actual marks; the new
+    // histogram-relative heuristic correctly returns 0.05 because
+    // the dark grey IS the background and the 5 whites are the
+    // outliers.
+    const buf = new Uint8ClampedArray(100 * 4);
+    for (let i = 0; i < 95 * 4; i += 4) {
+      buf[i] = 40;
+      buf[i + 1] = 40;
+      buf[i + 2] = 40;
+      buf[i + 3] = 255;
+    }
+    for (let i = 95 * 4; i < buf.length; i += 4) {
+      buf[i] = 255;
+      buf[i + 1] = 255;
+      buf[i + 2] = 255;
+      buf[i + 3] = 255;
+    }
+    expect(computeContentRatio(buf)).toBe(0.05);
   });
 
   it('rounds to 6 decimal places so the "near-blank" band stays discriminable', () => {

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -11,6 +11,7 @@ function makePage(overrides: Partial<PageResult> & Pick<PageResult, 'page'>): Pa
     imageCount: 0,
     textCoverage: 0,
     nonPrintableRatio: 0,
+    nonPrintableCount: 0,
     quality: { nativeTextStatus: 'empty' },
     width: 612,
     height: 792,
@@ -221,14 +222,37 @@ describe('formatMarkdown', () => {
       makeResult({
         totalPages: 2,
         pages: [
-          makePage({ page: 1, text: 'clean', charCount: 5, nonPrintableRatio: 0 }),
-          makePage({ page: 2, text: '\x00\x01bad', charCount: 3, nonPrintableRatio: 0.667 }),
+          makePage({ page: 1, text: 'clean', charCount: 5, nonPrintableRatio: 0, nonPrintableCount: 0 }),
+          makePage({
+            page: 2,
+            text: '\x00\x01bad',
+            charCount: 3,
+            nonPrintableRatio: 0.667,
+            nonPrintableCount: 2,
+          }),
         ],
       }),
     );
     expect(out).toMatch(/\| Page \| Chars \| Images \| Coverage \| NonPrint \| Size \(pt\) \|/);
     expect(out).toMatch(/\| 1 \| 5 \| 0 \| 0% \| 0% \| 612×792 \|/);
     expect(out).toMatch(/\| 2 \| 3 \| 0 \| 0% \| 67% \| 612×792 \|/);
+  });
+
+  it('shows `<1%` instead of `0%` when nonPrintableCount > 0 but the ratio rounds to 0', () => {
+    // Sparse occurrences (a couple of control bytes in a multi-thousand-char
+    // body page) round to 0% but are still worth surfacing so the agent can
+    // filter on "is there ANY garbage?".
+    const out = formatMarkdown(
+      makeResult({
+        totalPages: 2,
+        pages: [
+          makePage({ page: 1, text: 'a'.repeat(1000), charCount: 1000, nonPrintableRatio: 0, nonPrintableCount: 0 }),
+          makePage({ page: 2, text: 'b'.repeat(1000), charCount: 1000, nonPrintableRatio: 0, nonPrintableCount: 2 }),
+        ],
+      }),
+    );
+    expect(out).toMatch(/NonPrint/);
+    expect(out).toMatch(/\| 2 \| 1000 \| 0 \| 0% \| <1% \| 612×792 \|/);
   });
 
   it('omits the NonPrint column when every page has nonPrintableRatio = 0', () => {
@@ -247,7 +271,7 @@ describe('formatMarkdown', () => {
   it('appends a nonPrint fragment to the page density line when nonPrintableRatio > 0', () => {
     const out = formatMarkdown(
       makeResult({
-        pages: [makePage({ page: 1, text: '\x00', charCount: 1, nonPrintableRatio: 1 })],
+        pages: [makePage({ page: 1, text: '\x00', charCount: 1, nonPrintableRatio: 1, nonPrintableCount: 1 })],
       }),
     );
     expect(out).toMatch(/_chars: 1 · images: 0 · coverage: 0% · nonPrint: 100% · size: 612×792pt_/);

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -11,6 +11,7 @@ function makePage(overrides: Partial<PageResult> & Pick<PageResult, 'page'>): Pa
     imageCount: 0,
     textCoverage: 0,
     nonPrintableRatio: 0,
+    quality: { nativeTextStatus: 'empty' },
     width: 612,
     height: 792,
     ...overrides,

--- a/tests/output/xml.test.ts
+++ b/tests/output/xml.test.ts
@@ -9,6 +9,7 @@ function makePage(overrides: Partial<PageResult> & Pick<PageResult, 'page'>): Pa
     imageCount: 0,
     textCoverage: 0,
     nonPrintableRatio: 0,
+    nonPrintableCount: 0,
     quality: { nativeTextStatus: 'empty' },
     width: 612,
     height: 792,
@@ -61,6 +62,7 @@ describe('formatXml', () => {
             imageCount: 0,
             textCoverage: 0.1,
             nonPrintableRatio: 0,
+            nonPrintableCount: 0,
             quality: { nativeTextStatus: 'ok' },
             width: 612,
             height: 792,
@@ -71,6 +73,7 @@ describe('formatXml', () => {
             imageCount: 5,
             textCoverage: 0.02,
             nonPrintableRatio: 0,
+            nonPrintableCount: 0,
             quality: { nativeTextStatus: 'empty_but_visual_content' },
             width: 612,
             height: 792,
@@ -84,10 +87,10 @@ describe('formatXml', () => {
     );
     expect(out).toMatch(/<overview>/);
     expect(out).toMatch(
-      /<page no="1" charCount="10" imageCount="0" textCoverage="0\.1" nonPrintableRatio="0" width="612" height="792"\/>/,
+      /<page no="1" charCount="10" imageCount="0" textCoverage="0\.1" nonPrintableRatio="0" nonPrintableCount="0" nativeTextStatus="ok" width="612" height="792"\/>/,
     );
     expect(out).toMatch(
-      /<page no="2" charCount="0" imageCount="5" textCoverage="0\.02" nonPrintableRatio="0" width="612" height="792"\/>/,
+      /<page no="2" charCount="0" imageCount="5" textCoverage="0\.02" nonPrintableRatio="0" nonPrintableCount="0" nativeTextStatus="empty_but_visual_content" width="612" height="792"\/>/,
     );
   });
 

--- a/tests/output/xml.test.ts
+++ b/tests/output/xml.test.ts
@@ -9,6 +9,7 @@ function makePage(overrides: Partial<PageResult> & Pick<PageResult, 'page'>): Pa
     imageCount: 0,
     textCoverage: 0,
     nonPrintableRatio: 0,
+    quality: { nativeTextStatus: 'empty' },
     width: 612,
     height: 792,
     ...overrides,
@@ -54,8 +55,26 @@ describe('formatXml', () => {
       makeResult({
         totalPages: 2,
         overview: [
-          { page: 1, charCount: 10, imageCount: 0, textCoverage: 0.1, nonPrintableRatio: 0, width: 612, height: 792 },
-          { page: 2, charCount: 0, imageCount: 5, textCoverage: 0.02, nonPrintableRatio: 0, width: 612, height: 792 },
+          {
+            page: 1,
+            charCount: 10,
+            imageCount: 0,
+            textCoverage: 0.1,
+            nonPrintableRatio: 0,
+            quality: { nativeTextStatus: 'ok' },
+            width: 612,
+            height: 792,
+          },
+          {
+            page: 2,
+            charCount: 0,
+            imageCount: 5,
+            textCoverage: 0.02,
+            nonPrintableRatio: 0,
+            quality: { nativeTextStatus: 'empty_but_visual_content' },
+            width: 612,
+            height: 792,
+          },
         ],
         pages: [
           makePage({ page: 1, text: 'aa', charCount: 10, textCoverage: 0.1 }),


### PR DESCRIPTION
## Summary

Close the three "silent failure" gaps surfaced by the codex 21-sample QA pass on `main`:

1. **cMap missing** — pdfvision didn't pass `cMapUrl`, so SpeakerDeck / Office Japanese exports came back with `text: ""`. Switched to plain filesystem paths (Node's `fs.readFile` silently rejects `file://` strings) and added `cMapPacked: true`. **twada slide: 0% pages with text → 100%.**
2. **`renderContentRatio` false positive on dark/beige pages** — the white-anchored heuristic claimed `renderContentRatio = 1` on Alice's solid-dark book cover. Rebuilt the signal as background-aware (16-bucket luminance histogram → dominant bucket is the background → count outliers). **Alice p2: 1.000 → 0.000021.**
3. **No agent-side dispatch field** — agents had to combine `charCount`, `nonPrintableRatio`, `imageCount`, `renderContentRatio` themselves. Added `pages[].quality.nativeTextStatus` (`ok` / `unusable_glyph_indices` / `empty_but_visual_content` / `empty`) and `quality.visualStatus` (`ok` / `blank`). Pure observation, no recommended action — matches the `--auto-render` rejection precedent.

Plus two LOW items from the same QA:

4. `nonPrintableCount` surfaced alongside the ratio (sparse occurrences round to 0% and were previously invisible).
5. `--pages 1-3,5` against a 4-page doc now warns to stderr listing the skipped pages instead of silently dropping them.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 213/213 pass
- [x] Manual verification on `life/project/pdfvision/samples/`:
  - SpeakerDeck twada/azukiazusa/cyberagent — all 0% empty pages now
  - Alice p2 / p5 / p9 — `renderContentRatio` matches actual content
  - Hebrew UDHR — `quality.nativeTextStatus = "unusable_glyph_indices"`
  - resnet p2 — `nonPrintableCount = 2`, ratio still 0
  - apple-10-k `--pages 1-3,5,99` — stderr warning emitted
- [ ] CI runs on this push

## Commits

1. `b5a8a68` fix(core): wire cMapUrl + cMapPacked and switch to plain fs paths
2. `539ccb9` fix(core): make renderContentRatio background-aware via luminance histogram
3. `9f44d94` feat(core): derive pages[].quality (nativeTextStatus + visualStatus)
4. `cdd46ca` feat(core): surface nonPrintableCount + warn on out-of-range --pages, bump cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)