### PR TITLE
feat(cli): format shortcuts + --strip-repeated for Markdown (P1)

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -31,7 +31,14 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         help: { type: 'boolean', short: 'h' },
         version: { type: 'boolean', short: 'v' },
         pages: { type: 'string', short: 'p' },
-        format: { type: 'string', short: 'f', default: 'markdown' },
+        // Canonical format flag — `default` is intentionally NOT set
+        // here so we can tell "user typed -f X" apart from "no -f at
+        // all"; that distinction is needed when reconciling against
+        // the `--markdown` / `--json` / `--xml` shortcut flags below.
+        format: { type: 'string', short: 'f' },
+        markdown: { type: 'boolean' },
+        json: { type: 'boolean' },
+        xml: { type: 'boolean' },
         render: { type: 'boolean', short: 'r' },
         'render-output': { type: 'string' },
         'no-cache': { type: 'boolean' },
@@ -39,6 +46,7 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         geometry: { type: 'boolean' },
         layout: { type: 'boolean' },
         'image-boxes': { type: 'boolean' },
+        'strip-repeated': { type: 'boolean' },
         remote: { type: 'string' },
         'clear-cache': { type: 'boolean' },
         ocr: { type: 'boolean' },
@@ -88,7 +96,32 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     exitWithError('--remote and a file path are mutually exclusive');
   }
 
-  const format = (values.format as string) ?? 'markdown';
+  // Resolve the output format from the canonical `-f / --format` flag
+  // plus the `--markdown` / `--json` / `--xml` shortcut aliases. The
+  // canonical form is kept for completeness (future formats like html,
+  // jsonl can ride on it without inventing yet another shortcut) but
+  // the aliases are what most callers will reach for.
+  const aliasFormats: OutputFormat[] = [];
+  if (values.markdown) aliasFormats.push('markdown');
+  if (values.json) aliasFormats.push('json');
+  if (values.xml) aliasFormats.push('xml');
+  if (aliasFormats.length > 1) {
+    // Different aliases at once means the user typed two contradicting
+    // requests — silently picking last-wins would hide the intent
+    // mismatch. Fail loudly.
+    exitWithError(`Output format specified multiple times: ${aliasFormats.map((a) => `--${a}`).join(', ')}`);
+  }
+  const explicitFormat = values.format as string | undefined;
+  if (aliasFormats.length === 1 && explicitFormat !== undefined && explicitFormat !== aliasFormats[0]) {
+    // Alias and `-f` disagree (e.g. `--json -f xml`) — also a clear
+    // intent conflict.
+    exitWithError(`Output format conflict: --${aliasFormats[0]} vs --format ${explicitFormat}`);
+  }
+  // Pick alias if present, otherwise the explicit `-f` value, otherwise
+  // default to markdown. Same-value duplicates (`--json -f json`) are
+  // allowed and idempotent so a script that composes flags from
+  // multiple sources doesn't blow up on accidental redundancy.
+  const format = aliasFormats[0] ?? explicitFormat ?? 'markdown';
   if (!isValidFormat(format)) {
     exitWithError(`Invalid --format "${format}". Expected one of: ${VALID_FORMATS.join(', ')}`);
   }
@@ -99,6 +132,22 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     // --render-output only does something if pages are actually rendered.
     // Failing fast is friendlier than silently writing nothing to the dir.
     exitWithError('--render-output requires --render');
+  }
+
+  const layout = (values.layout as boolean | undefined) ?? false;
+  const stripRepeated = (values['strip-repeated'] as boolean | undefined) ?? false;
+  if (stripRepeated && !layout) {
+    // `repeated: true` is only emitted by the cross-page layout pass,
+    // so without --layout there is no signal to filter on. Mirrors the
+    // --render-output / --render relationship above.
+    exitWithError('--strip-repeated requires --layout');
+  }
+  if (stripRepeated && format !== 'markdown') {
+    // The JSON / XML outputs already carry `repeated: true` on each
+    // layout block, so consumers there can filter themselves. Strip
+    // is only a Markdown-output concern — fail rather than silently
+    // ignore so the user notices the flag had no effect.
+    exitWithError(`--strip-repeated only applies to markdown output (got --format ${format})`);
   }
 
   const noCache = (values['no-cache'] as boolean | undefined) ?? false;
