### PR TITLE
chore(renovate): pin @napi-rs/canvas below 1.0 + isolate its group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,18 @@
       "matchUpdateTypes": ["major"],
       "groupName": "major dependencies",
     },
+    // @napi-rs/canvas 1.0.0 ships a breaking change to ctx.fill() that
+    // pdfjs-dist@5.x's paintChar path trips into (Error: "Value is none
+    // of these types `String`, `Path`" — see closed PR #51). Pin to
+    // <1.0.0 until pdfjs-dist (or a canvas 1.x patch) restores
+    // compatibility, and give it its own group so future bumps don't
+    // re-block the rest of the dependency tree behind the same PR.
+    // When unblocking, drop `allowedVersions` and leave `groupName`.
+    {
+      "matchPackageNames": ["@napi-rs/canvas"],
+      "groupName": "@napi-rs/canvas",
+      "allowedVersions": "<1.0.0",
+    },
   ],
   "ignoreDeps": [
     // Node engines are bumped intentionally alongside CI matrix changes.


### PR DESCRIPTION
## Summary

\`@napi-rs/canvas\` 1.0.0 ships a breaking change to \`ctx.fill()\` (now refuses non-\`String\` / non-\`Path\` arguments) that pdfjs-dist@5.x's \`paintChar()\` trips into. Effect: every page that draws text characters (Japanese rasters, OCR pre-render) fails at the canvas layer with:

\`\`\`
Error: Value is none of these types \`String\`, \`Path\`,
  { code: 'InvalidArg' }
    at fill        node_modules/pdfjs-dist/.../canvas.js:2100:14
    at paintChar   node_modules/pdfjs-dist/.../canvas.js:2414:15
\`\`\`

Caught by PR #51 (now closed) — the test failures were pinpoint: 2 of 295 (\`ocr.test.ts > multi-page docs\`, \`processor.japanese.test.ts > renders Japanese pages\`), reproduced across all OS and Node versions, so it's a clean API breakage rather than a flake.

## Changes

\`.github/renovate.json5\`:

1. Pin \`@napi-rs/canvas\` to \`<1.0.0\` so renovate stops re-opening the broken PR every Saturday.
2. Give the package its own group (\`@napi-rs/canvas\`) so future bumps don't share a PR with secretlint/typescript/etc. and re-block the major-dependencies group on one broken transitive.

When upstream (\`pdfjs-dist\` or a canvas 1.x patch) restores compatibility, drop \`allowedVersions\` and leave \`groupName\`.

## Test plan
- [x] Renovate config is pure metadata — no app code touched, lint/test stay green
- [ ] After merge, verify no new canvas 1.x PR opens on next renovate cycle (Saturday 9am)

🤖 Generated with [Claude Code](https://claude.com/claude-code)