### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Bump version `0.6.0` → `0.7.0` ahead of the v0.7.0 release.

After merge, this branch's commit becomes the target of the `v0.7.0` tag and the `npm-publish` workflow can be dispatched.

## What's in v0.7.0

### Silent-failure coverage — new signals on every page

- **`nonPrintableRatio` + `nonPrintableCount`** — catches PDFs whose fonts have no ToUnicode CMap. pdf.js falls back to raw glyph indices (U+0000, U+0001, …) which look like clean text by char count but are binary garbage. `>= 0.05` is the dispatch threshold (`#39`).
- **`renderContentRatio`** — fraction of pixels carrying visible content, measured against the page's own dominant luminance bucket (so dark / beige / cream scans aren't false-positives). Catches blank-render failures the text-side signals miss — typically pdf.js + `@napi-rs/canvas` failing on JPEG2000 / JPX or missing fonts.
- **`pages[].quality`** — single derived classification (`nativeTextStatus` + optional `visualStatus`) so agents dispatch on one field instead of re-implementing the threshold logic. Pure observation — pdfvision deliberately does NOT recommend an action; that judgment stays with the agent.
- **`--pages` out-of-range now warns** instead of silently dropping. CLI emits `pdfvision: warning: ...` to stderr; library callers receive it via the new `onWarning` callback.

### CJK / multilingual text fidelity

- **CJK-aware page-text join** — pdf.js emits one glyph per item for CJK and inserts synthetic spaces between any two glyphs that aren't touching in the text matrix. Result: `人 人 生 而 自 由` instead of `人人生而自由`. The new joiner drops whitespace items whose visual gap is under 30 % of the surrounding fontSize when both neighbours are CJK. Latin-CJK boundaries (`2025 年`) and wide column-break gaps are preserved.
- **Predefined CJK CMap pack wired up** (`cMapUrl` + `cMapPacked: true`) — SpeakerDeck / Office Japanese exports no longer come back with `text: ""`.
- **Layout-side join uses the same threshold** so `pages[].text` and `pages[].layout.blocks[].text` agree on the same gap.

### Layout reconstruction

- **Tiered heading detection** — `LayoutBlock.role: 'heading'` now carries a `level: 1 | 2 | 3` for major titles / section headings / subsection candidates. Strict gates on the low tiers (short, single-line, standalone, locally larger than neighbours) keep arxiv-style subsections discoverable without false-positives on body emphasis runs.
- **Repeated-chrome detection demotes headings** — running headers, page numbers, language markers that happen to sit at heading fontSize no longer pollute the `headings` slice.

### Render pipeline

- **JPX (JPEG2000) wasm decoder wired up** (`wasmUrl`) — Internet Archive scans render instead of coming out blank.
- **`renderContentRatio` reuses cached PNG bytes** on cache hit instead of rasterising again through pdf.js.

### `--render-output` isolation (breaking change)

Previously two different PDFs sharing the same `--render-output ./images` overwrote each other's `page-N.png`. **Output layout is now per-PDF fingerprint subdir**:

```
before: ./images/page-1.png
after:  ./images/<contentFingerprint>/page-1.png
```

`<contentFingerprint>` is the same 16-char sha256 prefix the cache already uses, so the layout is deterministic for a given PDF.

### Library API additions

- New public helper `pdfFingerprint(filePath)` (re-exportable from `pdfvision/core/cache`) so external callers can derive the same per-PDF identity.
- `getCacheDir(filePath, fingerprint?)` accepts a precomputed fingerprint with strict `^[a-f0-9]{16}$` validation.
- New `onWarning?: (msg: string) => void` option on `processDocument` / `processFile`.

### Agent skill

- **Bundled `skills/pdfvision/` agent skill** — drop-in for Claude Code / Cursor. Captures the dispatch model, density-signal thresholds, and OCR / render workflows. Iteratively tuned against 21 real-world PDFs.

### Internal

- Cache key bumped `structured-v8` → `structured-v13` (covers OCR keys, new fields, level field on `LayoutBlock`, image-path layout).
- `Int32Array` neighbour-index buffers in `joinPageText` for long pages.
- Hardened `renderOutput` subdir: refuses pre-planted symlinks at the per-PDF path.
- 184 → 242 tests.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 242/242 passing
- [x] `npm run build` succeeds (109.9 kB total dist)
- [ ] After merge: create GitHub release tag `v0.7.0` + dispatch `npm-publish` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)