### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Minor release. Bundles the two follow-up features Codex requested after v0.7.0 usage testing:

### `pages[].warnings[]` — geometry-driven anomaly detection (#44)

Layout pass now emits per-page warnings for visual problems the existing density signals can't catch (the extraction succeeded but something looks off):

- `text_overlap` — two blocks share enough bbox area to overlap on the page
- `near_bottom_edge` — block sits within the bottom edge tolerance (gated by absolute pt + page-relative ratio)
- `body_near_repeated_chrome` — body block crowds a detected running header / footer (uses true intersection depth, not signed gap)
- `off_page` — block bbox extends past the page MediaBox

Surfaced in JSON, XML, and Markdown outputs. Detection skipped when only one page is selected (the chrome-aware rules need cross-page comparison).

### `--render-scale <n>` + `LayoutBlock.roleConfidence` + NFKC docs (#45)

- `--render-scale` CLI flag and `ProcessDocumentOptions.renderScale` library option. Bounds `(0, 4]`, default `2`. Non-default scales write into a `s<scale>` subdir so back-to-back runs at different scales don't clobber each other. Plumbed through both `--render` and `--ocr` rasterisation paths.
- `LayoutBlock.roleConfidence` (0..1, 2dp) attached whenever a block is classified as heading. Lets agents threshold on a number (`>= 0.7` as a section anchor) instead of relying solely on the discrete `level`. Wiped by `markRepeatedBlocks` along with `role` / `level` when chrome is detected.
- README, `--help`, and JSDoc on `normalize` now spell out the `rawText` behaviour and the `--no-normalize` escape hatch (markdown output renders the normalised form only).

Cache key bumped `structured-v13` → `structured-v14` → `structured-v15`.

### Other
- Hardening: assert intermediate `<renderOutput>/<fingerprint>/` against pre-planted symlinks before composing the scale subdir on top (PR #45 codex round 1).
- Cache permission symmetry: when a scale subdir lands under `cacheDir`, the intermediate `images/` now gets `ensurePrivateDir` too instead of inheriting umask 0o755 (PR #45 gemini suggestion).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test` — 295 tests pass
- [x] After merge, trigger `npm-publish` workflow with `dry-run: false`
- [x] Tag `v0.8.0`
- [x] Cut GitHub release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)