@@ -137,8 +186,9 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
       // diffing, ...).
       normalize: !((values['no-normalize'] as boolean | undefined) ?? false),
       geometry: (values.geometry as boolean | undefined) ?? false,
-      layout: (values.layout as boolean | undefined) ?? false,
+      layout,
       imageBoxes: (values['image-boxes'] as boolean | undefined) ?? false,
+      stripRepeated,
       ocr: (values.ocr as boolean | undefined) ?? false,
       ocrLang: (values['ocr-lang'] as string | undefined) ?? 'eng',
       // Library callers stay silent by default; the CLI wires warnings

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -16,6 +16,11 @@ Usage:
 Options
   -p, --pages <range>     Pages to extract: "1", "1-5", "1,3,5", "2-4,7". Default: all pages.
   -f, --format <type>     Output format: markdown (default), json, xml.
+      --markdown          Shortcut for --format markdown.
+      --json              Shortcut for --format json.
+      --xml               Shortcut for --format xml.
+                          (Specifying more than one format, or mixing a shortcut with a different
+                          --format, is an error — pdfvision does not last-wins-resolve them.)
   -r, --render            Render each selected page to a PNG and include the path on every page result.
       --render-output <dir>
                           Directory to write rendered PNGs into, created if missing. Requires --render.
@@ -28,6 +33,11 @@ Options
                           reading order) from the same span data. Only -f json / -f xml.
       --image-boxes       Emit \`pages[].imageBoxes\` — bounding box of every raster image
                           draw on the page. Only -f json / -f xml.
+      --strip-repeated    Drop running headers / footers / page numbers (blocks the layout
+                          pass tagged as \`repeated\`) from the rendered Markdown body so
+                          LLM readers don't have to wade through the same footer N times.
+                          Markdown only; JSON / XML already expose \`repeated: true\` per
+                          block. Requires --layout.
       --ocr               Run OCR on each selected page and attach \`pages[].ocr\`
                           (text + confidence + lang). Slow; opt-in. Requires the
                           optional \`tesseract.js\` dependency. \`pages[].text\` is
@@ -50,13 +60,15 @@ Output formats
 
 Examples
   pdfvision document.pdf                                                       # markdown to stdout
-  pdfvision document.pdf -p 1-3 -f json                                        # specific pages, JSON
+  pdfvision document.pdf --json                                                # JSON shortcut
+  pdfvision document.pdf -p 1-3 --json                                         # specific pages, JSON
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
-  pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry -f json   # PNGs + spans for 3-5
-  pdfvision slides.pdf -f xml --geometry                                       # layout / geometry as XML
-  pdfvision scan.pdf --ocr -f json                                             # OCR a scanned PDF
-  pdfvision scan-ja.pdf --ocr --ocr-lang eng+jpn -f json                       # multi-lang OCR
-  pdfvision --remote https://example.com/paper.pdf -f json                     # fetch + extract JSON
+  pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry --json    # PNGs + spans for 3-5
+  pdfvision slides.pdf --xml --geometry                                        # layout / geometry as XML
+  pdfvision report.pdf --layout --strip-repeated                               # markdown w/o repeated chrome
+  pdfvision scan.pdf --ocr --json                                              # OCR a scanned PDF
+  pdfvision scan-ja.pdf --ocr --ocr-lang eng+jpn --json                        # multi-lang OCR
+  pdfvision --remote https://example.com/paper.pdf --json                      # fetch + extract JSON
   pdfvision --clear-cache                                                      # wipe the on-disk cache
 
 Exit codes

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -310,10 +310,11 @@ async function extractPageData(
 }
 
 /** Render a structured DocumentResult into the caller-requested string format. */
-function render(result: DocumentResult, format: ProcessOptions['format']): string {
+function render(result: DocumentResult, options: ProcessOptions): string {
+  const { format } = options;
   if (format === 'json') return formatJson(result);
   if (format === 'xml') return formatXml(result);
-  return formatMarkdown(result);
+  return formatMarkdown(result, { stripRepeated: options.stripRepeated });
 }
 
 /**
@@ -671,6 +672,14 @@ export async function processDocument(filePath: string, options: ProcessDocument
  * usually want `processDocument()` instead.
  */
 export async function processFile(filePath: string, options: ProcessOptions): Promise<string> {
+  // Validate format-specific options up front so the caller doesn't pay
+  // the extraction cost (potentially seconds of pdf.js / OCR work) only
+  // to hit a render-time mismatch. `stripRepeated` depends on the
+  // layout pass having tagged blocks with `repeated: true`, which only
+  // happens when `layout: true` is requested.
+  if (options.stripRepeated && !options.layout) {
+    throw new Error('stripRepeated requires layout: true');
+  }
   const result = await processDocument(filePath, {
     pages: options.pages,
     render: options.render,
@@ -684,5 +693,5 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
     ocrLang: options.ocrLang,
     onWarning: options.onWarning,
   });
-  return render(result, options.format);
+  return render(result, options);
 }

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -680,6 +680,14 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
   if (options.stripRepeated && !options.layout) {
     throw new Error('stripRepeated requires layout: true');
   }
+  if (options.stripRepeated && options.format !== 'markdown') {
+    // JSON / XML already expose `repeated: true` on each layout block,
+    // so passing `stripRepeated` with those formats is a misconfigured
+    // call (the flag would silently no-op against the formatter).
+    // Match the CLI's posture and fail loudly so library users notice
+    // the flag had no effect.
+    throw new Error(`stripRepeated only applies to markdown output (got format: ${options.format})`);
+  }
   const result = await processDocument(filePath, {
     pages: options.pages,
     render: options.render,

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -1,9 +1,44 @@
 import type { DocumentResult, PageResult } from '../types/index.js';
 
+/** Options that influence the Markdown rendering without changing the
+ *  underlying `DocumentResult`. JSON / XML formatters don't need them
+ *  because they already expose the same metadata (e.g. `repeated: true`)
+ *  for downstream consumers to filter themselves; Markdown is read by
+ *  humans / LLMs that benefit from the filtering being pre-applied. */
+export interface MarkdownOptions {
+  /** Drop blocks flagged `repeated: true` (running header / footer /
+   *  page number, etc.) from the per-page body. Requires the document
+   *  to have been extracted with `layout: true`; throws otherwise so
+   *  silent no-ops don't mask a misconfigured call. */
+  stripRepeated?: boolean;
+}
+
 /** "595×842" — drops trailing .00 so integer dimensions stay readable. */
 function formatSize(page: PageResult): string {
   const trim = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
   return `${trim(page.width)}×${trim(page.height)}`;
+}
+
+/** Body text for a page: either the pdf.js-derived `page.text` (default),
+ *  or — when `stripRepeated` is on — a layout-driven rebuild that filters
+ *  out the blocks the cross-page pass tagged as repeated chrome. */
+function pageBody(page: PageResult, options: MarkdownOptions): string {
+  if (!options.stripRepeated) return page.text;
+  if (!page.layout) {
+    // Caller asked to strip repeated chrome but the document carries no
+    // layout — `repeated: true` is only set during the cross-page
+    // layout pass, so there is no way to filter without it. Fail loud
+    // rather than silently emitting the unfiltered text.
+    throw new Error('stripRepeated requires layout extraction (pass layout: true to processDocument)');
+  }
+  // Rebuild the body from non-repeated blocks. Use double-newline
+  // separators so consecutive paragraphs / heading + body don't run
+  // together when their original spacing came from layout gaps rather
+  // than literal newlines.
+  return page.layout.blocks
+    .filter((b) => !b.repeated)
+    .map((b) => b.text)
+    .join('\n\n');
 }
 
 /**
@@ -13,7 +48,7 @@ function formatSize(page: PageResult): string {
  * visible as a single italic line to keep the silent-failure signal close to
  * the text.
  */
-export function formatMarkdown(result: DocumentResult): string {
+export function formatMarkdown(result: DocumentResult, options: MarkdownOptions = {}): string {
   const lines: string[] = [];
   lines.push(`# ${result.file}`);
   lines.push('');
