### PR TITLE
fix(core): CJK-aware text join + heading filter for repeated chrome

### DIFF
--- a/src/core/cjkJoin.ts
+++ b/src/core/cjkJoin.ts
@@ -91,8 +91,11 @@ export function joinPageText(items: readonly JoinItem[]): string {
   // non-empty / non-whitespace neighbour. Walking the index once is
   // cheaper than the nested lookup the per-item decision would
   // otherwise need on long pages.
-  const prevNon: number[] = Array.from({ length: items.length }, () => -1);
-  const nextNon: number[] = Array.from({ length: items.length }, () => -1);
+  // Typed-array form: one contiguous 32-bit-signed buffer per side,
+  // initialised to -1 (the "no neighbour" sentinel). For long pages
+  // this avoids the per-cell heap allocation a `number[]` would do.
+  const prevNon = new Int32Array(items.length).fill(-1);
+  const nextNon = new Int32Array(items.length).fill(-1);
   let lastNon = -1;
   for (let i = 0; i < items.length; i++) {
     prevNon[i] = lastNon;

--- a/src/core/cjkJoin.ts
+++ b/src/core/cjkJoin.ts
@@ -1,0 +1,143 @@
+/**
+ * Stitch the per-item text stream returned by pdf.js `getTextContent`
+ * into a single page-level string, with CJK-aware whitespace handling.
+ *
+ * Why this exists: pdf.js emits one text item per glyph for CJK PDFs
+ * (positioned per-character so that 行 spacing is preserved), and
+ * inserts a synthetic " " item between any two glyphs that are not
+ * touching in the PDF's text matrix. For latin scripts that lines up
+ * with real word boundaries; for CJK the same machinery produces
+ * `人 人 生 而 自 由` even though the source reads `人人生而自由`.
+ *
+ * Heuristic: drop a whitespace-only item if it sits between two CJK
+ * glyphs whose visual horizontal gap is below ~30 % of the surrounding
+ * font size — that's tight enough to be a positioning artifact, not a
+ * deliberate space. Latin-CJK boundaries (e.g. `2025 年`) and wide-gap
+ * CJK pairs (column breaks) keep their space.
+ */
+
+/**
+ * One item from pdf.js's `getTextContent`, narrowed to the fields we
+ * need for join. Kept structural so unit tests can synthesize items
+ * without pulling pdf.js in.
+ */
+export interface JoinItem {
+  str: string;
+  /** Top-left x of the glyph in PDF user-space points (from `transform[4]`). */
+  x: number;
+  /** Glyph run width in points (from item.width, may be 0 on broken PDFs). */
+  width: number;
+  /** Glyph height in points — used as a fontSize proxy when fontSize is unknown. */
+  fontSize: number;
+  /** pdf.js's hard line-break marker between two items. */
+  hasEOL: boolean;
+}
+
+/**
+ * Max gap (as a fraction of fontSize) between two CJK glyphs that we
+ * still consider "touching". Pdf.js inserts a synthetic space whenever
+ * the horizontal gap > 0; we treat anything below this fraction as a
+ * positioning artifact and drop the intervening whitespace item.
+ * Empirically 0.3 catches the udhr-chinese case (gap ≈ 0) while
+ * preserving column-break gaps (typically > 1.0 * fontSize).
+ */
+const CJK_TIGHT_GAP_RATIO = 0.3;
+
+/**
+ * Returns `true` if `s`'s first code point is in a CJK script we want
+ * to apply the tight-join rule to. Covers Han (incl. extensions A and
+ * Supplementary Plane B), Hiragana, Katakana, Hangul Syllables, and
+ * Hangul Jamo. The check is on the first character — pdf.js typically
+ * emits one CJK glyph per item, and even when it emits multiple the
+ * leading character is enough to dispatch.
+ */
+export function isCjkLeading(s: string): boolean {
+  const cp = s.codePointAt(0);
+  if (cp === undefined) return false;
+  return (
+    // Hiragana + Katakana + small / phonetic extensions
+    (cp >= 0x3040 && cp <= 0x30ff) ||
+    // CJK Unified Ideographs + Extension A + compatibility forms
+    (cp >= 0x3400 && cp <= 0x9fff) ||
+    // Hangul Jamo + Compatibility Jamo
+    (cp >= 0x1100 && cp <= 0x11ff) ||
+    (cp >= 0x3130 && cp <= 0x318f) ||
+    // Hangul Syllables
+    (cp >= 0xac00 && cp <= 0xd7af) ||
+    // Half-width Katakana (FF65-FF9F) in the broader half-width / full-width forms block
+    (cp >= 0xff00 && cp <= 0xffef) ||
+    // CJK Unified Ideographs Extension B (supplementary plane)
+    (cp >= 0x20000 && cp <= 0x2a6df)
+  );
+}
+
+/** Pure whitespace (str collapses to empty after trim) but non-empty. */
+function isWhitespaceOnly(s: string): boolean {
+  return s.length > 0 && s.trim().length === 0;
+}
+
+/**
+ * Build the page-level text string from pdf.js items.
+ *
+ * - Hard line breaks (`hasEOL`) always emit `\n`.
+ * - Whitespace-only items between two CJK glyphs are dropped when the
+ *   visual gap looks like a positioning artifact (see
+ *   {@link CJK_TIGHT_GAP_RATIO}). Everything else (latin words, wide
+ *   CJK column gaps, mixed-script boundaries) keeps its whitespace,
+ *   preserving the pre-fix behaviour.
+ */
+export function joinPageText(items: readonly JoinItem[]): string {
+  // Pre-compute, for each whitespace-only item, the previous and next
+  // non-empty / non-whitespace neighbour. Walking the index once is
+  // cheaper than the nested lookup the per-item decision would
+  // otherwise need on long pages.
+  const prevNon: number[] = Array.from({ length: items.length }, () => -1);
+  const nextNon: number[] = Array.from({ length: items.length }, () => -1);
+  let lastNon = -1;
+  for (let i = 0; i < items.length; i++) {
+    prevNon[i] = lastNon;
+    if (items[i].str.length > 0 && !isWhitespaceOnly(items[i].str)) lastNon = i;
+  }
+  lastNon = -1;
+  for (let i = items.length - 1; i >= 0; i--) {
+    nextNon[i] = lastNon;
+    if (items[i].str.length > 0 && !isWhitespaceOnly(items[i].str)) lastNon = i;
+  }
+
+  const parts: string[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const cur = items[i];
+
+    if (cur.hasEOL) {
+      // Hard line break wins — flush the item's text (in case the item
+      // has both str and hasEOL), then the newline.
+      if (cur.str.length > 0) parts.push(cur.str);
+      parts.push('\n');
+      continue;
+    }
+
+    if (isWhitespaceOnly(cur.str)) {
+      const prev = prevNon[i] >= 0 ? items[prevNon[i]] : undefined;
+      const next = nextNon[i] >= 0 ? items[nextNon[i]] : undefined;
+      if (prev && next && isCjkLeading(prev.str) && isCjkLeading(next.str)) {
+        // Take fontSize from whichever neighbour reports a positive one
+        // (some PDFs leave items at fontSize 0; falling back keeps the
+        // gap test stable). The gap is measured from the previous
+        // glyph's right edge to the next glyph's left edge.
+        const fontSize = next.fontSize || prev.fontSize;
+        if (fontSize > 0) {
+          const gap = next.x - (prev.x + prev.width);
+          if (gap < fontSize * CJK_TIGHT_GAP_RATIO) {
+            // Positioning artifact between two CJK glyphs — drop the
+            // whitespace silently. Leave parts unchanged so the two
+            // glyphs concatenate directly.
+            continue;
+          }
+        }
+      }
+    }
+
+    parts.push(cur.str);
+  }
+  return parts.join('');
+}

--- a/src/core/layout.ts
+++ b/src/core/layout.ts
@@ -557,7 +557,22 @@ export function markRepeatedBlocks(pages: PageResult[]): void {
     if (seenPages.size < minOccurrences) continue;
     for (const ref of refs) {
       const block = pagesWithLayout[ref.pageIndex].layout?.blocks[ref.blockIndex];
-      if (block) block.repeated = true;
+      if (!block) continue;
+      block.repeated = true;
+      // Demote chrome from heading. A running header / page-number /
+      // language-marker line that happens to be short and slightly
+      // larger than the body fontSize sails through the heading
+      // classifier (eu-ai-act surfaces "EN" as a level-1 heading on
+      // every page). Once we know the block is repeated chrome, the
+      // heading role is almost always wrong — and agents iterating
+      // `headings` then see "EN" once per page. Drop the role here.
+      // Consumers that genuinely want repeated headings (a doc title
+      // that only appears in the running header) can still recover it
+      // from `text` + `repeated: true` + size; the common case wins.
+      if (block.role === 'heading') {
+        block.role = undefined;
+        block.level = undefined;
+      }
     }
   }
 }

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -18,6 +18,7 @@ import type {
   TextSpan,
 } from '../types/index.js';
 import { dropCached, ensurePrivateDir, getCacheDir, getCached, setCache } from './cache.js';
+import { type JoinItem, joinPageText } from './cjkJoin.js';
 import { buildImageBoxes, type ImageOps } from './imageBoxes.js';
 import { buildLayout, markRepeatedBlocks } from './layout.js';
 import { nonPrintableStats } from './nonPrintable.js';
@@ -193,13 +194,15 @@ async function extractPageData(
   // PageResult when `geometry` is on.
   const wantSpans = flags.geometry || flags.layout;
 
-  const parts: string[] = [];
+  // Collect typed items for the CJK-aware page-text joiner. We can't
+  // build the final string in this loop because the join decision for
+  // a whitespace item depends on its neighbours' positions, which we
+  // only know after the walk.
+  const joinItems: JoinItem[] = [];
   let textArea = 0;
   const spans: TextSpan[] = [];
   for (const item of content.items) {
     if (!('str' in item)) continue;
-    parts.push(item.str);
-    if (item.hasEOL) parts.push('\n');
     const w = typeof item.width === 'number' ? item.width : 0;
     // pdfjs reports item.height as 0 for many PDFs (e.g. those produced by
     // certain Office exporters); fall back to the vertical scale from the
@@ -208,6 +211,20 @@ async function extractPageData(
     const transform = item.transform;
     const h = reportedH > 0 ? reportedH : Math.abs(transform?.[3] ?? 0);
     textArea += Math.abs(w * h);
+
+    // Feed the page-text joiner. x/fontSize default to 0 when the
+    // item lacks a transform (pdf.js does this for synthetic-EOL
+    // items); the joiner already handles zero fontSize by falling back
+    // to a neighbour.
+    const itemX = transform ? transform[4] : 0;
+    const itemFontSize = transform ? Math.max(Math.abs(transform[0]), Math.abs(transform[3])) : h;
+    joinItems.push({
+      str: item.str,
+      x: itemX,
+      width: w,
+      fontSize: itemFontSize,
+      hasEOL: !!item.hasEOL,
+    });
 
     // Skip whitespace-only items in spans output — pdf.js emits a span
     // for every positioned space, which can double the array length and
@@ -236,7 +253,7 @@ async function extractPageData(
       });
     }
   }
-  const rawText = parts.join('').trimEnd();
+  const rawText = joinPageText(joinItems).trimEnd();
   // charCount must reflect the string the caller actually receives, so
   // measure after normalization.
   const text = flags.normalize ? normalizeText(rawText) : rawText;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -189,9 +189,12 @@ export interface LayoutBlock {
    * same text on enough other pages to look like a running header, footer,
    * page number, or watermark. Lets agents skip the chrome and focus on
    * the body. Detected post-clustering across the selected page set.
-   * Repeated blocks can still carry `role: 'heading'` (a doc title in a
-   * running header is still a heading); consumers that want body-only
-   * chunking should filter `repeated: true` before reading `role`.
+   *
+   * When a block is flagged `repeated`, any heading classification is
+   * dropped — a 2-character language marker that happens to sit at the
+   * page-header fontSize was being classified as `level: 1` on every
+   * page (eu-ai-act `EN` × 5 pages). The chrome marker wins; agents
+   * after `headings` no longer see those duplicates.
    */
   repeated?: boolean;
 }

--- a/tests/core/cjkJoin.test.ts
+++ b/tests/core/cjkJoin.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { isCjkLeading, type JoinItem, joinPageText } from '../../src/core/cjkJoin.js';
+
+/**
+ * Build the per-item stream that pdf.js's `getTextContent` would emit
+ * for a string of CJK glyphs at tight horizontal spacing. Each glyph is
+ * one JoinItem; a whitespace-only item sits between every pair to
+ * mirror the positional-gap artifact pdfjs inserts. Coordinates use a
+ * unit font (fontSize=10, width=10) for simple gap arithmetic.
+ */
+function cjkRun(text: string, fontSize = 10, glyphWidth = 10, spacingGap = 0): JoinItem[] {
+  const items: JoinItem[] = [];
+  let x = 0;
+  for (let i = 0; i < text.length; i++) {
+    items.push({ str: text[i], x, width: glyphWidth, fontSize, hasEOL: false });
+    x += glyphWidth;
+    if (i < text.length - 1) {
+      // Whitespace item with the synthetic positional gap pdf.js
+      // inserts. Width carries the visual gap; the next glyph's x picks
+      // up after it.
+      items.push({ str: ' ', x, width: spacingGap, fontSize, hasEOL: false });
+      x += spacingGap;
+    }
+  }
+  return items;
+}
+
+describe('isCjkLeading', () => {
+  it('recognises Han characters', () => {
+    expect(isCjkLeading('人')).toBe(true);
+    expect(isCjkLeading('的')).toBe(true);
+  });
+
+  it('recognises Hiragana and Katakana', () => {
+    expect(isCjkLeading('あ')).toBe(true);
+    expect(isCjkLeading('ア')).toBe(true);
+  });
+
+  it('recognises Hangul syllables', () => {
+    expect(isCjkLeading('세')).toBe(true);
+    expect(isCjkLeading('한')).toBe(true);
+  });
+
+  it('rejects latin and digit lead characters', () => {
+    expect(isCjkLeading('a')).toBe(false);
+    expect(isCjkLeading('9')).toBe(false);
+    expect(isCjkLeading('')).toBe(false);
+  });
+});
+
+describe('joinPageText (CJK-aware whitespace handling)', () => {
+  it('returns the source text unchanged for a simple latin run', () => {
+    const items: JoinItem[] = [
+      { str: 'hello', x: 0, width: 50, fontSize: 12, hasEOL: false },
+      { str: ' ', x: 50, width: 4, fontSize: 12, hasEOL: false },
+      { str: 'world', x: 54, width: 50, fontSize: 12, hasEOL: false },
+    ];
+    expect(joinPageText(items)).toBe('hello world');
+  });
+
+  it('drops the synthetic whitespace between tight CJK glyphs', () => {
+    // The Chinese-UDHR case: every Han glyph is followed by a
+    // whitespace item with effectively zero visual gap. Pdfvision
+    // used to surface `人 人 生 而 自 由`; the fixed joiner emits
+    // `人人生而自由`.
+    const items = cjkRun('人人生而自由', /*fontSize*/ 10, /*glyphWidth*/ 10, /*spacingGap*/ 0);
+    expect(joinPageText(items)).toBe('人人生而自由');
+  });
+
+  it('keeps the whitespace when the CJK gap is wide enough to be intentional', () => {
+    // Column break inside a CJK paragraph: a real space that the
+    // joiner must preserve. We make the gap > 30 % of fontSize so it
+    // passes the threshold.
+    const items = cjkRun('左右', /*fontSize*/ 10, /*glyphWidth*/ 10, /*spacingGap*/ 5);
+    expect(joinPageText(items)).toBe('左 右');
+  });
+
+  it('keeps whitespace at latin↔CJK boundaries even when the gap is tight', () => {
+    // `2025 年` should NOT collapse to `2025年` — the script change
+    // signals a real word boundary regardless of geometry.
+    const items: JoinItem[] = [
+      { str: '2025', x: 0, width: 30, fontSize: 10, hasEOL: false },
+      { str: ' ', x: 30, width: 0, fontSize: 10, hasEOL: false },
+      { str: '年', x: 30, width: 10, fontSize: 10, hasEOL: false },
+    ];
+    expect(joinPageText(items)).toBe('2025 年');
+  });
+
+  it('honours hard line breaks (hasEOL) even between tight CJK glyphs', () => {
+    // Two CJK glyphs that pdfjs flagged as a paragraph break — the
+    // tight-gap rule must not swallow the newline.
+    const items: JoinItem[] = [
+      { str: '人', x: 0, width: 10, fontSize: 10, hasEOL: false },
+      { str: '', x: 10, width: 0, fontSize: 10, hasEOL: true },
+      { str: '人', x: 0, width: 10, fontSize: 10, hasEOL: false },
+    ];
+    expect(joinPageText(items)).toBe('人\n人');
+  });
+
+  it('drops the artifact even when the joiner has no fontSize on one side', () => {
+    // PDFs from some Office exporters report `fontSize: 0` on
+    // individual items. We fall back to the other neighbour rather
+    // than refusing to apply the rule.
+    const items: JoinItem[] = [
+      { str: '人', x: 0, width: 10, fontSize: 10, hasEOL: false },
+      { str: ' ', x: 10, width: 0, fontSize: 0, hasEOL: false },
+      { str: '人', x: 10, width: 10, fontSize: 0, hasEOL: false },
+    ];
+    // Next.fontSize is 0, falls back to prev.fontSize (10); gap is 0 < 3, drops the space.
+    expect(joinPageText(items)).toBe('人人');
+  });
+
+  it('returns the empty string for empty input', () => {
+    expect(joinPageText([])).toBe('');
+  });
+});

--- a/tests/core/layout.unit.test.ts
+++ b/tests/core/layout.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildLayout } from '../../src/core/layout.js';
-import type { TextSpan } from '../../src/types/index.js';
+import { buildLayout, markRepeatedBlocks } from '../../src/core/layout.js';
+import type { LayoutBlock, PageResult, TextSpan } from '../../src/types/index.js';
 
 /**
  * Produce a span shaped like the ones pdf.js emits, but with explicit
@@ -256,6 +256,65 @@ describe('buildLayout — multi-column reading order', () => {
     // Same as input order — each block already y-sorted.
     expect(ys).toEqual([...ys].sort((a, b) => a - b));
     expect(layout.blocks[0].text.startsWith('Paragraph one')).toBe(true);
+  });
+
+  it('demotes a repeated-chrome block from heading role (the EN running-header case)', () => {
+    // Three pages, each carrying a tiny "EN" marker at y=40 plus a
+    // body paragraph below. The heading classifier slips because the
+    // marker is short and slightly larger than the body fontSize; the
+    // cross-page repeated detector flags it, and markRepeatedBlocks
+    // must drop the heading role so agents iterating `headings` no
+    // longer see "EN" once per page.
+    function makePage(pageNum: number, bodyText: string): PageResult {
+      const enBlock: LayoutBlock = {
+        text: 'EN',
+        x: 50,
+        y: 40,
+        width: 20,
+        height: 14,
+        lines: [{ text: 'EN', x: 50, y: 40, width: 20, height: 14, fontSize: 14 }],
+        role: 'heading',
+        level: 1,
+      };
+      const bodyBlock: LayoutBlock = {
+        text: bodyText,
+        x: 50,
+        y: 100,
+        width: 400,
+        height: 12,
+        lines: [{ text: bodyText, x: 50, y: 100, width: 400, height: 12, fontSize: 10 }],
+      };
+      return {
+        page: pageNum,
+        text: `EN\n${bodyText}`,
+        charCount: bodyText.length + 3,
+        imageCount: 0,
+        textCoverage: 0.5,
+        nonPrintableRatio: 0,
+        nonPrintableCount: 0,
+        width: 612,
+        height: 792,
+        quality: { nativeTextStatus: 'ok' },
+        layout: { blocks: [enBlock, bodyBlock] },
+      };
+    }
+
+    const pages: PageResult[] = [
+      makePage(1, 'Body of page 1'),
+      makePage(2, 'Body of page 2'),
+      makePage(3, 'Body of page 3'),
+    ];
+    markRepeatedBlocks(pages);
+    for (const page of pages) {
+      const en = page.layout?.blocks[0];
+      const body = page.layout?.blocks[1];
+      expect(en?.repeated).toBe(true);
+      expect(en?.role).toBeUndefined();
+      expect(en?.level).toBeUndefined();
+      // Body blocks (different text per page) stay non-repeated and
+      // keep whatever role they had.
+      expect(body?.repeated).toBeUndefined();
+    }
   });
 
   it('does not falsely detect columns when only one block sits at a different x', () => {


### PR DESCRIPTION
## Summary

The two MED-priority items from the codex 21-sample QA, grouped because both are "extracted text looks weird in a specific shape" fixes (PR-B in the codex-FB followup plan).

### MED-1 — CJK-aware page-text join (`commit 5b62e76`)

`pdf.js` emits one text item per CJK glyph and inserts a synthetic " " between any pair that aren't visually touching. For latin scripts that lines up with real word boundaries; for CJK it produces `人 人 生 而 自 由` even though the source reads `人人生而自由` (codex flagged this on `misc/udhr-chinese`).

New helper `joinPageText(items)` (pure, unit-tested with synthesised `JoinItem[]`) drops the whitespace item iff its prev / next non-whitespace neighbours are both CJK *and* the visual gap is < 30 % of fontSize. Wide CJK gaps (column breaks), latin↔CJK boundaries (`2025 年`) and hard line breaks all keep their whitespace.

End-to-end:
- `misc/udhr-chinese` p2: `人 人 生 而 自 由,` → `人人生而自由,`
- `misc/udhr-korean` p1 title: `세 계 인 권 선 언` → `세계인권선언`
- `speakerdeck/twada` p3: unchanged (mixed JP/latin spacing preserved)

### MED-2 — drop heading role from repeated chrome (`commit b728413`)

`eu-ai-act` was surfacing the 2-character `EN` language marker stamped on every page header as a `level: 1` heading on every one of its 144 pages. The heading classifier picked it up (short block at slightly-larger fontSize), the repeated detector flagged it as chrome, but the heading role survived — agents iterating headings saw `EN` repeated 144 times.

`markRepeatedBlocks` now drops `role` + `level` from any block it flags repeated. The previous contract (`repeated` blocks may still carry headings, for the rare doc-title-in-running-header case) was a misfire on balance.

Pre-fix → post-fix:
- `gov/eu-ai-act` p2-5: `EN` × 4 → no heading
- `forms/irs-w9-form` p1: unchanged (legitimate "W-9", "Part I", "Part II", …)
- `speakerdeck/twada` p3 / p10 / p20: unchanged (legitimate slide titles)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 229/229 pass (12 new unit tests across `cjkJoin.test.ts` and the new layout repeated-demotion case)
- [x] Verified against the `life/project/pdfvision/samples` corpus (no PDF fixtures committed; tests use synthesised `JoinItem` / `PageResult` shapes)
- [ ] CI runs on this push

🤖 Generated with [Claude Code](https://claude.com/claude-code)