### PR TITLE
chore(release): v0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Bump version `0.7.0` → `0.7.1` ahead of the v0.7.1 release.

After merge, this branch's commit becomes the target of the `v0.7.1` tag and the `npm-publish` workflow can be dispatched.

## What's in v0.7.1

### Smaller, cleaner library surface

`src/index.ts` no longer re-exports internal cache primitives (`getCacheDir` / `getCached` / `setCache`) or the pdf.js-backed renderer entry points (`renderPage` / `renderPages`). Those had no documented contract, gave callers a way to corrupt the on-disk cache, and made pdf.js the de-facto public type of pdfvision. They live under `src/core/*` for internal use only now.

`PageQuality` is now exported by name (was previously only inferable through `PageResult.quality`).

Public surface:

```
Functions:  parsePageRange, processDocument, processFile
Types:      DocumentMetadata, DocumentResult, ImageBox, LayoutBlock,
            LayoutLine, OutputFormat, PageLayout, PageOcr, PageOverview,
            PageQuality, PageResult, ProcessDocumentOptions,
            ProcessOptions, TextSpan
```

### CLI format shortcuts: `--markdown` / `--json` / `--xml`

```bash
pdfvision doc.pdf --json       # shortcut for --format json
pdfvision doc.pdf -f json      # canonical still works
```

Conflict resolution is strict (not last-wins):

| input | result |
|---|---|
| `--json --xml` | error: "Output format specified multiple times" |
| `--json -f xml` | error: "Output format conflict" |
| `--json -f json` | OK (idempotent) |

### `--strip-repeated` for Markdown

```bash
pdfvision report.pdf --layout --strip-repeated
```

Drops running headers / footers / page numbers (the cross-page layout pass already tags them as `repeated: true` in JSON / XML output) from the rendered Markdown body so an LLM doesn't have to re-read the same footer N times. Requires `--layout`. Markdown only — passing it with `--json` / `--xml` is an error rather than a silent no-op, both in the CLI and via the library's `processFile`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 256/256 passing
- [x] `npm run build` succeeds
- [ ] After merge: create GitHub release tag `v0.7.1` + dispatch `npm-publish` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)