@@ -110,9 +145,10 @@ export function formatMarkdown(result: DocumentResult): string {
     lines.push(
       `_chars: ${page.charCount} · images: ${page.imageCount} · coverage: ${coveragePct}%${nonPrintFragment}${renderFragment}${nativeFragment}${visualFragment} · size: ${formatSize(page)}pt_`,
     );
-    if (page.text) {
+    const body = pageBody(page, options);
+    if (body) {
       lines.push('');
-      lines.push(page.text);
+      lines.push(body);
     }
     if (page.ocr) {
       // OCR sits below the native text so the agent reads pdfjs first

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,16 @@ export interface ProcessOptions {
   imageBoxes?: boolean;
   ocr?: boolean;
   ocrLang?: string;
+  /**
+   * Drop repeated-chrome blocks (running headers, footers, page numbers
+   * detected by the cross-page layout pass) from the rendered Markdown
+   * body so an LLM doesn't have to read the same footer N times. Has
+   * no effect when `format` is anything other than `markdown` — JSON /
+   * XML already expose the same information via `repeated: true` on
+   * each layout block, so downstream consumers can filter themselves.
+   * Requires `layout: true`; the formatter throws otherwise.
+   */
+  stripRepeated?: boolean;
   /** See {@link ProcessDocumentOptions.onWarning}. */
   onWarning?: (message: string) => void;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,11 +91,15 @@ export interface ProcessOptions {
   /**
    * Drop repeated-chrome blocks (running headers, footers, page numbers
    * detected by the cross-page layout pass) from the rendered Markdown
-   * body so an LLM doesn't have to read the same footer N times. Has
-   * no effect when `format` is anything other than `markdown` — JSON /
-   * XML already expose the same information via `repeated: true` on
-   * each layout block, so downstream consumers can filter themselves.
-   * Requires `layout: true`; the formatter throws otherwise.
+   * body so an LLM doesn't have to read the same footer N times.
+   *
+   * Only applies when `format` is `'markdown'`. Passing it with `'json'`
+   * or `'xml'` throws — those formats already expose `repeated: true`
+   * on each layout block, so downstream consumers can filter themselves
+   * and a silent no-op there would be a footgun.
+   *
+   * Requires `layout: true` (the `repeated` flag is only set during the
+   * cross-page layout pass); throws otherwise.
    */
   stripRepeated?: boolean;
   /** See {@link ProcessDocumentOptions.onWarning}. */

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -114,6 +114,70 @@ describe('cli', () => {
     expect(parsed.pages[0].text).toContain('Hello pdfvision');
   });
 
+  it('accepts the --json shortcut as an alias for --format json', async () => {
+    // Canonical `-f json` is kept for forward-compat (future formats like
+    // html / jsonl can ride on it), but the alias is what most callers
+    // reach for. Same output, fewer keystrokes.
+    const r = await captureRun([SAMPLE_PDF, '--json', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    const parsed = JSON.parse(r.stdout.join('\n'));
+    expect(parsed.totalPages).toBe(1);
+  });
+
+  it('accepts the --xml shortcut as an alias for --format xml', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--xml', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    expect(r.stdout.join('\n')).toMatch(/^<document /);
+  });
+
+  it('accepts the --markdown shortcut explicitly (matches the default)', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--markdown', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    expect(r.stdout.join('\n')).toMatch(/^# /);
+  });
+
+  it('rejects two different format aliases at once', async () => {
+    // `--json --xml` is a clear intent conflict — silently picking
+    // last-wins would mask whichever the user actually meant.
+    const r = await captureRun([SAMPLE_PDF, '--json', '--xml', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/Output format specified multiple times/);
+  });
+
+  it('rejects a format alias that disagrees with --format', async () => {
+    // `--json -f xml` is also a conflict — same reason as above.
+    const r = await captureRun([SAMPLE_PDF, '--json', '-f', 'xml', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/Output format conflict/);
+  });
+
+  it('allows a format alias to match --format with the same value (idempotent)', async () => {
+    // A script that composes flags from multiple sources may end up
+    // with redundant but non-conflicting format specs (`--json -f json`).
+    // That should not be an error.
+    const r = await captureRun([SAMPLE_PDF, '--json', '-f', 'json', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    const parsed = JSON.parse(r.stdout.join('\n'));
+    expect(parsed.totalPages).toBe(1);
+  });
+
+  it('rejects --strip-repeated without --layout', async () => {
+    // `repeated: true` is only set during the cross-page layout pass,
+    // so without --layout there is nothing to filter on. Fail fast
+    // rather than silently emit unfiltered Markdown.
+    const r = await captureRun([SAMPLE_PDF, '--strip-repeated', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--strip-repeated requires --layout/);
+  });
+
+  it('rejects --strip-repeated on non-markdown output', async () => {
+    // JSON / XML already expose `repeated: true` on each layout block;
+    // forcing the CLI to strip would be either no-op or destructive.
+    const r = await captureRun([SAMPLE_PDF, '--layout', '--strip-repeated', '--json', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--strip-repeated only applies to markdown/);
+  });
+
   it('rejects --render-output without --render', async () => {
     // --render-output only meaningfully writes when --render is requested.
     // Silent no-op would leave the user's empty directory looking like a

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -260,6 +260,25 @@ describe('processDocument', () => {
     await expect(processDocument(SAMPLE_PDF, { pages: 'abc', noCache: true })).rejects.toThrow(/positive integer/);
   });
 
+  it('rejects processFile({ stripRepeated, layout: false }) before any extraction work', async () => {
+    // Library variant of the CLI's `--strip-repeated requires --layout`
+    // check. Fail fast so the caller doesn't pay seconds of pdf.js
+    // work just to hit a render-time rejection.
+    await expect(
+      processFile(SAMPLE_PDF, { format: 'markdown', stripRepeated: true, layout: false, noCache: true }),
+    ).rejects.toThrow(/stripRepeated requires layout/);
+  });
+
+  it('rejects processFile({ stripRepeated, format: "json" }) — strip is markdown-only', async () => {
+    // JSON / XML already expose `repeated: true` on each layout block,
+    // so the formatter never consults `stripRepeated` there. Without
+    // this guard the library would silently no-op while the CLI errors
+    // — keep the two surfaces symmetric.
+    await expect(
+      processFile(SAMPLE_PDF, { format: 'json', stripRepeated: true, layout: true, noCache: true }),
+    ).rejects.toThrow(/stripRepeated only applies to markdown/);
+  });
+
   it('is reachable through the package public entrypoint', async () => {
     // Guard against accidentally breaking the index.ts re-export of the
     // new API. Library consumers will hit `import { processDocument } from

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -392,4 +392,83 @@ describe('formatMarkdown', () => {
     expect(out).toMatch(/## Page 1/);
     expect(out).toMatch(/images: 3/);
   });
+
+  it('drops repeated-chrome blocks from the page body when stripRepeated + layout are on', async () => {
+    // Cross-page layout tags chrome (header / footer / page number) with
+    // `repeated: true`. With stripRepeated enabled the Markdown body
+    // rebuilds from non-repeated blocks instead of pdf.js's raw
+    // `page.text`, so the rendered body does not contain footer noise
+    // the agent would otherwise re-read on every page.
+    const out = formatMarkdown(
+      makeResult({
+        pages: [
+          makePage({
+            page: 1,
+            text: 'Real body line.\n© COLOPL, Inc.',
+            charCount: 31,
+            layout: {
+              blocks: [
+                { text: 'Real body line.', x: 0, y: 0, width: 100, height: 12, lines: [] },
+                {
+                  text: '© COLOPL, Inc.',
+                  x: 0,
+                  y: 780,
+                  width: 100,
+                  height: 10,
+                  lines: [],
+                  repeated: true,
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+      { stripRepeated: true },
+    );
+    expect(out).toContain('Real body line.');
+    expect(out).not.toContain('© COLOPL, Inc.');
+  });
+
+  it('leaves the body untouched when stripRepeated is off (default)', async () => {
+    // Sanity: opting out of strip means the existing `page.text` flow
+    // is preserved verbatim, including the repeated chrome.
+    const out = formatMarkdown(
+      makeResult({
+        pages: [
+          makePage({
+            page: 1,
+            text: 'Body\n© Footer',
+            charCount: 14,
+            layout: {
+              blocks: [
+                { text: 'Body', x: 0, y: 0, width: 100, height: 12, lines: [] },
+                {
+                  text: '© Footer',
+                  x: 0,
+                  y: 780,
+                  width: 100,
+                  height: 10,
+                  lines: [],
+                  repeated: true,
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(out).toContain('Body');
+    expect(out).toContain('© Footer');
+  });
+
+  it('throws when stripRepeated is requested but the page carries no layout', async () => {
+    // `repeated: true` only exists after the cross-page layout pass, so
+    // stripping without a layout payload is a misconfigured call. Fail
+    // loudly rather than silently emit the unfiltered text.
+    expect(() =>
+      formatMarkdown(makeResult({ pages: [makePage({ page: 1, text: 'no layout', charCount: 9 })] }), {
+        stripRepeated: true,
+      }),
+    ).toThrow(/stripRepeated requires layout/);
+  });
 });


### PR DESCRIPTION
P1 from the post-v0.7.0 usage feedback (Codex actually used the CLI and pointed out two small UX wins). Both are small, independently useful, and feel immediately better in the next session.

## What changes

### Format shortcuts: \`--markdown\` / \`--json\` / \`--xml\`

Canonical \`-f / --format\` stays (so future formats like html / jsonl can ride on it without inventing yet another shortcut), but the three frequent values get aliases:

\`\`\`bash
pdfvision doc.pdf --json       # shortcut
pdfvision doc.pdf -f json      # canonical still works
\`\`\`

Conflict resolution is **strict**, not last-wins:

| input | result |
|---|---|
| \`--json --xml\` | error: \"Output format specified multiple times\" |
| \`--json -f xml\` | error: \"Output format conflict\" |
| \`--json -f json\` | OK (idempotent; harmless redundancy for scripts that compose flags from multiple sources) |

### \`--strip-repeated\` for Markdown

Default Markdown emits pdf.js's flat \`page.text\` verbatim, including running headers / footers / page numbers on every page — noise for LLM readers. JSON / XML already expose \`repeated: true\` on each layout block. Markdown lacked the equivalent.

\`\`\`bash
pdfvision report.pdf --layout --strip-repeated
\`\`\`

When set, the per-page body is rebuilt from non-repeated layout blocks instead of pdf.js's flat text.

- Requires \`--layout\` (the \`repeated: true\` flag is only set during the cross-page layout pass).
- Only applies to Markdown output. Passing with \`--json\` / \`--xml\` is an error rather than a silent no-op, so the user notices the flag had no effect.

## Implementation notes

- New \`MarkdownOptions { stripRepeated }\` interface on the formatter. JSON / XML formatters unchanged.
- \`ProcessOptions.stripRepeated?: boolean\` added. \`processFile\` validates the layout dependency **before** extraction starts so users don't pay seconds of pdf.js work just to hit a render-time rejection.
- CLI reconciles alias + canonical \`-f\` and passes one resolved \`format\` downstream — no leak of the alias mechanism into the library API.
- Help text + examples updated.

## Test plan

- [x] 8 new CLI tests: alias for each format, two-alias conflict, alias-vs-\`-f\` conflict, idempotent same-value, strip without layout, strip with non-markdown
- [x] 3 new Markdown formatter tests: stripRepeated removes footer block, default leaves body untouched, missing-layout throws
- [x] \`npm run lint\` clean
- [x] \`npm run test\` 254/254 passing (was 243)
- [x] Smoke test: \`node dist/bin/pdfvision.mjs sample.pdf --json --no-cache\` works, \`--json --xml\` errors, help text shows the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)