### PR TITLE
refactor(api): trim public surface to the library entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ for (const page of result.pages) {
 
 `processFile()` returns the same string output the CLI prints (`markdown` / `json` / `xml`).
 
-Exports: `processDocument`, `processFile`, `parsePageRange`, `renderPage`, `renderPages`, `getCacheDir`, `getCached`, `setCache`, plus full type definitions for `DocumentResult` / `PageResult` / `PageOverview` / `DocumentMetadata` / `ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` / `LayoutBlock` / `LayoutLine` / `PageLayout` / `ImageBox` / `PageOcr`.
+Exports: `processDocument`, `processFile`, `parsePageRange`, plus full type definitions for `DocumentResult` / `PageResult` / `PageOverview` / `PageQuality` / `DocumentMetadata` / `ProcessDocumentOptions` / `ProcessOptions` / `OutputFormat` / `TextSpan` / `LayoutBlock` / `LayoutLine` / `PageLayout` / `ImageBox` / `PageOcr`.
 
 ## 🤖 Agent Skill
 

--- a/skills/pdfvision/references/structured-output.md
+++ b/skills/pdfvision/references/structured-output.md
@@ -238,4 +238,4 @@ for (const page of result.pages) {
 
 `processFile()` returns the formatted string output (`markdown` / `json` / `xml`). `processDocument()` returns the structured object directly.
 
-Exported types: `DocumentResult`, `DocumentMetadata`, `PageOverview`, `PageResult`, `LayoutBlock`, `LayoutLine`, `PageLayout`, `ImageBox`, `TextSpan`, `PageOcr`, `OutputFormat`, `ProcessDocumentOptions`, `ProcessOptions`.
+Exported types: `DocumentResult`, `DocumentMetadata`, `PageOverview`, `PageResult`, `PageQuality`, `LayoutBlock`, `LayoutLine`, `PageLayout`, `ImageBox`, `TextSpan`, `PageOcr`, `OutputFormat`, `ProcessDocumentOptions`, `ProcessOptions`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,18 @@
-export { getCacheDir, getCached, setCache } from './core/cache.js';
+// Public surface — kept narrow on purpose. Everything else lives under
+// `src/core/*` and is internal implementation. In particular:
+//
+//   - `getCacheDir` / `getCached` / `setCache` were re-exported in
+//     earlier versions but have no useful entry point for library
+//     consumers — they expect cache-internal arguments and can corrupt
+//     the on-disk cache if misused. Use `--clear-cache` (CLI) for
+//     cache management.
+//   - `renderPage` / `renderPages` took a `PDFDocumentProxy` directly,
+//     which forced any caller to import `pdfjs-dist` themselves and
+//     made pdf.js the de-facto public contract. The library entry
+//     point is `processDocument({ render: true })` instead — it owns
+//     the pdf.js lifetime and returns image paths on the page result.
 export { parsePageRange } from './core/pageRange.js';
 export { processDocument, processFile } from './core/processor.js';
-export { renderPage, renderPages } from './core/renderer.js';
 export type {
   DocumentMetadata,
   DocumentResult,
@@ -12,6 +23,7 @@ export type {
   PageLayout,
   PageOcr,
   PageOverview,
+  PageQuality,
   PageResult,
   ProcessDocumentOptions,
   ProcessOptions,

--- a/tests/core/cache.test.ts
+++ b/tests/core/cache.test.ts
@@ -110,13 +110,15 @@ describe('cache', () => {
   });
 
   it('rejects an externally-supplied fingerprint that is not a 16-char hex string', () => {
-    // `getCacheDir` is re-exported from `src/index.ts`. Its optional
-    // second arg lands inside `join(cacheRoot, fingerprint)` and then
-    // `ensurePrivateDir` will mkdir+chmod 0700 it. A caller that
-    // forwards user input (or a buggy plugin) must not be able to
-    // escape the cache root via `..` or any other path-traversal
-    // payload. Reject anything that isn't the same shape
-    // `pdfFingerprint` produces.
+    // `getCacheDir` is internal to `src/core/cache.ts` but still gets
+    // a precomputed fingerprint from `processor.ts`. Its second arg
+    // lands inside `join(cacheRoot, fingerprint)` and then
+    // `ensurePrivateDir` will mkdir+chmod 0700 it. Even though the
+    // function is no longer re-exported from `src/index.ts`, any
+    // caller inside core (or a future plugin) that forwards user
+    // input must not be able to escape the cache root via `..` or
+    // any other path-traversal payload. Reject anything that isn't
+    // the same shape `pdfFingerprint` produces.
     expect(() => getCacheDir(tmpFile, '../escape')).toThrow(/Invalid pdf fingerprint/);
     expect(() => getCacheDir(tmpFile, '/abs/path')).toThrow(/Invalid pdf fingerprint/);
     expect(() => getCacheDir(tmpFile, 'CAPSHEX0123456789')).toThrow(/Invalid pdf fingerprint/);

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -270,6 +270,22 @@ describe('processDocument', () => {
     expect(result.totalPages).toBe(1);
   });
 
+  it('keeps the public surface narrow — internal cache + renderer entry points stay unexported', async () => {
+    // Negative guard against the public surface accidentally widening
+    // again. Earlier versions re-exported cache primitives and the
+    // pdf.js-backed renderer entry points from `src/index.ts`; both
+    // had no useful contract for library consumers (renderPage
+    // required a `PDFDocumentProxy`, which made pdf.js the de-facto
+    // public contract). They live under `src/core/*` now and must
+    // not leak back out of the package barrel.
+    const pkg = (await import('../../src/index.js')) as Record<string, unknown>;
+    expect(pkg.getCacheDir).toBeUndefined();
+    expect(pkg.getCached).toBeUndefined();
+    expect(pkg.setCache).toBeUndefined();
+    expect(pkg.renderPage).toBeUndefined();
+    expect(pkg.renderPages).toBeUndefined();
+  });
+
   it('drops the cache entry when a previously rendered image has gone missing', async () => {
     // Populate the rendered cache, then delete the PNG file out from under
     // it. The next call must detect the missing image, drop the stale


### PR DESCRIPTION
## Summary

Addresses **HIGH-1** from the recent architecture review (codex): the package barrel `src/index.ts` re-exported internal cache primitives and pdf.js-backed renderer entry points, making pdf.js a de-facto public contract and giving external callers a way to corrupt the cache.

### What changes

Removed from `src/index.ts` (still under `src/core/*` for internal use):

- `getCacheDir`, `getCached`, `setCache` — internal cache plumbing. Expected cache-internal arguments and let callers write arbitrary blobs into pdfvision's on-disk cache. No documented use case for library consumers.
- `renderPage`, `renderPages` — required a `PDFDocumentProxy`, which forced the caller to install + import `pdfjs-dist` directly and locked the public surface to pdf.js. The supported library entry is `processDocument({ render: true })`, which owns the pdf.js lifetime internally and surfaces rendered PNG paths on `pages[].image`.

Added to `src/index.ts`:

- `PageQuality` type export — previously only inferable through `PageResult.quality`, not importable by name. Closes a small typing gap.

### Resulting public surface

```
Functions:  parsePageRange, processDocument, processFile
Types:      DocumentMetadata, DocumentResult, ImageBox, LayoutBlock,
            LayoutLine, OutputFormat, PageLayout, PageOcr, PageOverview,
            PageQuality, PageResult, ProcessDocumentOptions,
            ProcessOptions, TextSpan
```

(3 functions + 14 types, was 6 functions + 13 types.)

## Breaking change

Technically yes — but the removed names had no documented contract and were flagged as a backend lock-in risk in the architecture review. Anyone using `renderPage()` was already coupled to pdf.js (they had to import `pdfjs-dist` to obtain the doc). `package.json` exposes only `"."` as a subpath, and build chunks are hashed, so there is no supported deep-import escape hatch.

Will land in the next minor bump (v0.8.0).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 243/243 passing
- [x] New negative guard `keeps the public surface narrow — internal cache + renderer entry points stay unexported` asserts the five removed names are not re-exposed
- [x] `npm run build` succeeds; emitted `dist/index.d.mts` carries the trimmed surface
- [x] README + skill docs updated to match the new surface (added in `5b3436b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)