### PR TITLE
fix(render): isolate per-PDF PNGs under a shared --render-output dir

### DIFF
--- a/skills/pdfvision/references/ocr.md
+++ b/skills/pdfvision/references/ocr.md
@@ -109,7 +109,10 @@ Most likely the rasterise step produced a blank page, not an actual OCR failure.
 
 ```bash
 npx pdfvision doc.pdf -p <page> --render --render-output /tmp/dbg
-# Inspect /tmp/dbg/page-<n>.png — if it's blank, OCR has nothing to chew on.
+# Inspect /tmp/dbg/<contentFingerprint>/page-<n>.png — if it's blank, OCR has
+# nothing to chew on. (pdfvision namespaces the output by a per-PDF
+# fingerprint so two different PDFs sharing a --render-output dir don't
+# overwrite each other.)
 ```
 
 This is a known limitation tracked separately from OCR. Workaround: source a different copy of the PDF, or pre-decode the JPX stream with a wasm decoder before invoking pdfvision.

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -38,6 +38,11 @@ const FILE_MODE = 0o600;
 // Reject any cache key that isn't a single safe path segment.
 // Cache callers always supply a hash-derived key, so the safe set is narrow.
 const SAFE_KEY = /^[A-Za-z0-9._-]+$/;
+// Strict shape of a per-PDF fingerprint — 16 lowercase hex chars as
+// produced by `hashFileContent`. Used to validate the optional
+// fingerprint argument to `getCacheDir`, since that path joins the
+// value into the cache root before `ensurePrivateDir` would chmod it.
+const SAFE_FINGERPRINT = /^[a-f0-9]{16}$/;
 
 const isPosix = process.platform !== 'win32';
 
