### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Minor release. Headline: **\`--render-region\`** — rasterise a sub-rectangle of a single page instead of the whole thing. Closes the loop Codex flagged after v0.8.0 ("warnings[] / layout points at a suspect block, but I still need to render the whole page and crop externally").

### New: \`--render-region <x,y,width,height>\` (#53)

CLI flag + library option \`renderRegion: { x, y, width, height }\`. PDF points, top-left origin — same coord system as \`imageBoxes\` / \`layout.blocks\`, so an agent can pipe one straight into the other:

\`\`\`bash
pdfvision report.pdf -p 3 -r --render-region 100,200,300,150
\`\`\`

\`\`\`ts
const result = await processDocument(file, {
  pages: '3',
  render: true,
  renderRegion: { x: 100, y: 200, width: 300, height: 150 },
});
// result.pages[0].image — PNG cropped to the region
// result.pages[0].renderRegion — echoed back so consumers can tell crop vs full
\`\`\`

Composes orthogonally with \`--render-scale\`: a 400×300pt region at scale 3 yields a 1200×900px PNG.

### V1 contract (strict, by design)

| Rule | Why |
|---|---|
| Exactly one page selected | Per-page xywh needs a richer API; not yet justified |
| Region within page bounds (no silent clip) | Off-page typically means coord-system confusion; surface it |
| Page must not be rotated (\`page.rotate === 0\`) | pdfvision's existing geometry is in unrotated MediaBox coords; the underlying rotation fix is a multi-file refactor pending |
| Requires \`--render\` or \`--ocr\` | Enforced at CLI **and** processor boundary so library callers can't bypass into the text-only cache slot |
| Positive width / height after 2dp rounding | Shape errors fail fast; rounding is canonical so the value flows consistently through cache key / filename / echo |

### Other changes

- \`RenderRegion\` is a new exported public type (\`src/index.ts\`).
- XML output echoes the region as four sibling \`<page renderRegionX/Y/Width/Height>\` attributes, matching the existing bbox attribute shape.
- Skill (\`skills/pdfvision/\`) updated to teach the \`--layout → warnings[]/layout で suspect 発見 → --render-region で zoom\` loop, plus catches up on \`--render-scale\` and \`warnings[]\` that hadn't been propagated to the skill yet.
- Hardening: assert intermediate \`<renderOutput>/<fingerprint>/\` dir before composing scale subdir (carried from the same PR).

### Cache

Cache key bumped \`structured-v15\` → \`structured-v17\`. Old entries dropped on first read.

## Install

\`\`\`bash
npm install pdfvision@0.9.0
\`\`\`

**Full Changelog**: https://github.com/yamadashy/pdfvision/compare/v0.8.0...v0.9.0

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 314 tests pass
- [ ] After merge: tag v0.9.0, trigger npm-publish workflow, cut GitHub release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)