### PR TITLE
feat(core): --render-scale + heading roleConfidence + NFKC docs (P3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Options:
   -r, --render            Render pages as PNG images
       --render-output <dir>
                           Directory for rendered PNGs (requires --render)
+      --render-scale <n>  Rasterisation multiplier (default 2; bounds (0, 4]). Requires --render or --ocr.
       --geometry          Emit per-text-item bbox + font size in pages[].spans (json/xml)
       --layout            Reconstruct lines + blocks (with role / repeated flags) in pages[].layout
       --image-boxes       Emit per-image bbox in pages[].imageBoxes
@@ -70,7 +71,9 @@ Options:
       --ocr-lang <lang>   Tesseract lang(s), plus-separated (e.g. eng+jpn). Default: eng
       --remote <url>      Download an http(s) PDF into the cache, then extract
       --no-cache          Skip the on-disk cache
-      --no-normalize      Disable Unicode NFKC normalization (default: on)
+      --no-normalize      Disable Unicode NFKC normalization (default: on; pre-normalization text
+                          is preserved in JSON/XML \`rawText\` only when normalization changed
+                          the string — pass this if you need raw codepoints in markdown too)
       --clear-cache       Wipe every cached extraction, render, and remote download, then exit
   -v, --version           Show version
   -h, --help              Show this help

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -41,6 +41,7 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         xml: { type: 'boolean' },
         render: { type: 'boolean', short: 'r' },
         'render-output': { type: 'string' },
+        'render-scale': { type: 'string' },
         'no-cache': { type: 'boolean' },
         'no-normalize': { type: 'boolean' },
         geometry: { type: 'boolean' },
@@ -134,6 +135,26 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     exitWithError('--render-output requires --render');
   }
 
+  // --render-scale parses as a number with explicit error messaging so
+  // the user sees the actual bounds (0, 4] instead of a generic NaN
+  // failure inside the processor. Allows --ocr-only scale changes too
+  // (OCR's internal rasterise respects the scale), so we don't gate
+  // on --render here.
+  const renderScaleRaw = values['render-scale'] as string | undefined;
+  let renderScale: number | undefined;
+  if (renderScaleRaw !== undefined) {
+    if (!render && !(values.ocr as boolean | undefined)) {
+      // No rasterisation will actually happen; the flag silently does
+      // nothing. Failing loudly mirrors the --render-output relationship.
+      exitWithError('--render-scale requires --render or --ocr');
+    }
+    const parsed = Number(renderScaleRaw);
+    if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 4) {
+      exitWithError(`Invalid --render-scale "${renderScaleRaw}": expected a number in (0, 4]`);
+    }
+    renderScale = parsed;
+  }
+
   const layout = (values.layout as boolean | undefined) ?? false;
   const stripRepeated = (values['strip-repeated'] as boolean | undefined) ?? false;
   if (stripRepeated && !layout) {
@@ -179,6 +200,7 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
       format,
       render,
       renderOutput,
+      renderScale,
       noCache,
       // NFKC normalization is on by default — agents almost always want
       // canonical Unicode. --no-normalize lets callers opt out for cases

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -25,8 +25,14 @@ Options
       --render-output <dir>
                           Directory to write rendered PNGs into, created if missing. Requires --render.
                           Without this, PNGs land under the cache (or OS tmp with --no-cache).
+      --render-scale <n>  Rasterisation multiplier for --render / --ocr. Default 2 (≈144 DPI on a
+                          letter page). Smaller values shrink the PNG (and vision-model payload);
+                          larger values capture more detail. Accepts decimals; bounds (0, 4].
       --no-normalize      Disable Unicode NFKC normalization. Default ON; pre-normalization text is
                           surfaced in \`rawText\` (json/xml) when normalization changed the string.
+                          Markdown output shows only the normalized form — pass --no-normalize if
+                          original codepoint fidelity (e.g. fullwidth punctuation \`（\`, ligatures
+                          \`ﬁ\`) matters for downstream diff / forensics.
       --geometry          Emit per-text-item bbox + font size in \`pages[].spans\`.
                           Only takes effect with -f json or -f xml.
       --layout            Reconstruct \`pages[].layout\` (lines + blocks in approximate
@@ -66,6 +72,7 @@ Examples
   pdfvision document.pdf --json                                                # JSON shortcut
   pdfvision document.pdf -p 1-3 --json                                         # specific pages, JSON
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
+  pdfvision slides.pdf -r --render-scale 1                                     # 1× raster (smaller PNGs)
   pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry --json    # PNGs + spans for 3-5
   pdfvision slides.pdf --xml --geometry                                        # layout / geometry as XML
   pdfvision report.pdf --layout --strip-repeated                               # markdown w/o repeated chrome

--- a/src/core/layout.ts
+++ b/src/core/layout.ts
@@ -202,6 +202,27 @@ function classifyHeadings(blocks: LayoutBlock[]): void {
     dominantFs.set(b, fontWeights.length > 0 ? median(fontWeights) : (b.lines[0]?.fontSize ?? bodyFontSize));
   }
 
+  // Map a heading block's geometric features to a 0..1 confidence. Used
+  // to populate `roleConfidence` whenever a block is classified — agents
+  // that want a high-precision slice can threshold (e.g. `>= 0.7`) instead
+  // of relying on the discrete `level`. The formula is intentionally
+  // simple and inspectable: half the score comes from how far the
+  // candidate's fontSize sits above body (saturating at ratio 1.5), the
+  // other half from how many of the 4 structural gates passed (each
+  // worth 0.125). See LayoutBlock.roleConfidence in types/index.ts for
+  // the band guidance that surfaces in JSDoc.
+  const computeRoleConfidence = (
+    ratio: number,
+    isShort: boolean,
+    standalone: boolean,
+    locallyLarger: boolean,
+    singleLine: boolean,
+  ): number => {
+    const fontRatioScore = Math.max(0, Math.min(1, (ratio - 1.0) / 0.5));
+    const passed = (isShort ? 1 : 0) + (standalone ? 1 : 0) + (locallyLarger ? 1 : 0) + (singleLine ? 1 : 0);
+    return Math.round((0.5 * fontRatioScore + 0.125 * passed) * 100) / 100;
+  };
+
   for (const b of blocks) {
     const repFont = b.lines[0]?.fontSize ?? bodyFontSize;
     const ratio = repFont / bodyFontSize;
@@ -247,12 +268,14 @@ function classifyHeadings(blocks: LayoutBlock[]): void {
     const neighbours = [above, below].filter((n): n is LayoutBlock => n !== undefined);
     const locallyLarger = neighbours.every((n) => repFont > (dominantFs.get(n) ?? bodyFontSize));
 
+    const singleLine = lineCount === 1;
     if (ratio >= 1.4) {
       // Level 1: titles. Always classify, even on poster/slide pages with
       // no body text — losing the title hurts more than a rare false
       // positive on a page that's nothing but a single big word.
       b.role = 'heading';
       b.level = 1;
+      b.roleConfidence = computeRoleConfidence(ratio, isShort, standalone, locallyLarger, singleLine);
     } else if (ratio >= 1.25) {
       // Level 2 (legacy band). The historical 1.25× rule, kept intact
       // except for one new guard: if the page lacks a credible body, we
@@ -260,6 +283,7 @@ function classifyHeadings(blocks: LayoutBlock[]): void {
       if (!hasCredibleBody) continue;
       b.role = 'heading';
       b.level = 2;
+      b.roleConfidence = computeRoleConfidence(ratio, isShort, standalone, locallyLarger, singleLine);
     } else if (ratio >= 1.15) {
       // Level 2 (structural band). Catches arxiv-style 12pt section
       // headings over 10pt body. Requires the page to have real body
@@ -270,6 +294,7 @@ function classifyHeadings(blocks: LayoutBlock[]): void {
       if (!standalone && !locallyLarger) continue;
       b.role = 'heading';
       b.level = 2;
+      b.roleConfidence = computeRoleConfidence(ratio, isShort, standalone, locallyLarger, singleLine);
     } else {
       // Level 3 (subsection band). Strict gates — short + single-line +
       // locally-larger-than-same-column-neighbours + credible body. The
@@ -286,6 +311,7 @@ function classifyHeadings(blocks: LayoutBlock[]): void {
       if (!locallyLarger) continue;
       b.role = 'heading';
       b.level = 3;
+      b.roleConfidence = computeRoleConfidence(ratio, isShort, standalone, locallyLarger, singleLine);
     }
   }
 }
@@ -600,6 +626,7 @@ export function markRepeatedBlocks(pages: PageResult[]): void {
       if (block.role === 'heading') {
         block.role = undefined;
         block.level = undefined;
+        block.roleConfidence = undefined;
       }
     }
   }

--- a/src/core/ocr.ts
+++ b/src/core/ocr.ts
@@ -125,6 +125,7 @@ export async function attachOcr(
   pages: { ocr?: PageOcr; renderContentRatio?: number }[],
   lang: string,
   imagePaths?: (string | undefined)[],
+  scale?: number,
 ): Promise<void> {
   // Canonicalise whitespace / stray separators so ` eng + jpn ` and
   // `eng+jpn` end up with the same echoed `ocr.lang`. Order is preserved
@@ -148,7 +149,7 @@ export async function attachOcr(
       if (cachedImage) {
         png = await readFile(cachedImage);
       } else {
-        const rasterised = await renderPageToBuffer(doc, pageNumbers[i]);
+        const rasterised = await renderPageToBuffer(doc, pageNumbers[i], scale);
         png = rasterised.buffer;
         contentRatio = rasterised.contentRatio;
       }

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -56,15 +56,17 @@ const MAX_RENDER_SCALE = 4;
  */
 function validateRenderScale(scale: number | undefined): number | undefined {
   if (scale === undefined) return undefined;
-  if (!Number.isFinite(scale)) {
+  // Gate against the upper bound on the raw value — otherwise `4.004`
+  // would round to `4` and slip past the cap, contradicting both the
+  // JSDoc contract and the CLI's pre-round rejection.
+  if (!Number.isFinite(scale) || scale > MAX_RENDER_SCALE) {
     throw new Error(`Invalid renderScale ${scale}: expected a finite number in (0, ${MAX_RENDER_SCALE}]`);
   }
-  // Round before the range gate so a value like `0.004` (which would
-  // otherwise pass `> 0`, then round to `0`, then ship `0` to the
-  // renderer) is rejected up front instead of silently breaking the
-  // (0, 4] invariant downstream.
   const rounded = Math.round(scale * 100) / 100;
-  if (rounded <= 0 || rounded > MAX_RENDER_SCALE) {
+  // Gate against the lower bound on the rounded value — `0.004` would
+  // otherwise pass `> 0`, round to `0`, and ship `scale: 0` to the
+  // renderer. Both gates together pin the rounded result to (0, MAX].
+  if (rounded <= 0) {
     throw new Error(`Invalid renderScale ${scale}: expected a finite number in (0, ${MAX_RENDER_SCALE}]`);
   }
   return rounded;

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -31,12 +31,41 @@ interface CacheKeyInput {
   pages?: string;
   render?: boolean;
   renderOutput?: string;
+  renderScale?: number;
   normalize?: boolean;
   geometry?: boolean;
   layout?: boolean;
   imageBoxes?: boolean;
   ocr?: boolean;
   ocrLang?: string;
+}
+
+/** Default rasterisation multiplier — must match renderer.ts DEFAULT_SCALE. */
+const DEFAULT_RENDER_SCALE = 2;
+/** Hard cap: 4× a letter page is 2448×3168px, ~7.7Mpx. Higher invites OOM. */
+const MAX_RENDER_SCALE = 4;
+
+/**
+ * Validate a user-supplied `renderScale`. Rejects non-finite values, ≤ 0
+ * scales, and scales above {@link MAX_RENDER_SCALE}. Returns the validated
+ * number unchanged so callers can chain it inline.
+ */
+function validateRenderScale(scale: number | undefined): number | undefined {
+  if (scale === undefined) return undefined;
+  if (!Number.isFinite(scale) || scale <= 0 || scale > MAX_RENDER_SCALE) {
+    throw new Error(`Invalid renderScale ${scale}: expected a finite number in (0, ${MAX_RENDER_SCALE}]`);
+  }
+  return scale;
+}
+
+/**
+ * Format the scale for use as a filesystem path component. Trims trailing
+ * zeros so `2.0` → `2` (keeps the default path stable when callers pass
+ * the default explicitly) and `1.50` → `1.5`. Rounds to 2dp first to
+ * keep e.g. `1.234567` from minting unique cache dirs per FP-noise tick.
+ */
+function scaleDirSuffix(scale: number): string {
+  return `s${(Math.round(scale * 100) / 100).toString()}`;
 }
 
 /**
@@ -52,11 +81,17 @@ function buildCacheKey(input: CacheKeyInput): string {
     pages: input.pages ?? 'all',
     // Bump when the on-disk DocumentResult shape changes so older entries
     // (missing newly-added page fields) are not handed out as fresh results.
-    format: 'structured-v14',
+    format: 'structured-v15',
     render: !!input.render,
     // Including the resolved render-output dir keeps two invocations with
     // different `--render-output` targets from sharing image paths.
     renderOutput: input.renderOutput ? resolve(input.renderOutput) : null,
+    // Different `renderScale` values change `pages[].image` content and
+    // `renderContentRatio` (anti-aliasing shifts the histogram); key
+    // separately so a 1.5× run doesn't return a cached 2.0× payload.
+    // `null` for the off path so non-render extractions still hit a
+    // shared slot regardless of the value the caller passed.
+    renderScale: input.render || input.ocr ? (input.renderScale ?? DEFAULT_RENDER_SCALE) : null,
     // Normalized vs raw text are different payloads; key them separately so
     // toggling the flag doesn't return stale text.
     normalize: input.normalize !== false,
@@ -358,6 +393,11 @@ function dropCachedSafe(cacheDir: string, cacheKey: string): void {
  * For the formatted (string) variant used by the CLI, see {@link processFile}.
  */
 export async function processDocument(filePath: string, options: ProcessDocumentOptions = {}): Promise<DocumentResult> {
+  // Reject malformed renderScale up front — before fingerprint hashing
+  // or pdfjs load — so callers see the error fast even when --render
+  // isn't on (the validation is cheap and a leftover flag in a script
+  // shouldn't be quietly ignored).
+  const renderScale = validateRenderScale(options.renderScale);
   // Compute the per-PDF fingerprint up front when any code path below
   // needs it (caching, or render output isolation). Hashing the file is
   // the most expensive sync step in this function, so do it once and
@@ -367,7 +407,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
   const fingerprint = needFingerprint ? pdfFingerprint(filePath) : null;
   const cacheDir = options.noCache ? null : getCacheDir(filePath, fingerprint ?? undefined);
 
-  const cacheKey = buildCacheKey(options);
+  const cacheKey = buildCacheKey({ ...options, renderScale });
   if (cacheDir) {
     const cached = getCached(cacheDir, cacheKey);
     if (cached) {
@@ -481,6 +521,12 @@ export async function processDocument(filePath: string, options: ProcessDocument
     let renderRatios: (number | undefined)[] = [];
     if (options.render) {
       let imagesDir: string;
+      // Non-default scales sit in their own subdir so different scales
+      // don't share `page-N.png` filenames and stomp each other's bytes.
+      // Keeping the default (2.0) on the legacy path preserves existing
+      // user paths under `--render-output ./images/<fp>/page-N.png`.
+      const effectiveScale = renderScale ?? DEFAULT_RENDER_SCALE;
+      const scaleSubdir = effectiveScale === DEFAULT_RENDER_SCALE ? null : scaleDirSuffix(effectiveScale);
       if (options.renderOutput) {
         // User-supplied path: don't enforce 0o700 here — the caller owns
         // their output directory and may need it readable for downstream
@@ -497,7 +543,9 @@ export async function processDocument(filePath: string, options: ProcessDocument
         // `needFingerprint` above forces a hash whenever
         // `render && renderOutput`, so `fingerprint` is non-null on
         // this branch — assert rather than re-hash.
-        imagesDir = join(baseDir, fingerprint as string);
+        imagesDir = scaleSubdir
+          ? join(baseDir, fingerprint as string, scaleSubdir)
+          : join(baseDir, fingerprint as string);
         // `recursive: true` creates baseDir too if missing, so the
         // separate `mkdirSync(baseDir)` would be redundant.
         mkdirSync(imagesDir, { recursive: true });
@@ -519,7 +567,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
           throw new Error(`Refusing to render into ${imagesDir}: path exists but is not a directory`);
         }
       } else if (cacheDir) {
-        imagesDir = join(cacheDir, 'images');
+        imagesDir = scaleSubdir ? join(cacheDir, 'images', scaleSubdir) : join(cacheDir, 'images');
         ensurePrivateDir(imagesDir);
       } else {
         // mkdtemp creates with 0o700 by default and never reuses an existing
@@ -530,7 +578,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
       // renderer pulls in @napi-rs/canvas (native binding); only load it
       // when --render is requested.
       const { renderPagesWithStats } = await import('./renderer.js');
-      const rendered = await renderPagesWithStats(doc, pageNumbers, imagesDir);
+      const rendered = await renderPagesWithStats(doc, pageNumbers, imagesDir, renderScale);
       imagePaths = rendered.map((r) => r.path);
       renderRatios = rendered.map((r) => r.contentRatio);
     }
@@ -626,7 +674,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
       // and `--ocr` are on. attachOcr falls back to its own pdf.js
       // raster for any slot where the path is missing (no `--render`,
       // or a cache-hit slot that returned `contentRatio: undefined`).
-      await attachOcr(doc, pageNumbers, pages, ocrLang, imagePaths ?? undefined);
+      await attachOcr(doc, pageNumbers, pages, ocrLang, imagePaths ?? undefined, renderScale);
     }
 
     // Compute the derived `quality` field *after* OCR so the OCR-only
@@ -722,6 +770,7 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
     render: options.render,
     noCache: options.noCache,
     renderOutput: options.renderOutput,
+    renderScale: options.renderScale,
     normalize: options.normalize,
     geometry: options.geometry,
     layout: options.layout,

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -56,10 +56,18 @@ const MAX_RENDER_SCALE = 4;
  */
 function validateRenderScale(scale: number | undefined): number | undefined {
   if (scale === undefined) return undefined;
-  if (!Number.isFinite(scale) || scale <= 0 || scale > MAX_RENDER_SCALE) {
+  if (!Number.isFinite(scale)) {
     throw new Error(`Invalid renderScale ${scale}: expected a finite number in (0, ${MAX_RENDER_SCALE}]`);
   }
-  return Math.round(scale * 100) / 100;
+  // Round before the range gate so a value like `0.004` (which would
+  // otherwise pass `> 0`, then round to `0`, then ship `0` to the
+  // renderer) is rejected up front instead of silently breaking the
+  // (0, 4] invariant downstream.
+  const rounded = Math.round(scale * 100) / 100;
+  if (rounded <= 0 || rounded > MAX_RENDER_SCALE) {
+    throw new Error(`Invalid renderScale ${scale}: expected a finite number in (0, ${MAX_RENDER_SCALE}]`);
+  }
+  return rounded;
 }
 
 /**

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -46,26 +46,30 @@ const DEFAULT_RENDER_SCALE = 2;
 const MAX_RENDER_SCALE = 4;
 
 /**
- * Validate a user-supplied `renderScale`. Rejects non-finite values, ≤ 0
- * scales, and scales above {@link MAX_RENDER_SCALE}. Returns the validated
- * number unchanged so callers can chain it inline.
+ * Validate and canonicalise a user-supplied `renderScale`. Rejects
+ * non-finite values, ≤ 0 scales, and scales above {@link MAX_RENDER_SCALE},
+ * then rounds to 2dp so the same value flows through cache keys, render
+ * calls, and path composition. Without the rounding step `1.23` and
+ * `1.234` would hash to different cache slots but collapse onto the
+ * same `s1.23` PNG subdir, and the renderer would hand back the first
+ * call's bytes for the second.
  */
 function validateRenderScale(scale: number | undefined): number | undefined {
   if (scale === undefined) return undefined;
   if (!Number.isFinite(scale) || scale <= 0 || scale > MAX_RENDER_SCALE) {
     throw new Error(`Invalid renderScale ${scale}: expected a finite number in (0, ${MAX_RENDER_SCALE}]`);
   }
-  return scale;
+  return Math.round(scale * 100) / 100;
 }
 
 /**
- * Format the scale for use as a filesystem path component. Trims trailing
- * zeros so `2.0` → `2` (keeps the default path stable when callers pass
- * the default explicitly) and `1.50` → `1.5`. Rounds to 2dp first to
- * keep e.g. `1.234567` from minting unique cache dirs per FP-noise tick.
+ * Format the scale for use as a filesystem path component. Assumes the
+ * input is already rounded to 2dp via {@link validateRenderScale};
+ * `Number.toString()` then drops trailing zeros so `2` → `s2` and
+ * `1.5` → `s1.5`.
  */
 function scaleDirSuffix(scale: number): string {
-  return `s${(Math.round(scale * 100) / 100).toString()}`;
+  return `s${scale.toString()}`;
 }
 
 /**
@@ -543,12 +547,6 @@ export async function processDocument(filePath: string, options: ProcessDocument
         // `needFingerprint` above forces a hash whenever
         // `render && renderOutput`, so `fingerprint` is non-null on
         // this branch — assert rather than re-hash.
-        imagesDir = scaleSubdir
-          ? join(baseDir, fingerprint as string, scaleSubdir)
-          : join(baseDir, fingerprint as string);
-        // `recursive: true` creates baseDir too if missing, so the
-        // separate `mkdirSync(baseDir)` would be redundant.
-        mkdirSync(imagesDir, { recursive: true });
         // The fingerprint subdir name is deterministic (same PDF →
         // same name) and now sits inside a user-controlled directory
         // we explicitly do NOT lock down to 0700. In a shared writable
@@ -559,12 +557,34 @@ export async function processDocument(filePath: string, options: ProcessDocument
         // going if the path is a symlink or somehow not a directory,
         // matching the same posture `ensurePrivateDir` enforces for
         // the cache hierarchy.
-        const imagesDirStat = lstatSync(imagesDir);
-        if (imagesDirStat.isSymbolicLink()) {
-          throw new Error(`Refusing to render into ${imagesDir}: path is a symlink`);
-        }
-        if (!imagesDirStat.isDirectory()) {
-          throw new Error(`Refusing to render into ${imagesDir}: path exists but is not a directory`);
+        //
+        // When `scaleSubdir` is set we also have to check the
+        // *intermediate* fingerprint dir: a planted symlink there
+        // would otherwise be followed by `mkdirSync({recursive:true})`
+        // for the scale subdir, leaving the final lstat on a real
+        // directory at the symlink's target and bypassing the check.
+        // So: assert the fingerprint dir first, then create + assert
+        // the scale subdir on top.
+        const fingerprintDir = join(baseDir, fingerprint as string);
+        // `recursive: true` creates baseDir too if missing, so the
+        // separate `mkdirSync(baseDir)` would be redundant.
+        mkdirSync(fingerprintDir, { recursive: true });
+        const assertSafeDir = (dir: string): void => {
+          const stat = lstatSync(dir);
+          if (stat.isSymbolicLink()) {
+            throw new Error(`Refusing to render into ${dir}: path is a symlink`);
+          }
+          if (!stat.isDirectory()) {
+            throw new Error(`Refusing to render into ${dir}: path exists but is not a directory`);
+          }
+        };
+        assertSafeDir(fingerprintDir);
+        if (scaleSubdir) {
+          imagesDir = join(fingerprintDir, scaleSubdir);
+          mkdirSync(imagesDir, { recursive: true });
+          assertSafeDir(imagesDir);
+        } else {
+          imagesDir = fingerprintDir;
         }
       } else if (cacheDir) {
         imagesDir = scaleSubdir ? join(cacheDir, 'images', scaleSubdir) : join(cacheDir, 'images');

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -597,8 +597,21 @@ export async function processDocument(filePath: string, options: ProcessDocument
           imagesDir = fingerprintDir;
         }
       } else if (cacheDir) {
-        imagesDir = scaleSubdir ? join(cacheDir, 'images', scaleSubdir) : join(cacheDir, 'images');
-        ensurePrivateDir(imagesDir);
+        // Lock down the intermediate `images/` first, then the scale
+        // subdir (when present), matching the per-level pattern in
+        // ocr.ts. mkdirSync({recursive:true}) only applies the
+        // requested mode to the leaf — without an explicit
+        // ensurePrivateDir on the parent the `images/` perms would
+        // fall back to umask defaults (0755) even though the rest of
+        // the cache hierarchy is 0700.
+        const baseImagesDir = join(cacheDir, 'images');
+        ensurePrivateDir(baseImagesDir);
+        if (scaleSubdir) {
+          imagesDir = join(baseImagesDir, scaleSubdir);
+          ensurePrivateDir(imagesDir);
+        } else {
+          imagesDir = baseImagesDir;
+        }
       } else {
         // mkdtemp creates with 0o700 by default and never reuses an existing
         // path, so it sidesteps the symlink/ownership concerns for the

--- a/src/output/xml.ts
+++ b/src/output/xml.ts
@@ -118,6 +118,7 @@ export function formatXml(result: DocumentResult): string {
           const blockAttrs = [`x="${block.x}"`, `y="${block.y}"`, `width="${block.width}"`, `height="${block.height}"`];
           if (block.role) blockAttrs.push(`role="${block.role}"`);
           if (block.level !== undefined) blockAttrs.push(`level="${block.level}"`);
+          if (block.roleConfidence !== undefined) blockAttrs.push(`roleConfidence="${block.roleConfidence}"`);
           if (block.repeated) blockAttrs.push('repeated="true"');
           out.push(`<block ${blockAttrs.join(' ')}>`);
           for (const line of block.lines) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,12 +19,37 @@ export interface ProcessDocumentOptions {
    */
   renderOutput?: string;
   /**
+   * Multiplier applied to the PDF's intrinsic page size when rasterising
+   * (`--render` and `--ocr`). `2` (the default) renders a 612×792 letter
+   * page at 1224×1584 — readable by vision models without losing detail.
+   * Smaller values trade fidelity for payload size (a 1.0× page is roughly
+   * a quarter the bytes of the 2.0× default and is sufficient for most
+   * agentic-vision dispatch tasks). Values outside (0, 4] throw — 4× is
+   * 16× the pixel count and a soft ceiling against accidental OOM.
+   *
+   * Affects both `pages[].image` (the on-disk PNG) and `renderContentRatio`
+   * (the same raster is what the ratio scan runs on). Different scales
+   * cache separately and write to distinct directories so back-to-back
+   * runs at different scales don't clobber each other.
+   */
+  renderScale?: number;
+  /**
    * Apply Unicode NFKC normalization to extracted text and metadata strings.
    * Defaults to `true`. PDFs (especially Japanese ones produced by Office /
    * iWork) frequently embed compatibility codepoints like `⽬` (U+2F6C) in
    * place of `目` (U+76EE), which silently break grep / diff / structured
-   * extraction downstream. Pass `false` if you specifically need the raw
-   * code points emitted by pdf.js.
+   * extraction downstream. NFKC also folds fullwidth punctuation (`（` → `(`),
+   * ligatures (`ﬁ` → `fi`), and halfwidth/fullwidth digit variants.
+   *
+   * When the normalization actually changes the page text, the
+   * pre-normalization form is preserved on `pages[].rawText` (json / xml
+   * outputs) so callers can diff the two without re-running with
+   * `normalize: false`. Markdown output only renders the normalized form
+   * — pass `normalize: false` if original codepoint fidelity matters for
+   * downstream diff / forensics / glyph-level audit.
+   *
+   * Pass `false` if you specifically need the raw code points emitted by
+   * pdf.js (e.g. a forensic tool inspecting how the PDF was authored).
    */
   normalize?: boolean;
   /**
@@ -82,6 +107,8 @@ export interface ProcessOptions {
   noCache: boolean;
   render?: boolean;
   renderOutput?: string;
+  /** See {@link ProcessDocumentOptions.renderScale}. */
+  renderScale?: number;
   normalize?: boolean;
   geometry?: boolean;
   layout?: boolean;
@@ -198,6 +225,26 @@ export interface LayoutBlock {
    * extraction is `level === 1`.
    */
   level?: 1 | 2 | 3;
+  /**
+   * Heuristic confidence in the `role: 'heading'` classification on a
+   * 0–1 scale (rounded to 2dp). Present only when `role === 'heading'`.
+   *
+   * The classifier is feature-based (font-size ratio, isShort, standalone,
+   * locally-larger-than-neighbours), not statistical — `roleConfidence`
+   * exposes how many of those features lined up rather than a calibrated
+   * probability. Useful when an agent needs to threshold (e.g. only treat
+   * `>= 0.7` as a section anchor) instead of relying on the discrete
+   * `level` tier. The two fields are correlated by construction —
+   * higher levels imply higher confidence — but the threshold value is
+   * the agent's call.
+   *
+   * Rough bands (subject to tuning; do NOT hard-code exact values):
+   *   - `>= 0.85` — clear title / top-of-section heading (level 1, or
+   *     level 2 with every structural gate passing).
+   *   - `0.60–0.85` — solid section heading with most gates passing.
+   *   - `< 0.60` — recall-oriented level-3 subsection candidates.
+   */
+  roleConfidence?: number;
   /**
    * `true` when this block appears at the same vertical position with the
    * same text on enough other pages to look like a running header, footer,

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -187,6 +187,27 @@ describe('cli', () => {
     expect(r.stderr.join('\n')).toMatch(/--render-output requires --render/);
   });
 
+  it('rejects --render-scale without --render or --ocr', async () => {
+    // Same posture as --render-output: silently ignoring a flag the user
+    // explicitly passed would hide misconfiguration.
+    const r = await captureRun([SAMPLE_PDF, '--render-scale', '1.5']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--render-scale requires --render or --ocr/);
+  });
+
+  it('rejects --render-scale outside (0, 4]', async () => {
+    // Upper bound: 4× a letter page is already ~7.7Mpx; higher invites OOM.
+    const r = await captureRun([SAMPLE_PDF, '--render', '--render-scale', '10']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/Invalid --render-scale.*\(0, 4\]/);
+  });
+
+  it('rejects non-numeric --render-scale', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--render', '--render-scale', 'huge']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/Invalid --render-scale/);
+  });
+
   it('surfaces processor errors as a clean CLI error', async () => {
     // Invalid pages selector — processor throws, CLI should turn that into
     // exit(1) + stderr message instead of an unhandled rejection.

--- a/tests/core/layout.unit.test.ts
+++ b/tests/core/layout.unit.test.ts
@@ -129,6 +129,62 @@ describe('buildLayout — heading classification', () => {
     expect(title?.role).toBe('heading');
     expect(title?.level).toBe(1);
   });
+
+  it('attaches a 0..1 roleConfidence whenever a block is classified as heading', () => {
+    // The number is the agent-facing knob for threshold-based dispatch
+    // ("only treat >= 0.7 as a section anchor"). Pinning to a specific
+    // value would be brittle, but the field must (a) exist for every
+    // heading and (b) sit in [0, 1].
+    const spans: TextSpan[] = [
+      span('Title', 50, 50, 30, 100),
+      span('First sentence of body content that anchors the median.', 50, 100, 11),
+      span('Second sentence keeps the body weighting high.', 50, 115, 11),
+      span('Third sentence pushes char count above credible body.', 50, 130, 11),
+    ];
+    const layout = buildLayout(spans);
+    const title = layout.blocks.find((b) => b.text.includes('Title'));
+    expect(title?.role).toBe('heading');
+    expect(title?.roleConfidence).toBeTypeOf('number');
+    expect(title?.roleConfidence ?? 0).toBeGreaterThan(0);
+    expect(title?.roleConfidence ?? 0).toBeLessThanOrEqual(1);
+  });
+
+  it('does not attach roleConfidence to blocks that are not headings', () => {
+    // Negative complement to the heading-confidence test — body blocks
+    // must come back with the field absent so consumers can tell "no
+    // role" from "low-confidence role".
+    const spans: TextSpan[] = [
+      span('Body line one stays at the body fontSize.', 50, 50, 12),
+      span('Body line two keeps the page uniformly body.', 50, 70, 12),
+    ];
+    const layout = buildLayout(spans);
+    for (const block of layout.blocks) {
+      expect(block.roleConfidence).toBeUndefined();
+    }
+  });
+
+  it('reports higher roleConfidence for clear titles than for borderline subheadings', () => {
+    // Ordering is the agent-facing contract: an agent thresholding at
+    // 0.7 should reliably pick up clear titles and reliably drop
+    // borderline level-3 subsections, regardless of exact numeric values.
+    const titleSpans: TextSpan[] = [
+      span('Big Bold Title', 50, 50, 30, 100),
+      span('First sentence of body content that anchors the median fontSize.', 50, 100, 11),
+      span('Second sentence keeps the body weighting clearly high.', 50, 115, 11),
+      span('Third sentence pushes char count above credible body.', 50, 130, 11),
+    ];
+    const subSpans: TextSpan[] = [];
+    subSpans.push(span('Body paragraph above the candidate subheading.', 50, 100, 10));
+    subSpans.push(span('3.1. Subsection', 50, 200, 11, 80));
+    for (let i = 0; i < 20; i++) {
+      subSpans.push(span('Body content sits underneath the subheading here.', 50, 220 + i * 10, 10));
+    }
+    const titleLayout = buildLayout(titleSpans);
+    const subLayout = buildLayout(subSpans);
+    const title = titleLayout.blocks.find((b) => b.text.includes('Big Bold Title'));
+    const sub = subLayout.blocks.find((b) => b.text.includes('Subsection'));
+    expect(title?.roleConfidence).toBeGreaterThan(sub?.roleConfidence ?? 1);
+  });
 });
 
 describe('buildLayout — multi-column reading order', () => {
@@ -304,6 +360,12 @@ describe('buildLayout — multi-column reading order', () => {
       makePage(2, 'Body of page 2'),
       makePage(3, 'Body of page 3'),
     ];
+    // Seed roleConfidence on the EN block so we can assert it's wiped
+    // along with role / level when the block is reclassified as chrome.
+    for (const page of pages) {
+      const en = page.layout?.blocks[0];
+      if (en) en.roleConfidence = 0.9;
+    }
     markRepeatedBlocks(pages);
     for (const page of pages) {
       const en = page.layout?.blocks[0];
@@ -311,6 +373,7 @@ describe('buildLayout — multi-column reading order', () => {
       expect(en?.repeated).toBe(true);
       expect(en?.role).toBeUndefined();
       expect(en?.level).toBeUndefined();
+      expect(en?.roleConfidence).toBeUndefined();
       // Body blocks (different text per page) stay non-repeated and
       // keep whatever role they had.
       expect(body?.repeated).toBeUndefined();

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -305,6 +305,37 @@ describe('processDocument', () => {
     }
   });
 
+  it('also refuses a pre-planted symlink at the intermediate fingerprint dir when renderScale forces a nested subdir', async () => {
+    // Regression: with `--render-scale` the imagesDir becomes
+    // `<renderOutput>/<fingerprint>/s<scale>`. `mkdirSync(...,
+    // { recursive: true })` follows a symlink at the intermediate
+    // `<fingerprint>` segment to plant the scale subdir at the
+    // attacker's target — and a final lstat on the deeper path then
+    // sees a regular dir at the target and lets the render proceed.
+    // The check must also assert the fingerprint dir before going
+    // deeper, otherwise non-default scales silently bypass the
+    // hardening that already guards the default-scale path above.
+    if (process.platform === 'win32') return;
+    const { mkdtempSync, mkdirSync, rmSync, symlinkSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { pdfFingerprint } = await import('../../src/core/cache.js');
+    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-scale-symlink-'));
+    const outDir = join(baseTmp, 'images');
+    const decoy = join(baseTmp, 'decoy');
+    mkdirSync(outDir, { recursive: true });
+    mkdirSync(decoy, { recursive: true });
+    const fp = pdfFingerprint(SAMPLE_PDF);
+    symlinkSync(decoy, join(outDir, fp));
+    try {
+      await expect(
+        processDocument(SAMPLE_PDF, { render: true, renderOutput: outDir, renderScale: 1, noCache: true }),
+      ).rejects.toThrow(/symlink/);
+    } finally {
+      rmSync(baseTmp, { recursive: true, force: true });
+    }
+  });
+
   it('produces the same DocumentResult that processFile then JSON.parse would', async () => {
     // Same content under both APIs is the contract.
     const direct = await processDocument(SAMPLE_PDF, { noCache: true });

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -102,6 +102,12 @@ describe('processDocument', () => {
     await expect(processDocument(SAMPLE_PDF, { render: true, renderScale: Number.NaN, noCache: true })).rejects.toThrow(
       /renderScale/,
     );
+    // Sub-rounding-tick value: `0.004` rounds to `0`, which would otherwise
+    // slip past a naive `> 0` gate done before rounding and ship `scale: 0`
+    // to the renderer. The validator must round first, then range-check.
+    await expect(processDocument(SAMPLE_PDF, { render: true, renderScale: 0.004, noCache: true })).rejects.toThrow(
+      /renderScale/,
+    );
   });
 
   it('renders a smaller PNG when renderScale is set below the default', async () => {

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -108,6 +108,13 @@ describe('processDocument', () => {
     await expect(processDocument(SAMPLE_PDF, { render: true, renderScale: 0.004, noCache: true })).rejects.toThrow(
       /renderScale/,
     );
+    // Upper-bound symmetry with the sub-tick floor test: `4.004` must
+    // be rejected on the *raw* value, not silently clamped to `4` via
+    // rounding. Otherwise the library API would accept inputs the CLI
+    // and the JSDoc explicitly reject.
+    await expect(processDocument(SAMPLE_PDF, { render: true, renderScale: 4.004, noCache: true })).rejects.toThrow(
+      /renderScale/,
+    );
   });
 
   it('renders a smaller PNG when renderScale is set below the default', async () => {

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -89,6 +89,65 @@ describe('processDocument', () => {
     expect(existsSync(result.pages[0].image as string)).toBe(true);
   });
 
+  it('rejects an out-of-range renderScale before extraction starts', async () => {
+    // The validator runs ahead of pdfjs load + hashing so a typo in a
+    // CI script fails fast rather than burning the extraction budget on
+    // an unusable scale value.
+    await expect(processDocument(SAMPLE_PDF, { render: true, renderScale: 0, noCache: true })).rejects.toThrow(
+      /renderScale/,
+    );
+    await expect(processDocument(SAMPLE_PDF, { render: true, renderScale: 10, noCache: true })).rejects.toThrow(
+      /renderScale/,
+    );
+    await expect(processDocument(SAMPLE_PDF, { render: true, renderScale: Number.NaN, noCache: true })).rejects.toThrow(
+      /renderScale/,
+    );
+  });
+
+  it('renders a smaller PNG when renderScale is set below the default', async () => {
+    // Geometry: scale ratio should propagate to the encoded PNG dimensions
+    // (1.0× → ~half the per-axis pixels of the default 2.0×). Use loadImage
+    // because PNG dimensions live in the IHDR chunk, no full decode needed.
+    const { loadImage } = await import('@napi-rs/canvas');
+    const def = await processDocument(SAMPLE_PDF, { render: true, noCache: true });
+    const small = await processDocument(SAMPLE_PDF, { render: true, renderScale: 1, noCache: true });
+    const defImg = await loadImage(def.pages[0].image as string);
+    const smallImg = await loadImage(small.pages[0].image as string);
+    // Roughly half on each axis (allow ±1 for rounding by the rasteriser).
+    expect(Math.abs(smallImg.width - defImg.width / 2)).toBeLessThanOrEqual(1);
+    expect(Math.abs(smallImg.height - defImg.height / 2)).toBeLessThanOrEqual(1);
+  });
+
+  it('isolates non-default renderScale output from the default-scale dir under renderOutput', async () => {
+    // Two scales must not stomp each other's PNGs. The non-default scale
+    // gets a `s<scale>` subdir so the default-scale path stays stable for
+    // existing user workflows.
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-scale-isolation-'));
+    try {
+      const def = await processDocument(SAMPLE_PDF, {
+        render: true,
+        renderOutput: baseTmp,
+        noCache: true,
+      });
+      const small = await processDocument(SAMPLE_PDF, {
+        render: true,
+        renderOutput: baseTmp,
+        renderScale: 1,
+        noCache: true,
+      });
+      expect(def.pages[0].image).not.toBe(small.pages[0].image);
+      // Non-default scale lives under an extra subdir.
+      expect((small.pages[0].image as string).split('/').filter(Boolean)).toEqual(
+        expect.arrayContaining([expect.stringMatching(/^s1$/)]),
+      );
+    } finally {
+      rmSync(baseTmp, { recursive: true, force: true });
+    }
+  });
+
   it('writes rendered PNGs into a per-PDF subdirectory of the caller-supplied renderOutput', async () => {
     // Agent ergonomics: with renderOutput the PNGs land under the caller's
     // chosen directory (created if missing) rather than tmp. They sit in a

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -137,7 +137,7 @@ describe('processDocument', () => {
     // existing user workflows.
     const { mkdtempSync, rmSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
-    const { join } = await import('node:path');
+    const { basename, dirname, join } = await import('node:path');
     const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-scale-isolation-'));
     try {
       const def = await processDocument(SAMPLE_PDF, {
@@ -152,10 +152,10 @@ describe('processDocument', () => {
         noCache: true,
       });
       expect(def.pages[0].image).not.toBe(small.pages[0].image);
-      // Non-default scale lives under an extra subdir.
-      expect((small.pages[0].image as string).split('/').filter(Boolean)).toEqual(
-        expect.arrayContaining([expect.stringMatching(/^s1$/)]),
-      );
+      // Non-default scale lives under an extra subdir. Use path utilities
+      // rather than a hardcoded `/` split so the assertion stays valid on
+      // Windows runners (where the separator is `\`).
+      expect(basename(dirname(small.pages[0].image as string))).toBe('s1');
     } finally {
       rmSync(baseTmp, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Closes the **P3** of the 3-PR follow-up to Codex's v0.7.0 usage feedback. P1 (CLI aliases + `--strip-repeated`) and P2 (geometry-driven `warnings[]`) already landed; this PR closes the three smaller pieces:

- **`--render-scale <n>`** — multiplier for `--render` and `--ocr` rasterisation. Default 2 (≈144 DPI on letter), bounds `(0, 4]`. Vision-model payloads at the default get expensive across many pages; agents can now dial it down. Non-default scales write into a `s<scale>` subdir so back-to-back runs at different scales don't clobber each other.
- **`LayoutBlock.roleConfidence?: number`** — 0..1 score (font-size ratio + 4 structural gates) attached whenever a block is classified as heading. `role: 'heading'` reads like a confident classification but is actually heuristic; agents can now threshold (`>= 0.7`) instead of relying solely on the discrete `level`. Wiped by `markRepeatedBlocks` alongside `role` / `level` when chrome is detected.
- **NFKC docs** — Codex reported that markdown output silently shows the normalised form (`（` → `(`, `ﬁ` → `fi`, ...) and that `rawText` (json/xml only) wasn't discoverable. Updated `--help`, README, and JSDoc on `ProcessDocumentOptions.normalize` to spell out the `--no-normalize` escape hatch.

Cache key bumped `structured-v14` → `structured-v15`.

## Codex review loop

Ran 3 rounds before opening this PR. Findings:

| Round | Sev | Finding | Outcome |
|---|---|---|---|
| 1 | HIGH | `mkdirSync({recursive:true})` followed a planted symlink at `<renderOutput>/<fingerprint>/` when `--render-scale` forced a nested subdir, bypassing the existing lstat hardening | Fixed: assert fingerprintDir before going deeper |
| 1 | MED | `scaleDirSuffix` rounded but cache key used raw scale → `1.23` / `1.234` would cross-contaminate | Fixed: round inside `validateRenderScale` so the canonical value flows everywhere |
| 2 | HIGH | TOCTOU race between `assertSafeDir(fingerprintDir)` and the subsequent `mkdirSync` for the scale subdir | Skipped — matches existing `ensurePrivateDir` lstat-then-trust posture across the codebase; closing it requires openat-style fd-anchored ops Node `fs` doesn't expose. Same scope-skip accepted on PR #38 |
| 2 | LOW | `0.004` rounded to `0` after the `<=0` gate, shipping `scale: 0` to the renderer | Fixed: round first, validate rounded value against lower bound |
| 3 | LOW | `4.004` rounded to `4` and slid past the upper-bound gate, contradicting JSDoc / CLI | Fixed: gate raw value against upper bound, rounded value against lower bound |

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` — 295 tests pass (+10 new across CLI / processDocument / layout.unit)
- [x] New tests cover: --render-scale CLI validation (range / non-numeric / no --render or --ocr), library API validation (`0.004`, `4.004`, `NaN`, `0`, `10`), per-scale PNG isolation under shared `--render-output`, intermediate-symlink defense with `--render-scale`, roleConfidence existence + ordering between clear titles and borderline subheadings, roleConfidence wipe on repeated chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)