@@ -120,6 +125,13 @@ export function getCacheDir(filePath: string, fingerprint?: string): string {
   // Optional precomputed fingerprint lets a caller hash the file once
   // and feed the same identity into both `getCacheDir` and any other
   // per-PDF path (e.g. the render-output subdir layout in processor).
+  // Validate the shape strictly — the value is joined into the cache
+  // root and then `ensurePrivateDir` will mkdir+chmod 0700 it, so an
+  // unchecked `../foo` from an external caller would escape the cache
+  // hierarchy.
+  if (fingerprint !== undefined && !SAFE_FINGERPRINT.test(fingerprint)) {
+    throw new Error(`Invalid pdf fingerprint: ${fingerprint}`);
+  }
   const key = fingerprint ?? hashFileContent(filePath);
   const root = getCacheRoot();
   ensurePrivateDir(root);

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -105,8 +105,22 @@ function hashFileContent(filePath: string): string {
   return hash.digest('hex').slice(0, 16);
 }
 
-export function getCacheDir(filePath: string): string {
-  const key = hashFileContent(filePath);
+/**
+ * Stable per-PDF content fingerprint — the same 16-char sha256 prefix
+ * that powers the cache directory name. Exposed so other modules can
+ * derive per-PDF subdirectories (e.g. the render output layout) from
+ * the same identity the cache uses, without re-hashing or having to
+ * parse it back out of the cache dir path.
+ */
+export function pdfFingerprint(filePath: string): string {
+  return hashFileContent(filePath);
+}
+
+export function getCacheDir(filePath: string, fingerprint?: string): string {
+  // Optional precomputed fingerprint lets a caller hash the file once
+  // and feed the same identity into both `getCacheDir` and any other
+  // per-PDF path (e.g. the render-output subdir layout in processor).
+  const key = fingerprint ?? hashFileContent(filePath);
   const root = getCacheRoot();
   ensurePrivateDir(root);
   const dir = join(root, key);

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -17,7 +17,7 @@ import type {
   ProcessOptions,
   TextSpan,
 } from '../types/index.js';
-import { dropCached, ensurePrivateDir, getCacheDir, getCached, setCache } from './cache.js';
+import { dropCached, ensurePrivateDir, getCacheDir, getCached, pdfFingerprint, setCache } from './cache.js';
 import { type JoinItem, joinPageText } from './cjkJoin.js';
 import { buildImageBoxes, type ImageOps } from './imageBoxes.js';
 import { buildLayout, markRepeatedBlocks } from './layout.js';
@@ -51,7 +51,7 @@ function buildCacheKey(input: CacheKeyInput): string {
     pages: input.pages ?? 'all',
     // Bump when the on-disk DocumentResult shape changes so older entries
     // (missing newly-added page fields) are not handed out as fresh results.
-    format: 'structured-v12',
+    format: 'structured-v13',
     render: !!input.render,
     // Including the resolved render-output dir keeps two invocations with
     // different `--render-output` targets from sharing image paths.
@@ -356,7 +356,14 @@ function dropCachedSafe(cacheDir: string, cacheKey: string): void {
  * For the formatted (string) variant used by the CLI, see {@link processFile}.
  */
 export async function processDocument(filePath: string, options: ProcessDocumentOptions = {}): Promise<DocumentResult> {
-  const cacheDir = options.noCache ? null : getCacheDir(filePath);
+  // Compute the per-PDF fingerprint up front when any code path below
+  // needs it (caching, or render output isolation). Hashing the file is
+  // the most expensive sync step in this function, so do it once and
+  // share — the cache layer accepts a precomputed fingerprint to avoid
+  // re-reading the same file.
+  const needFingerprint = !options.noCache || !!(options.render && options.renderOutput);
+  const fingerprint = needFingerprint ? pdfFingerprint(filePath) : null;
+  const cacheDir = options.noCache ? null : getCacheDir(filePath, fingerprint ?? undefined);
 
   const cacheKey = buildCacheKey(options);
   if (cacheDir) {
@@ -476,7 +483,17 @@ export async function processDocument(filePath: string, options: ProcessDocument
         // User-supplied path: don't enforce 0o700 here — the caller owns
         // their output directory and may need it readable for downstream
         // consumers. We do create it if missing.
-        imagesDir = resolve(options.renderOutput);
+        //
+        // Always namespace by the PDF fingerprint: two different PDFs
+        // sharing the same `--render-output ./images` used to overwrite
+        // each other's `page-N.png` and the renderer's PNG-reuse check
+        // happily handed the survivor back as both documents' image.
+        // A per-fingerprint subdir makes collisions structurally
+        // impossible while keeping the inner filename (`page-N.png`)
+        // stable for downstream consumers.
+        const baseDir = resolve(options.renderOutput);
+        mkdirSync(baseDir, { recursive: true });
+        imagesDir = join(baseDir, fingerprint ?? pdfFingerprint(filePath));
         mkdirSync(imagesDir, { recursive: true });
       } else if (cacheDir) {
         imagesDir = join(cacheDir, 'images');

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -495,6 +495,23 @@ export async function processDocument(filePath: string, options: ProcessDocument
         mkdirSync(baseDir, { recursive: true });
         imagesDir = join(baseDir, fingerprint ?? pdfFingerprint(filePath));
         mkdirSync(imagesDir, { recursive: true });
+        // The fingerprint subdir name is deterministic (same PDF →
+        // same name) and now sits inside a user-controlled directory
+        // we explicitly do NOT lock down to 0700. In a shared writable
+        // parent (CI runners, multi-user hosts) another process could
+        // pre-create that subdir as a symlink to elsewhere; mkdir
+        // -p would silently accept it and the renderer would then
+        // write `page-N.png` through the redirect. Refuse to keep
+        // going if the path is a symlink or somehow not a directory,
+        // matching the same posture `ensurePrivateDir` enforces for
+        // the cache hierarchy.
+        const imagesDirStat = lstatSync(imagesDir);
+        if (imagesDirStat.isSymbolicLink()) {
+          throw new Error(`Refusing to render into ${imagesDir}: path is a symlink`);
+        }
+        if (!imagesDirStat.isDirectory()) {
+          throw new Error(`Refusing to render into ${imagesDir}: path exists but is not a directory`);
+        }
       } else if (cacheDir) {
         imagesDir = join(cacheDir, 'images');
         ensurePrivateDir(imagesDir);

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -492,8 +492,12 @@ export async function processDocument(filePath: string, options: ProcessDocument
         // impossible while keeping the inner filename (`page-N.png`)
         // stable for downstream consumers.
         const baseDir = resolve(options.renderOutput);
-        mkdirSync(baseDir, { recursive: true });
-        imagesDir = join(baseDir, fingerprint ?? pdfFingerprint(filePath));
+        // `needFingerprint` above forces a hash whenever
+        // `render && renderOutput`, so `fingerprint` is non-null on
+        // this branch — assert rather than re-hash.
+        imagesDir = join(baseDir, fingerprint as string);
+        // `recursive: true` creates baseDir too if missing, so the
+        // separate `mkdirSync(baseDir)` would be redundant.
         mkdirSync(imagesDir, { recursive: true });
         // The fingerprint subdir name is deterministic (same PDF →
         // same name) and now sits inside a user-controlled directory

--- a/tests/core/cache.test.ts
+++ b/tests/core/cache.test.ts
@@ -109,6 +109,22 @@ describe('cache', () => {
     }
   });
 
+  it('rejects an externally-supplied fingerprint that is not a 16-char hex string', () => {
+    // `getCacheDir` is re-exported from `src/index.ts`. Its optional
+    // second arg lands inside `join(cacheRoot, fingerprint)` and then
+    // `ensurePrivateDir` will mkdir+chmod 0700 it. A caller that
+    // forwards user input (or a buggy plugin) must not be able to
+    // escape the cache root via `..` or any other path-traversal
+    // payload. Reject anything that isn't the same shape
+    // `pdfFingerprint` produces.
+    expect(() => getCacheDir(tmpFile, '../escape')).toThrow(/Invalid pdf fingerprint/);
+    expect(() => getCacheDir(tmpFile, '/abs/path')).toThrow(/Invalid pdf fingerprint/);
+    expect(() => getCacheDir(tmpFile, 'CAPSHEX0123456789')).toThrow(/Invalid pdf fingerprint/);
+    expect(() => getCacheDir(tmpFile, 'short')).toThrow(/Invalid pdf fingerprint/);
+    // Accepts a well-formed precomputed fingerprint.
+    expect(() => getCacheDir(tmpFile, '0123456789abcdef')).not.toThrow();
+  });
+
   it('writes cache files private to the current user', () => {
     if (process.platform === 'win32') return; // POSIX mode bits only
     const dir = getCacheDir(tmpFile);

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -164,6 +164,88 @@ describe('processDocument', () => {
     }
   });
 
+  it('keeps cached image paths isolated when two PDFs share renderOutput across cache hits', async () => {
+    // Complements the noCache regression test above with the cache-hit
+    // half of the same bug: a stale cached `pages[].image` must continue
+    // to point at the original PDF's fingerprint subdir even after a
+    // different PDF has been rendered into the same renderOutput. Uses
+    // an isolated PDFVISION_CACHE_DIR so this test never races the
+    // shared cache root with other vitest workers.
+    const { mkdtempSync, rmSync, readFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { createHash } = await import('node:crypto');
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'pdfvision-cache-isolation-test-'));
+    const sharedOut = mkdtempSync(join(tmpdir(), 'pdfvision-render-isolation-test-'));
+    const originalCache = process.env.PDFVISION_CACHE_DIR;
+    process.env.PDFVISION_CACHE_DIR = cacheRoot;
+    try {
+      const a1 = await processDocument(SAMPLE_PDF, {
+        render: true,
+        renderOutput: sharedOut,
+        noCache: false,
+      });
+      const aImagePath = a1.pages[0].image as string;
+      const aBytesBefore = createHash('sha256').update(readFileSync(aImagePath)).digest('hex');
+
+      await processDocument(SAMPLE_WITH_IMAGE_PDF, {
+        render: true,
+        renderOutput: sharedOut,
+        noCache: false,
+      });
+
+      // Re-run A: should hit the cache and hand back the same path.
+      const a2 = await processDocument(SAMPLE_PDF, {
+        render: true,
+        renderOutput: sharedOut,
+        noCache: false,
+      });
+      expect(a2.pages[0].image).toBe(aImagePath);
+      const aBytesAfter = createHash('sha256')
+        .update(readFileSync(a2.pages[0].image as string))
+        .digest('hex');
+      expect(aBytesAfter).toBe(aBytesBefore);
+    } finally {
+      if (originalCache === undefined) delete process.env.PDFVISION_CACHE_DIR;
+      else process.env.PDFVISION_CACHE_DIR = originalCache;
+      rmSync(cacheRoot, { recursive: true, force: true });
+      rmSync(sharedOut, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to render when the per-PDF subdir under renderOutput is a pre-planted symlink', async () => {
+    // Hardening: the fingerprint subdir name is deterministic, so on a
+    // shared writable host another process could plant
+    // `<renderOutput>/<fingerprint>` as a symlink to elsewhere and
+    // redirect our `page-N.png` writes. Catch that before any render
+    // happens — silently following the symlink would be a security
+    // regression vs the cache hierarchy's posture.
+    //
+    // POSIX-only: Windows `symlinkSync` needs elevated privileges or
+    // a special `type: 'dir'` mode and is awkward to test there. The
+    // matching cache-side symlink tests in `tests/core/cache.test.ts`
+    // also skip Windows for the same reason.
+    if (process.platform === 'win32') return;
+    const { mkdtempSync, mkdirSync, rmSync, symlinkSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { pdfFingerprint } = await import('../../src/core/cache.js');
+    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-symlink-test-'));
+    const outDir = join(baseTmp, 'images');
+    const decoy = join(baseTmp, 'decoy');
+    mkdirSync(outDir, { recursive: true });
+    mkdirSync(decoy, { recursive: true });
+    const fp = pdfFingerprint(SAMPLE_PDF);
+    symlinkSync(decoy, join(outDir, fp));
+    try {
+      await expect(processDocument(SAMPLE_PDF, { render: true, renderOutput: outDir, noCache: true })).rejects.toThrow(
+        /symlink/,
+      );
+    } finally {
+      rmSync(baseTmp, { recursive: true, force: true });
+    }
+  });
+
   it('produces the same DocumentResult that processFile then JSON.parse would', async () => {
     // Same content under both APIs is the contract.
     const direct = await processDocument(SAMPLE_PDF, { noCache: true });

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -89,12 +89,15 @@ describe('processDocument', () => {
     expect(existsSync(result.pages[0].image as string)).toBe(true);
   });
 
-  it('writes rendered PNGs into a caller-supplied renderOutput directory', async () => {
-    // Agent ergonomics: with renderOutput the PNGs should land directly in
-    // the caller's chosen directory (created if missing) rather than tmp.
+  it('writes rendered PNGs into a per-PDF subdirectory of the caller-supplied renderOutput', async () => {
+    // Agent ergonomics: with renderOutput the PNGs land under the caller's
+    // chosen directory (created if missing) rather than tmp. They sit in a
+    // per-PDF subdirectory (keyed by content fingerprint) so two different
+    // PDFs sharing the same `--render-output ./images` never overwrite each
+    // other — see the "keeps per-PDF rendered PNGs isolated" test below.
     const { mkdtempSync, rmSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
-    const { join, dirname } = await import('node:path');
+    const { join, dirname, relative } = await import('node:path');
     const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-output-test-'));
     const outDir = join(baseTmp, 'nested', 'images'); // not yet created
     try {
@@ -106,8 +109,56 @@ describe('processDocument', () => {
       const imagePath = result.pages[0].image as string;
       expect(imagePath).toBeTypeOf('string');
       expect(existsSync(imagePath)).toBe(true);
-      // The PNG must be inside the requested directory, not anywhere else.
-      expect(dirname(imagePath)).toBe(outDir);
+      // The PNG sits one level below the requested dir (in a fingerprint
+      // subdir), not anywhere outside it.
+      const rel = relative(outDir, imagePath);
+      expect(rel.startsWith('..')).toBe(false);
+      expect(dirname(imagePath).startsWith(outDir)).toBe(true);
+      expect(dirname(imagePath)).not.toBe(outDir);
+    } finally {
+      rmSync(baseTmp, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps per-PDF rendered PNGs isolated when two PDFs share the same renderOutput directory', async () => {
+    // Regression: previously `renderer` always wrote `page-${n}.png` into the
+    // caller-supplied renderOutput dir verbatim. Running two different PDFs
+    // against the same `--render-output ./img` overwrote A's page-1.png with
+    // B's bytes — and worse, `isReusableImage` then handed B's PNG back as
+    // A's image on subsequent runs because the filename matched.
+    //
+    // Contract: distinct PDFs sharing a renderOutput directory MUST end up
+    // with distinct on-disk PNG paths, and the first PDF's image bytes
+    // MUST survive a subsequent render of the second PDF.
+    const { mkdtempSync, rmSync, readFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { createHash } = await import('node:crypto');
+    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-collision-test-'));
+    const sharedOut = join(baseTmp, 'images');
+    try {
+      const a = await processDocument(SAMPLE_PDF, {
+        render: true,
+        renderOutput: sharedOut,
+        noCache: true,
+      });
+      const aImagePath = a.pages[0].image as string;
+      const aBytesBefore = createHash('sha256').update(readFileSync(aImagePath)).digest('hex');
+
+      const b = await processDocument(SAMPLE_WITH_IMAGE_PDF, {
+        render: true,
+        renderOutput: sharedOut,
+        noCache: true,
+      });
+      const bImagePath = b.pages[0].image as string;
+
+      // Different PDFs must resolve to different on-disk paths under the
+      // shared directory.
+      expect(aImagePath).not.toBe(bImagePath);
+      // A's PNG bytes must still match the original A render — they must
+      // not have been silently replaced by B's render.
+      const aBytesAfter = createHash('sha256').update(readFileSync(aImagePath)).digest('hex');
+      expect(aBytesAfter).toBe(aBytesBefore);
     } finally {
       rmSync(baseTmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Two different PDFs sharing the same `--render-output ./images` used to overwrite each other's `page-N.png`, and the renderer's PNG-reuse check happily handed the survivor back as both documents' image. The result cache made it worse: PDF A's cache hit returned a `pages[].image` path whose bytes had been silently replaced by a later run of PDF B.

Fix: always namespace user-supplied `renderOutput` by the PDF's content fingerprint, so a shared `./images` becomes a container of per-PDF subdirectories instead of a flat shared bucket. Inner filenames (`page-N.png`) stay stable, and the existing PNG-reuse / cache-recovery paths keep working without further changes.

## Details

- Export `pdfFingerprint(filePath)` from `core/cache.ts` so callers can derive per-PDF paths from the same identity the cache already uses.
- Compute the fingerprint once in `processDocument` and reuse it for both `getCacheDir` and the new render subdirectory.
- Bump cache key `structured-v12` → `structured-v13`: cached `pages[].image` strings carry old flat paths and must be re-rendered into the new subdir layout.

## Behavior change

`--render-output ./images` previously produced:

```
./images/page-1.png
./images/page-2.png
```

Now produces:

```
./images/<contentFingerprint>/page-1.png
./images/<contentFingerprint>/page-2.png
```

The fingerprint is the same 16-char sha256 prefix the result cache already uses, so two distinct PDFs land in disjoint subdirs and the same PDF always lands in the same subdir across runs.

## Test plan

- [x] New regression test: `keeps per-PDF rendered PNGs isolated when two PDFs share the same renderOutput directory` — asserts distinct on-disk paths AND that PDF A's PNG bytes survive a subsequent render of PDF B. Fails on `main`, passes here.
- [x] Updated existing test to reflect the per-PDF subdir contract.
- [x] `npm run lint` — clean.
- [x] `npm run test` — 239/239 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)