### PR TITLE
feat(core): --search — find text with bbox, pipe straight into --render-region

### DIFF
--- a/skills/pdfvision/SKILL.md
+++ b/skills/pdfvision/SKILL.md
@@ -5,7 +5,7 @@ description: "Extract text, metadata, per-page density signals, structural layou
 
 # pdfvision
 
-[pdfvision](https://github.com/yamadashy/pdfvision) extracts text + metadata + per-page density signals from any PDF, with opt-in OCR (`--ocr`), layout reconstruction (`--layout`), geometry-driven anomaly detection (`pages[].warnings[]` when `--layout` is on), image bounding boxes (`--image-boxes`), per-text-item geometry (`--geometry`), and PNG rendering (`--render`, optionally sized with `--render-scale` and cropped with `--render-region`). Cached by content hash, so the second read of the same PDF returns in ~30 ms.
+[pdfvision](https://github.com/yamadashy/pdfvision) extracts text + metadata + per-page density signals from any PDF, with opt-in OCR (`--ocr`), layout reconstruction (`--layout`), geometry-driven anomaly detection (`pages[].warnings[]` when `--layout` is on), image bounding boxes (`--image-boxes`), per-text-item geometry (`--geometry`), PNG rendering (`--render`, optionally sized with `--render-scale` and cropped with `--render-region`), and per-page text search with bbox (`--search`, hits ride into `--render-region` for one-pipeline find-then-zoom). Cached by content hash, so the second read of the same PDF returns in ~30 ms.
 
 ## Prerequisite
 
@@ -46,6 +46,10 @@ npx pdfvision tiny.pdf --render --render-scale 3         # higher-detail PNG
 # Zoom into a specific region on one page (PDF points, top-left origin)
 npx pdfvision doc.pdf -p 3 --render --render-region 100,200,300,150
 
+# Find a string with bbox of every hit — pipe match.bbox into --render-region for visual zoom
+npx pdfvision report.pdf --search "revenue" --json
+npx pdfvision paper.pdf --search "GPT" --search "transformer" --json  # multi-query (each match carries queryIndex)
+
 # Wipe the on-disk cache
 npx pdfvision --clear-cache
 ```
@@ -67,6 +71,7 @@ The default extraction is enough for most native-text PDFs (papers, exports from
 | Hand the page to a vision model | `--render` + `--render-output <dir>` | Multimodal flows. Density Overview already flagged the page as low-text |
 | Shrink / enlarge the rendered PNG | `--render-scale <n>` (default 2, bounds `(0, 4]`) | 1×: half-size payload, fine for most agentic-vision dispatch. 3×+: capture chart / fine-print detail |
 | Zoom into a sub-rectangle of one page | `--render-region <x,y,w,h>` | Agent already saw a suspect block via `--layout` / `warnings[]` and only wants the visual confirmation of that bbox, not the whole page. PDF points, top-left origin, single-page only (errors if `--pages` resolves to multiple). Composes with `--render-scale` |
+| Find every occurrence of a string with bbox | `--search <query>` (repeatable; `--search-regex` / `--search-case-sensitive` modifiers) | The agent's "where does this term appear?" question. Returns `pages[N].matches[*]` with span-level bbox so the bbox feeds straight into `--render-region` for a follow-up visual zoom — one-pipeline find-then-zoom, no second pass. Literal substring by default, case-insensitive, NFKC-aware (so `"fi"` matches the U+FB01 ligature). Also searches OCR text when `--ocr` is on (match carries `source: 'ocr'`). |
 | Skip the on-disk cache | `--no-cache` | Forced re-extraction. Default behaviour is cache-on |
 
 ## Detecting silent failures with the density Overview
@@ -115,7 +120,8 @@ The density signal is the reason to prefer pdfvision over reading a PDF directly
 3. For low-coverage pages: re-run with `--ocr` if text is needed, or `--render` if a vision model will look at the rasterised page.
 4. For structured / multi-column docs: re-run with `--layout` (and `--image-boxes` when figure positions matter).
 5. **Zoom into a specific block when `--layout` flags one.** If `pages[].warnings[]` fires on a `blockIndex`, or `layout.blocks[i]` looks suspicious (overlapping bboxes, a chart you want a vision model to read), re-run with `--pages <N> --render --render-region <x,y,w,h>` using that block's bbox. The PNG comes back cropped to just the region (xywh × `--render-scale` = pixel dims), avoiding a full-page raster the model has to ignore most of.
-6. Cache means steps 3–5 only re-pay the cost of the new flag combination on the affected page subset, not the whole extract.
+6. **Locate a keyword and pipe straight into zoom.** When the user's question is "find where X is mentioned" (a model name, a number, a heading), run `--search "X" --json` to get `pages[N].matches[*]` with span-level bbox of every hit. Each match knows its page and bbox, so the same loop closes: `--pages <m.page> --render --render-region <m.bbox.x>,<m.bbox.y>,<m.bbox.width>,<m.bbox.height>` zooms onto the match. Repeat `--search` for multi-term searches (each match carries `queryIndex`). `--search-regex` for patterns, `--search-case-sensitive` when default insensitive-recall is too lossy.
+7. Cache means steps 3–6 only re-pay the cost of the new flag combination on the affected page subset, not the whole extract.
 
 ## When to read `references/`
 

--- a/skills/pdfvision/references/structured-output.md
+++ b/skills/pdfvision/references/structured-output.md
@@ -30,6 +30,8 @@ interface PageOverview {
   nonPrintableCount: number;      // raw count — stays discriminable when the 3dp ratio rounds to 0
   renderContentRatio?: number;    // 0..1, fraction of pixels differing from the page's dominant background (present iff --render or --ocr)
   quality: PageQuality;           // derived classification — see below
+  warningCount?: number;          // mirror of pages[N].warnings.length, omitted when --layout off or no rule fired
+  matchCount?: number;            // mirror of pages[N].matches.length; present-with-0 means "search ran, no hit"
   width: number;                  // PDF user-space points
   height: number;
 }

--- a/skills/pdfvision/references/structured-output.md
+++ b/skills/pdfvision/references/structured-output.md
@@ -63,6 +63,7 @@ interface PageResult {
   imageBoxes?: ImageBox[];       // present iff --image-boxes
   ocr?: PageOcr;                 // present iff --ocr
   warnings?: PageWarning[];      // present iff --layout, omitted when no rule fired on the page
+  matches?: SearchMatch[];       // present iff --search; empty array means "search ran, no hit on this page"
 }
 
 interface PageQuality {
@@ -192,6 +193,44 @@ interface PageWarning {
 
 Emitted only when `--layout` is on. Each entry pins to a specific block (or block pair) and describes what looks visually off — overlapping text, off-page bbox, body crowding a detected running header/footer. Same observational posture as `quality`: pdfvision tells the agent what it saw; the agent decides whether to surface, re-OCR, or zoom in via `--render-region <blocks[blockIndex].x>,...`.
 
+## Search (`--search`)
+
+```ts
+interface SearchMatch {
+  page: number;                // 1-based, mirrors PageResult.page
+  query: string;               // verbatim source query
+  queryIndex?: number;         // 0-based into the search array; omitted for single-query calls
+  bbox: { x, y, width, height }; // union bbox of contributing spans; feed straight into --render-region
+  boxes: { x, y, width, height }[]; // per-span bboxes (V1: one entry for single-span matches)
+  text: string;                // matched substring in the same form as pages[].text (NFKC when normalize is on)
+  source: 'native' | 'ocr';    // native = precise span bbox; ocr = page-level bbox (V1 limit)
+  context?: string;            // surrounding line text for human / LLM readability
+}
+```
+
+Emitted only when `--search` is passed. Each query occurrence becomes one match — three hits of `"foo"` on page 5 yield three entries with `page: 5`.
+
+**One-pipeline find-then-zoom**: a match's `bbox` is in the same coord system as `--render-region`, so the agent loop is:
+
+```bash
+pdfvision doc.pdf --search "revenue" --json
+# pick a match m from pages[N].matches[*]
+pdfvision doc.pdf -p <m.page> --render --render-region <m.bbox.x>,<m.bbox.y>,<m.bbox.width>,<m.bbox.height>
+```
+
+**Semantics**:
+
+- **literal substring** by default (regex chars in the query are escaped). Pass `--search-regex` to opt into JavaScript regular expressions.
+- **case-insensitive** by default (recall-oriented). Pass `--search-case-sensitive` for exact-case matching.
+- **NFKC-aware in literal mode** when `--normalize` is on (default) — `"fi"` finds `"ﬁ"` (U+FB01 ligature) PDFs that external grep would miss, same fold for fullwidth Latin / CJK compatibility forms.
+- **Regex queries are NOT normalized** — NFKC can turn compatibility punctuation into regex metacharacters (silent overmatch or syntax break). Regex users get the literal codepoints they typed against the normalized document text and own the asymmetry.
+- **Multi-query** via repeating `--search` (or `search: string[]` in library). Each match carries `queryIndex` so the agent can demultiplex which query produced it.
+- **OCR text is searched too when `--ocr` is on**. OCR-derived matches come back with `source: 'ocr'` and a page-level `bbox` (V1: per-word OCR bbox from tesseract `data.words[]` not plumbed yet — the source-tag lets consumers disambiguate from precise native matches).
+
+V1 native matching is **single-span only**. A query straddling two pdf.js spans (e.g. `"Hello World"` where `Hello` and `World` are different spans) won't match. Most short queries hit single spans because pdf.js groups by font run; multi-span matching is a follow-up.
+
+`pages[].matches` is **present-with-`[]`** when `--search` ran but the page had no hits — distinct from the field being absent entirely (search wasn't requested). The same posture extends to the overview, which gains a `matchCount` mirror field with the same present-with-`0` semantics.
+
 ## XML output shape
 
 `-f xml` mirrors the JSON shape one-for-one:
@@ -297,4 +336,4 @@ for (const page of result.pages) {
 
 `processFile()` returns the formatted string output (`markdown` / `json` / `xml` / `toon`). `processDocument()` returns the structured object directly.
 
-Exported types: `DocumentResult`, `DocumentMetadata`, `PageOverview`, `PageResult`, `PageQuality`, `PageWarning`, `LayoutBlock`, `LayoutLine`, `PageLayout`, `ImageBox`, `RenderRegion`, `TextSpan`, `PageOcr`, `OutputFormat`, `ProcessDocumentOptions`, `ProcessOptions`.
+Exported types: `DocumentResult`, `DocumentMetadata`, `PageOverview`, `PageResult`, `PageQuality`, `PageWarning`, `SearchMatch`, `LayoutBlock`, `LayoutLine`, `PageLayout`, `ImageBox`, `RenderRegion`, `TextSpan`, `PageOcr`, `OutputFormat`, `ProcessDocumentOptions`, `ProcessOptions`.

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,7 +18,7 @@ function exitWithError(message: string): never {
 }
 
 export async function run(argv: string[] = process.argv.slice(2)): Promise<void> {
-  let values: Record<string, string | boolean | undefined>;
+  let values: Record<string, string | string[] | boolean | undefined>;
   let positionals: string[];
   try {
     // parseArgs throws on unknown options or missing required values.
@@ -54,9 +54,16 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
         'clear-cache': { type: 'boolean' },
         ocr: { type: 'boolean' },
         'ocr-lang': { type: 'string', default: 'eng' },
+        // --search is repeatable so `--search A --search B` works
+        // (multi-query AND-merge into pages[].matches[]). The bool
+        // companions modify ALL queries — case sensitivity / regex
+        // semantics per-query would invite confusion.
+        search: { type: 'string', multiple: true },
+        'search-regex': { type: 'boolean' },
+        'search-case-sensitive': { type: 'boolean' },
       },
     });
-    values = parsed.values as Record<string, string | boolean | undefined>;
+    values = parsed.values as Record<string, string | string[] | boolean | undefined>;
     positionals = parsed.positionals;
   } catch (error) {
     exitWithError(error instanceof Error ? error.message : String(error));
@@ -205,6 +212,19 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
     exitWithError(`--strip-repeated only applies to markdown output (got --format ${format})`);
   }
 
+  // --search collects 0..N queries (multiple: true gives string[] |
+  // undefined). The bool companions only make sense when at least one
+  // query was passed — fail loud rather than silently no-op.
+  const searchQueries = values.search as string[] | undefined;
+  const searchRegex = (values['search-regex'] as boolean | undefined) ?? false;
+  const searchCaseSensitive = (values['search-case-sensitive'] as boolean | undefined) ?? false;
+  if (!searchQueries && (searchRegex || values['search-case-sensitive'])) {
+    exitWithError('--search-regex / --search-case-sensitive require at least one --search query');
+  }
+  if (searchQueries?.some((q) => q === '')) {
+    exitWithError('--search: query must be a non-empty string');
+  }
+
   const noCache = (values['no-cache'] as boolean | undefined) ?? false;
 
   let filePath: string;
@@ -236,6 +256,12 @@ export async function run(argv: string[] = process.argv.slice(2)): Promise<void>
       renderOutput,
       renderScale,
       renderRegion,
+      // search may be undefined (no --search), a 1-length array (single
+      // --search), or a longer array (repeated --search). Pass through
+      // as-is — the processor's compileSearch handles both shapes.
+      search: searchQueries,
+      searchRegex,
+      searchCaseSensitive,
       noCache,
       // NFKC normalization is on by default — agents almost always want
       // canonical Unicode. --no-normalize lets callers opt out for cases

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -68,8 +68,9 @@ Options
                           zoom. Repeatable: \`--search A --search B\` searches both
                           (each match carries the source query). Literal substring
                           by default; case-insensitive; NFKC-aware (matches
-                          compatibility codepoints like \`⽬\` for \`目\`). Also
-                          searches OCR text when --ocr is on (marked source:'ocr').
+                          compatibility codepoints like \`ﬁ\` (U+FB01 ligature) for
+                          \`fi\`). Also searches OCR text when --ocr is on
+                          (marked source:'ocr').
       --search-regex      Treat each --search query as a JavaScript regular expression
                           (default: literal substring).
       --search-case-sensitive
@@ -97,7 +98,7 @@ Examples
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
   pdfvision slides.pdf -r --render-scale 1                                     # 1× raster (smaller PNGs)
   pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150pt box on page 3
-  pdfvision report.pdf --search "売上" --json                                  # find every "売上" with bbox; pipe to --render-region
+  pdfvision report.pdf --search "revenue" --json                               # find every "revenue" with bbox; pipe to --render-region
   pdfvision paper.pdf --search "GPT" --search "transformer" --json             # multi-query (each match keeps its source query)
   pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry --json    # PNGs + spans for 3-5
   pdfvision slides.pdf --xml --geometry                                        # layout / geometry as XML

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -62,6 +62,18 @@ Options
                           preserved alongside so callers can compare native vs OCR.
       --ocr-lang <lang>   Tesseract language code(s), plus-separated for multi-lang
                           (e.g. \`eng+jpn\`). Default: eng. Only used with --ocr.
+      --search <query>    Find every occurrence of <query> on each page and emit
+                          \`pages[].matches[]\` with the bbox of each hit. Pipe a
+                          match's bbox into a follow-up --render-region for visual
+                          zoom. Repeatable: \`--search A --search B\` searches both
+                          (each match carries the source query). Literal substring
+                          by default; case-insensitive; NFKC-aware (matches
+                          compatibility codepoints like \`⽬\` for \`目\`). Also
+                          searches OCR text when --ocr is on (marked source:'ocr').
+      --search-regex      Treat each --search query as a JavaScript regular expression
+                          (default: literal substring).
+      --search-case-sensitive
+                          Match case exactly (default: insensitive).
       --remote <url>      Download an http(s) URL to the on-disk cache and run extraction
                           on it. Same URL → same cache slot; combine with --no-cache (or
                           --clear-cache) to refresh.
@@ -85,6 +97,8 @@ Examples
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
   pdfvision slides.pdf -r --render-scale 1                                     # 1× raster (smaller PNGs)
   pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150pt box on page 3
+  pdfvision report.pdf --search "売上" --json                                  # find every "売上" with bbox; pipe to --render-region
+  pdfvision paper.pdf --search "GPT" --search "transformer" --json             # multi-query (each match keeps its source query)
   pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry --json    # PNGs + spans for 3-5
   pdfvision slides.pdf --xml --geometry                                        # layout / geometry as XML
   pdfvision report.pdf --toon --geometry                                       # token-efficient spans (TOON)

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -840,6 +840,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
           data.width,
           data.height,
           compiledSearch,
+          options.onWarning,
         );
         page.matches = nativeMatches;
       }
@@ -901,7 +902,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
     if (compiledSearch && ocrEnabled) {
       for (const p of pages) {
         if (!p.ocr) continue;
-        const ocrMatches = searchPage(undefined, p.ocr, p.page, p.width, p.height, compiledSearch);
+        const ocrMatches = searchPage(undefined, p.ocr, p.page, p.width, p.height, compiledSearch, options.onWarning);
         p.matches = (p.matches ?? []).concat(ocrMatches);
       }
     }

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -26,6 +26,7 @@ import { buildLayout, markRepeatedBlocks } from './layout.js';
 import { nonPrintableStats } from './nonPrintable.js';
 import { parsePageRangeWithSkipped } from './pageRange.js';
 import { runParallel } from './parallel.js';
+import { type CompiledSearch, compileSearch, searchPage } from './search.js';
 import { detectPageWarnings } from './warnings.js';
 
 /** Inputs that determine which cached entry a request maps to. */
@@ -41,6 +42,9 @@ interface CacheKeyInput {
   imageBoxes?: boolean;
   ocr?: boolean;
   ocrLang?: string;
+  search?: string | string[];
+  searchRegex?: boolean;
+  searchCaseSensitive?: boolean;
 }
 
 /** Default rasterisation multiplier — must match renderer.ts DEFAULT_SCALE. */
@@ -135,7 +139,7 @@ function buildCacheKey(input: CacheKeyInput): string {
     pages: input.pages ?? 'all',
     // Bump when the on-disk DocumentResult shape changes so older entries
     // (missing newly-added page fields) are not handed out as fresh results.
-    format: 'structured-v17',
+    format: 'structured-v18',
     render: !!input.render,
     // Including the resolved render-output dir keeps two invocations with
     // different `--render-output` targets from sharing image paths.
@@ -166,6 +170,13 @@ function buildCacheKey(input: CacheKeyInput): string {
     // `eng+jpn` do.
     ocr: !!input.ocr,
     ocrLang: input.ocr ? canonicalOcrLang(input.ocrLang) : null,
+    // Search results change the structured payload (pages[].matches),
+    // so the query list and flags are part of the key. Multi-query
+    // order matters (queryIndex on each match is index-stable), so we
+    // preserve array order in the key.
+    search: input.search !== undefined ? (Array.isArray(input.search) ? input.search : [input.search]) : null,
+    searchRegex: !!input.searchRegex,
+    searchCaseSensitive: !!input.searchCaseSensitive,
   });
   const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16);
   return `result_${hash}.json`;
@@ -218,6 +229,11 @@ interface PageData {
   width: number;
   height: number;
   spans?: TextSpan[];
+  /** Spans built internally (independent of `flags.geometry`) for
+   *  downstream search bbox computation. Mirrors `spans` when both
+   *  are present; lives separately so the public PageResult.spans
+   *  gating stays the simple "geometry on / off" rule. */
+  _internalSpans?: TextSpan[];
   layout?: PageLayout;
   imageBoxes?: ImageBox[];
 }
@@ -260,6 +276,10 @@ interface PageFlags {
   geometry: boolean;
   layout: boolean;
   imageBoxes: boolean;
+  /** Build spans internally even when neither `geometry` nor `layout`
+   *  was requested. Search needs them for per-match bbox; the public
+   *  `pages[].spans` payload still requires `geometry`. */
+  needSpansForSearch: boolean;
 }
 
 /**
@@ -286,10 +306,11 @@ async function extractPageData(
   const height = Math.abs(view[3] - view[1]);
   const yMin = Math.min(view[1], view[3]);
 
-  // Spans are also the input to layout reconstruction, so we build them
-  // whenever either flag is set — even though we may only expose them on
-  // PageResult when `geometry` is on.
-  const wantSpans = flags.geometry || flags.layout;
+  // Spans are the input to layout reconstruction AND to search bbox
+  // computation, so we build them whenever any of those needs is set —
+  // even though we may only expose them on PageResult when `geometry`
+  // is on.
+  const wantSpans = flags.geometry || flags.layout || flags.needSpansForSearch;
 
   // Collect typed items for the CJK-aware page-text joiner. We can't
   // build the final string in this loop because the join decision for
@@ -398,9 +419,14 @@ async function extractPageData(
     // A4 595×842) but encrypted/cropped PDFs can carry sub-point fractions.
     width: round2(width),
     height: round2(height),
-    // Spans are only exposed when --geometry is on; layout / imageBoxes
-    // each have their own opt-in flags and are independent of `geometry`.
+    // Spans are only exposed publicly when --geometry is on; layout /
+    // imageBoxes each have their own opt-in flags and are independent
+    // of `geometry`. The internal spans (always populated when
+    // wantSpans was true) ride on `_internalSpans` so the search pass
+    // downstream can compute per-match bbox without forcing the agent
+    // to opt into geometry.
     ...(flags.geometry && { spans }),
+    ...(wantSpans && { _internalSpans: spans }),
     ...(layout !== undefined && { layout }),
     ...(imageBoxes !== undefined && { imageBoxes }),
   };
@@ -471,6 +497,15 @@ export async function processDocument(filePath: string, options: ProcessDocument
   // single-page + within-bounds + non-rotated-page checks come after
   // page resolution and pdfjs load below.
   const renderRegion = validateRenderRegion(options.renderRegion);
+  // Compile search queries up front so a bad regex or empty query
+  // surfaces immediately rather than after the extraction budget
+  // is partly spent. `compileSearch` returns undefined when search
+  // isn't requested — the per-page loop below skips on undefined.
+  const compiledSearch: CompiledSearch | undefined = compileSearch(options.search, {
+    regex: options.searchRegex,
+    caseSensitive: options.searchCaseSensitive,
+    normalize: options.normalize,
+  });
   // renderRegion only makes sense when rasterisation actually runs.
   // The CLI already enforces this, but library callers can bypass it
   // and we'd then hit two real bugs: (1) the result cache slot is
@@ -742,6 +777,10 @@ export async function processDocument(filePath: string, options: ProcessDocument
       geometry: !!options.geometry,
       layout: !!options.layout,
       imageBoxes: !!options.imageBoxes,
+      // Search needs span-level bbox to populate `matches[*].bbox`;
+      // build spans internally even if the caller didn't ask for the
+      // full `pages[].spans` payload via --geometry.
+      needSpansForSearch: compiledSearch !== undefined,
     };
     const ocrEnabled = !!options.ocr;
     const ocrLang = options.ocrLang ?? 'eng';
@@ -789,6 +828,21 @@ export async function processDocument(filePath: string, options: ProcessDocument
         quality: { nativeTextStatus: 'empty' },
       };
       page.quality = derivePageQuality(page);
+      // Run the native (span-based) search pass here while the internal
+      // spans are still in scope. OCR-based matches are appended
+      // post-OCR below — both produce the same SearchMatch shape, so
+      // consumers iterate `pages[].matches` uniformly.
+      if (compiledSearch) {
+        const nativeMatches = searchPage(
+          data._internalSpans,
+          undefined,
+          pageNum,
+          data.width,
+          data.height,
+          compiledSearch,
+        );
+        page.matches = nativeMatches;
+      }
       return page;
     });
 
@@ -839,6 +893,19 @@ export async function processDocument(filePath: string, options: ProcessDocument
       p.quality = derivePageQuality(p);
     }
 
+    // OCR search pass. The native pass ran in the per-page loop above
+    // (spans were in scope); OCR results only exist after attachOcr,
+    // so this second pass adds OCR-source matches at the end of each
+    // page's `matches[]`. Skipped when OCR wasn't enabled — no
+    // ocr.text to search.
+    if (compiledSearch && ocrEnabled) {
+      for (const p of pages) {
+        if (!p.ocr) continue;
+        const ocrMatches = searchPage(undefined, p.ocr, p.page, p.width, p.height, compiledSearch);
+        p.matches = (p.matches ?? []).concat(ocrMatches);
+      }
+    }
+
     const metaString = (raw: unknown): string | null => {
       if (typeof raw !== 'string') return null;
       return flags.normalize ? normalizeText(raw) : raw;
@@ -869,6 +936,11 @@ export async function processDocument(filePath: string, options: ProcessDocument
             // ran), matching the PageResult.warnings field's optional
             // shape.
             ...(p.warnings && p.warnings.length > 0 && { warningCount: p.warnings.length }),
+            // Search hits per page. Present-with-`0` is meaningful
+            // ("search ran, no hits on this page"); omitted when
+            // `search` wasn't requested at all so the overview stays
+            // clean for the default extraction.
+            ...(compiledSearch !== undefined && { matchCount: p.matches?.length ?? 0 }),
             width: p.width,
             height: p.height,
           }))
@@ -927,6 +999,9 @@ export async function processFile(filePath: string, options: ProcessOptions): Pr
     renderOutput: options.renderOutput,
     renderScale: options.renderScale,
     renderRegion: options.renderRegion,
+    search: options.search,
+    searchRegex: options.searchRegex,
+    searchCaseSensitive: options.searchCaseSensitive,
     normalize: options.normalize,
     geometry: options.geometry,
     layout: options.layout,

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -421,12 +421,12 @@ async function extractPageData(
     height: round2(height),
     // Spans are only exposed publicly when --geometry is on; layout /
     // imageBoxes each have their own opt-in flags and are independent
-    // of `geometry`. The internal spans (always populated when
-    // wantSpans was true) ride on `_internalSpans` so the search pass
-    // downstream can compute per-match bbox without forcing the agent
-    // to opt into geometry.
+    // of `geometry`. `_internalSpans` only rides along when search
+    // actually needs them — `--layout` alone already consumed the
+    // span list during `buildLayout` above, so re-emitting them on
+    // PageData would waste memory on the typical extraction.
     ...(flags.geometry && { spans }),
-    ...(wantSpans && { _internalSpans: spans }),
+    ...(flags.needSpansForSearch && { _internalSpans: spans }),
     ...(layout !== undefined && { layout }),
     ...(imageBoxes !== undefined && { imageBoxes }),
   };

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -139,7 +139,7 @@ function buildCacheKey(input: CacheKeyInput): string {
     pages: input.pages ?? 'all',
     // Bump when the on-disk DocumentResult shape changes so older entries
     // (missing newly-added page fields) are not handed out as fresh results.
-    format: 'structured-v18',
+    format: 'structured-v19',
     render: !!input.render,
     // Including the resolved render-output dir keeps two invocations with
     // different `--render-output` targets from sharing image paths.

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -103,6 +103,25 @@ function round2(n: number): number {
 }
 
 /**
+ * Per-(query, page, source) cap on the number of emitted matches. Acts
+ * as a defence-in-depth against a degenerate regex (e.g. `.` against a
+ * 100KB OCR page produces 100k hits) and a soft brake on user typos.
+ *
+ * NOT a full ReDoS mitigation — the cap counts emitted matches, so a
+ * catastrophic-backtracking pattern on a single string can still stall
+ * inside one `regex.exec(...)` call before any match would have been
+ * pushed. pdfvision's threat model is "the user is matching against
+ * their own input", so the cost of safe-regex / worker / RE2 is
+ * deliberately not paid. Library consumers exposing pdfvision to
+ * untrusted regex input should wrap the call in their own timeout.
+ *
+ * 10000 is generous enough that a real "find every paragraph match"
+ * query passes; lower and we'd false-positive on legitimate use, higher
+ * and a degenerate pattern stays expensive enough to be a problem.
+ */
+const MAX_MATCHES_PER_QUERY_PER_PAGE = 10000;
+
+/**
  * Find every occurrence of every compiled query in the given page's
  * native text (via spans) and OCR text (when present). Returns the
  * matches in page-natural order: per-span pass for spans (top-down
@@ -128,11 +147,18 @@ export function searchPage(
   pageWidth: number,
   pageHeight: number,
   compiled: CompiledSearch,
+  onWarning?: (message: string) => void,
 ): SearchMatch[] {
   const matches: SearchMatch[] = [];
 
+  // Per-query, per-page, per-source emission counter. Resets between
+  // native and OCR passes (each gets its own cap). Track per matcher
+  // index so multi-query searches don't share a budget.
+  const nativeCount = new Map<number, number>();
+  const nativeCapped = new Set<number>();
+
   // Native pass — per-span literal/regex match.
-  for (const span of spans ?? []) {
+  spanLoop: for (const span of spans ?? []) {
     // Span text is already NFKC-normalised when `--normalize` is on
     // (matches what we put in pages[].spans). Literal-mode queries
     // were NFKC'd at compile time too, so they're in the same form
@@ -140,7 +166,9 @@ export function searchPage(
     // normalised — the user opts into literal-codepoint semantics
     // against the normalised document text (see CompiledSearch).
     const haystack = span.text;
-    for (const m of compiled.matchers) {
+    for (let mi = 0; mi < compiled.matchers.length; mi++) {
+      const m = compiled.matchers[mi];
+      if (nativeCapped.has(mi)) continue;
       // Reset lastIndex so the same RegExp object can be reused
       // across spans (`g` flag is stateful).
       m.regex.lastIndex = 0;
@@ -176,6 +204,18 @@ export function searchPage(
           source: 'native',
           context: haystack,
         });
+        const next = (nativeCount.get(mi) ?? 0) + 1;
+        nativeCount.set(mi, next);
+        if (next >= MAX_MATCHES_PER_QUERY_PER_PAGE) {
+          nativeCapped.add(mi);
+          onWarning?.(
+            `search query ${JSON.stringify(m.query)} hit the per-page native match cap of ${MAX_MATCHES_PER_QUERY_PER_PAGE} on page ${pageNum}; subsequent native matches for this query on this page were dropped.`,
+          );
+          // Stop scanning further spans for this matcher; other
+          // matchers may still have budget.
+          if (nativeCapped.size === compiled.matchers.length) break spanLoop;
+          break;
+        }
       }
     }
   }
@@ -187,6 +227,8 @@ export function searchPage(
     const pageBox = { x: 0, y: 0, width: round2(pageWidth), height: round2(pageHeight) };
     for (const m of compiled.matchers) {
       m.regex.lastIndex = 0;
+      let count = 0;
+      let capped = false;
       while (true) {
         const hit = m.regex.exec(ocrHaystack);
         if (hit === null) break;
@@ -211,6 +253,16 @@ export function searchPage(
           source: 'ocr',
           context,
         });
+        count++;
+        if (count >= MAX_MATCHES_PER_QUERY_PER_PAGE) {
+          capped = true;
+          break;
+        }
+      }
+      if (capped) {
+        onWarning?.(
+          `search query ${JSON.stringify(m.query)} hit the per-page OCR match cap of ${MAX_MATCHES_PER_QUERY_PER_PAGE} on page ${pageNum}; subsequent OCR matches for this query on this page were dropped.`,
+        );
       }
     }
   }

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -12,8 +12,8 @@ export interface CompiledSearch {
   matchers: { query: string; regex: RegExp; queryIndex?: number }[];
   /** Whether NFKC normalization applies on the *document* side
    *  (spans / OCR haystack). Literal-mode queries are also NFKC-
-   *  normalised in this case so `"目"` finds compatibility `"⽬"`
-   *  PDFs. Regex queries are NEVER normalised, even when this flag
+   *  normalised in this case so `"fi"` finds compatibility ligature
+   *  `"ﬁ"` (U+FB01) PDFs. Regex queries are NEVER normalised, even when this flag
    *  is true — NFKC can turn compatibility punctuation into regex
    *  metacharacters; users opting into regex get literal codepoints
    *  against the normalised document text and own the asymmetry.
@@ -77,10 +77,10 @@ export function compileSearch(
       // codepoints they typed.
       pattern = rawQuery;
     } else {
-      // Literal mode: NFKC the query so `"目"` finds compatibility
-      // `"⽬"` PDFs, matching what we do to the document text. Escape
-      // *after* normalization so a fullwidth `．` that normalises to
-      // `.` is still treated literally.
+      // Literal mode: NFKC the query so `"fi"` finds compatibility
+      // ligature `"ﬁ"` (U+FB01) PDFs, matching what we do to the
+      // document text. Escape *after* normalization so a fullwidth
+      // dot that normalises to `.` is still treated literally.
       const query = normalize ? nfkc(rawQuery) : rawQuery;
       pattern = escapeRegExp(query);
     }

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -10,10 +10,15 @@ export interface CompiledSearch {
    *  code below — literal queries get the substring escaped and the
    *  `g` flag added, regex queries get the user pattern verbatim. */
   matchers: { query: string; regex: RegExp; queryIndex?: number }[];
-  /** Whether NFKC normalization was applied to the queries (mirrors
-   *  the document side). When the document's `text` / spans are NFKC-
-   *  normalised, the queries must be too so `"目"` finds compatibility
-   *  `"⽬"` PDFs. When `--no-normalize` is on, both sides stay raw. */
+  /** Whether NFKC normalization applies on the *document* side
+   *  (spans / OCR haystack). Literal-mode queries are also NFKC-
+   *  normalised in this case so `"目"` finds compatibility `"⽬"`
+   *  PDFs. Regex queries are NEVER normalised, even when this flag
+   *  is true — NFKC can turn compatibility punctuation into regex
+   *  metacharacters; users opting into regex get literal codepoints
+   *  against the normalised document text and own the asymmetry.
+   *  When `--no-normalize` is on, this is false and the document
+   *  side stays raw too. */
   normalize: boolean;
 }
 
@@ -129,8 +134,11 @@ export function searchPage(
   // Native pass — per-span literal/regex match.
   for (const span of spans ?? []) {
     // Span text is already NFKC-normalised when `--normalize` is on
-    // (matches what we put in pages[].spans). So we don't re-normalize
-    // here — the compiled query is already in the same form.
+    // (matches what we put in pages[].spans). Literal-mode queries
+    // were NFKC'd at compile time too, so they're in the same form
+    // as the haystack. Regex-mode queries are intentionally NOT
+    // normalised — the user opts into literal-codepoint semantics
+    // against the normalised document text (see CompiledSearch).
     const haystack = span.text;
     for (const m of compiled.matchers) {
       // Reset lastIndex so the same RegExp object can be reused

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -1,0 +1,205 @@
+import type { PageOcr, SearchMatch, TextSpan } from '../types/index.js';
+
+/**
+ * Inputs the processor builds once per request, then passes to
+ * {@link searchPage} for every page.
+ */
+export interface CompiledSearch {
+  /** Each query's matcher, in the same order as the original input.
+   *  Captured as RegExp so literal and regex paths share the iteration
+   *  code below — literal queries get the substring escaped and the
+   *  `g` flag added, regex queries get the user pattern verbatim. */
+  matchers: { query: string; regex: RegExp; queryIndex?: number }[];
+  /** Whether NFKC normalization was applied to the queries (mirrors
+   *  the document side). When the document's `text` / spans are NFKC-
+   *  normalised, the queries must be too so `"目"` finds compatibility
+   *  `"⽬"` PDFs. When `--no-normalize` is on, both sides stay raw. */
+  normalize: boolean;
+}
+
+/**
+ * Escape every character that has special meaning in a JavaScript
+ * RegExp so a literal-mode query like `"3.14"` doesn't accidentally
+ * match `"3X14"`. Used only on the literal path; regex-mode queries
+ * skip this and are compiled verbatim.
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Apply NFKC the same way `processor.normalizeText` does. Inlined
+ *  here so search.ts doesn't reach back into processor.ts. */
+function nfkc(s: string): string {
+  return s.normalize('NFKC');
+}
+
+/**
+ * Compile the user-supplied search inputs into a {@link CompiledSearch}
+ * the processor can reuse across pages. Throws on:
+ *   - empty array / empty string queries (nothing to search for)
+ *   - invalid regex when `regex` is true
+ *
+ * Single-query callers omit `queryIndex` on the resulting matchers so
+ * downstream `SearchMatch.queryIndex` stays undefined for the common
+ * case; multi-query callers get 0-based indices.
+ */
+export function compileSearch(
+  search: string | string[] | undefined,
+  options: { regex?: boolean; caseSensitive?: boolean; normalize?: boolean },
+): CompiledSearch | undefined {
+  if (search === undefined) return undefined;
+  const queries = Array.isArray(search) ? search : [search];
+  if (queries.length === 0) {
+    throw new Error('search: expected at least one query');
+  }
+  for (const q of queries) {
+    if (typeof q !== 'string' || q.length === 0) {
+      throw new Error('search: query must be a non-empty string');
+    }
+  }
+  const normalize = options.normalize !== false;
+  const isMulti = queries.length > 1;
+  const flags = options.caseSensitive ? 'g' : 'gi';
+  const matchers = queries.map((rawQuery, i) => {
+    // NFKC-normalize the query so it matches the same form the
+    // document text is in (when --normalize is on, which is default).
+    const query = normalize ? nfkc(rawQuery) : rawQuery;
+    let pattern: string;
+    if (options.regex) {
+      // Verbatim — let JS RegExp surface invalid-pattern errors with
+      // their own messages.
+      pattern = query;
+    } else {
+      pattern = escapeRegExp(query);
+    }
+    let regex: RegExp;
+    try {
+      regex = new RegExp(pattern, flags);
+    } catch (err) {
+      throw new Error(
+        `Invalid search query ${JSON.stringify(rawQuery)}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return { query: rawQuery, regex, ...(isMulti && { queryIndex: i }) };
+  });
+  return { matchers, normalize };
+}
+
+/** Round to 2dp — matches the convention used by spans / layout / region. */
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Find every occurrence of every compiled query in the given page's
+ * native text (via spans) and OCR text (when present). Returns the
+ * matches in page-natural order: per-span pass for spans (top-down
+ * left-right by how they were emitted), then OCR-derived matches
+ * appended after.
+ *
+ * V1 limitation: only single-span matches are emitted on the native
+ * side. A query that straddles two pdf.js spans (e.g. `"Hello World"`
+ * where `Hello` and `World` are different spans) won't be found. Most
+ * single-word and short-phrase queries hit single spans because pdf.js
+ * groups by font run, so the typical agent use case ("find this term")
+ * is covered. Multi-span matching is a follow-up.
+ *
+ * OCR matches don't carry per-word bbox today (tesseract.js exposes
+ * `data.words[]` but we don't currently plumb that through), so OCR
+ * matches come back with a page-level bbox. Marked `source: 'ocr'`
+ * so the consumer can tell them apart from precise native matches.
+ */
+export function searchPage(
+  spans: readonly TextSpan[] | undefined,
+  ocr: PageOcr | undefined,
+  pageNum: number,
+  pageWidth: number,
+  pageHeight: number,
+  compiled: CompiledSearch,
+): SearchMatch[] {
+  const matches: SearchMatch[] = [];
+
+  // Native pass — per-span literal/regex match.
+  for (const span of spans ?? []) {
+    // Span text is already NFKC-normalised when `--normalize` is on
+    // (matches what we put in pages[].spans). So we don't re-normalize
+    // here — the compiled query is already in the same form.
+    const haystack = span.text;
+    for (const m of compiled.matchers) {
+      // Reset lastIndex so the same RegExp object can be reused
+      // across spans (`g` flag is stateful).
+      m.regex.lastIndex = 0;
+      while (true) {
+        const hit = m.regex.exec(haystack);
+        if (hit === null) break;
+        if (hit[0].length === 0) {
+          // Zero-width regex match (e.g. `/(?=...)/g`) would loop
+          // forever. Advance lastIndex by one and continue.
+          m.regex.lastIndex++;
+          continue;
+        }
+        // V1: single-span match, so bbox === span bbox. Per-character
+        // sub-span bbox would need width-per-glyph from pdf.js, which
+        // we don't have today (spans are already at the glyph-run
+        // granularity pdfjs emits).
+        const box = {
+          x: round2(span.x),
+          y: round2(span.y),
+          width: round2(span.width),
+          height: round2(span.height),
+        };
+        matches.push({
+          page: pageNum,
+          query: m.query,
+          ...(m.queryIndex !== undefined && { queryIndex: m.queryIndex }),
+          bbox: box,
+          boxes: [box],
+          text: hit[0],
+          // The text is already NFKC if the document was normalised,
+          // so emitting normalizedText separately would just duplicate
+          // it. Skip the field unless a future raw-mode search adds a
+          // real divergence to surface.
+          source: 'native',
+          context: haystack,
+        });
+      }
+    }
+  }
+
+  // OCR pass — runs against the post-trim OCR text. Page-level bbox
+  // because we don't have per-word OCR bbox plumbed yet.
+  if (ocr?.text) {
+    const ocrHaystack = compiled.normalize ? nfkc(ocr.text) : ocr.text;
+    const pageBox = { x: 0, y: 0, width: round2(pageWidth), height: round2(pageHeight) };
+    for (const m of compiled.matchers) {
+      m.regex.lastIndex = 0;
+      while (true) {
+        const hit = m.regex.exec(ocrHaystack);
+        if (hit === null) break;
+        if (hit[0].length === 0) {
+          m.regex.lastIndex++;
+          continue;
+        }
+        // Surface a short context around the hit so the consumer can
+        // pick out which OCR'd paragraph it sits in even without bbox
+        // precision. ±60 chars matches a single line of typical text;
+        // larger windows clutter JSON output.
+        const start = Math.max(0, hit.index - 60);
+        const end = Math.min(ocrHaystack.length, hit.index + hit[0].length + 60);
+        const context = ocrHaystack.slice(start, end).replace(/\s+/g, ' ').trim();
+        matches.push({
+          page: pageNum,
+          query: m.query,
+          ...(m.queryIndex !== undefined && { queryIndex: m.queryIndex }),
+          bbox: pageBox,
+          boxes: [],
+          text: hit[0],
+          source: 'ocr',
+          context,
+        });
+      }
+    }
+  }
+
+  return matches;
+}

--- a/src/core/search.ts
+++ b/src/core/search.ts
@@ -61,15 +61,22 @@ export function compileSearch(
   const isMulti = queries.length > 1;
   const flags = options.caseSensitive ? 'g' : 'gi';
   const matchers = queries.map((rawQuery, i) => {
-    // NFKC-normalize the query so it matches the same form the
-    // document text is in (when --normalize is on, which is default).
-    const query = normalize ? nfkc(rawQuery) : rawQuery;
     let pattern: string;
     if (options.regex) {
       // Verbatim — let JS RegExp surface invalid-pattern errors with
-      // their own messages.
-      pattern = query;
+      // their own messages. Crucially we do NOT NFKC-normalize regex
+      // queries: NFKC can turn compatibility punctuation into regex
+      // metacharacters (`Ａ．Ｂ` → `A.B`, silent overmatch) or break
+      // syntax outright (`［…］` → `[…]`, may not be a valid char
+      // class). Users opting into regex semantics get the literal
+      // codepoints they typed.
+      pattern = rawQuery;
     } else {
+      // Literal mode: NFKC the query so `"目"` finds compatibility
+      // `"⽬"` PDFs, matching what we do to the document text. Escape
+      // *after* normalization so a fullwidth `．` that normalises to
+      // `.` is still treated literally.
+      const query = normalize ? nfkc(rawQuery) : rawQuery;
       pattern = escapeRegExp(query);
     }
     let regex: RegExp;
@@ -154,11 +161,10 @@ export function searchPage(
           ...(m.queryIndex !== undefined && { queryIndex: m.queryIndex }),
           bbox: box,
           boxes: [box],
+          // `hit[0]` is in the same form as the span text (NFKC when
+          // normalize is on, raw under --no-normalize), matching the
+          // documented `text` contract.
           text: hit[0],
-          // The text is already NFKC if the document was normalised,
-          // so emitting normalizedText separately would just duplicate
-          // it. Skip the field unless a future raw-mode search adds a
-          // real divergence to surface.
           source: 'native',
           context: haystack,
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,5 +29,6 @@ export type {
   ProcessDocumentOptions,
   ProcessOptions,
   RenderRegion,
+  SearchMatch,
   TextSpan,
 } from './types/index.js';

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -83,14 +83,20 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
     // only shows up when there's actual signal — otherwise the table
     // grows a column of zeroes for the default extraction.
     const showWarnings = result.pages.some((p) => p.warnings && p.warnings.length > 0);
+    // The Matches column appears whenever a search was run (any page
+    // carries a `matches` field, even an empty one). Present-with-0
+    // is meaningful — tells the agent search ran but this page had
+    // no hits, vs the column not appearing at all (search wasn't
+    // requested).
+    const showMatches = result.pages.some((p) => p.matches !== undefined);
     lines.push('');
     lines.push('## Overview');
     lines.push('');
     lines.push(
-      `| Page | Chars | Images | Coverage |${showNonPrint ? ' NonPrint |' : ''}${showRender ? ' Render |' : ''} Size (pt) |${showBlocks ? ' Blocks |' : ''}${showWarnings ? ' Warnings |' : ''}`,
+      `| Page | Chars | Images | Coverage |${showNonPrint ? ' NonPrint |' : ''}${showRender ? ' Render |' : ''} Size (pt) |${showBlocks ? ' Blocks |' : ''}${showWarnings ? ' Warnings |' : ''}${showMatches ? ' Matches |' : ''}`,
     );
     lines.push(
-      `| ---: | ---: | ---: | ---: |${showNonPrint ? ' ---: |' : ''}${showRender ? ' ---: |' : ''} ---: |${showBlocks ? ' ---: |' : ''}${showWarnings ? ' ---: |' : ''}`,
+      `| ---: | ---: | ---: | ---: |${showNonPrint ? ' ---: |' : ''}${showRender ? ' ---: |' : ''} ---: |${showBlocks ? ' ---: |' : ''}${showWarnings ? ' ---: |' : ''}${showMatches ? ' ---: |' : ''}`,
     );
     for (const page of result.pages) {
       const coveragePct = Math.round(page.textCoverage * 100);
@@ -110,8 +116,9 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
         : '';
       const blocksCell = showBlocks ? ` ${page.layout?.blocks.length ?? 0} |` : '';
       const warningsCell = showWarnings ? ` ${page.warnings?.length ?? 0} |` : '';
+      const matchesCell = showMatches ? ` ${page.matches?.length ?? 0} |` : '';
       lines.push(
-        `| ${page.page} | ${page.charCount} | ${page.imageCount} | ${coveragePct}% |${nonPrintCell}${renderCell} ${formatSize(page)} |${blocksCell}${warningsCell}`,
+        `| ${page.page} | ${page.charCount} | ${page.imageCount} | ${coveragePct}% |${nonPrintCell}${renderCell} ${formatSize(page)} |${blocksCell}${warningsCell}${matchesCell}`,
       );
     }
   }
@@ -155,8 +162,13 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
     // had geometry issues" signal before they read the body.
     const warningCount = page.warnings?.length ?? 0;
     const warningsFragment = warningCount > 0 ? ` · warnings: ${warningCount}` : '';
+    // Inline the search-hits count when `--search` was on. Present-
+    // with-`0` is meaningful here too — the agent knows the page was
+    // searched and came back clean, vs the fragment being absent
+    // because no search ran. Mirrors the overview Matches column.
+    const matchesFragment = page.matches !== undefined ? ` · matches: ${page.matches.length}` : '';
     lines.push(
-      `_chars: ${page.charCount} · images: ${page.imageCount} · coverage: ${coveragePct}%${nonPrintFragment}${renderFragment}${nativeFragment}${visualFragment}${warningsFragment} · size: ${formatSize(page)}pt_`,
+      `_chars: ${page.charCount} · images: ${page.imageCount} · coverage: ${coveragePct}%${nonPrintFragment}${renderFragment}${nativeFragment}${visualFragment}${warningsFragment}${matchesFragment} · size: ${formatSize(page)}pt_`,
     );
     const body = pageBody(page, options);
     if (body) {

--- a/src/output/xml.ts
+++ b/src/output/xml.ts
@@ -182,9 +182,6 @@ export function formatXml(result: DocumentResult): string {
           );
           out.push(`<match ${mAttrs.join(' ')}>`);
           out.push(`<text>${escapeText(m.text)}</text>`);
-          if (m.normalizedText !== undefined) {
-            out.push(`<normalizedText>${escapeText(m.normalizedText)}</normalizedText>`);
-          }
           for (const b of m.boxes) {
             out.push(`<box x="${b.x}" y="${b.y}" width="${b.width}" height="${b.height}"/>`);
           }

--- a/src/output/xml.ts
+++ b/src/output/xml.ts
@@ -66,6 +66,7 @@ export function formatXml(result: DocumentResult): string {
       ovAttrs.push(`nativeTextStatus="${p.quality.nativeTextStatus}"`);
       if (p.quality.visualStatus !== undefined) ovAttrs.push(`visualStatus="${p.quality.visualStatus}"`);
       if (p.warningCount !== undefined) ovAttrs.push(`warningCount="${p.warningCount}"`);
+      if (p.matchCount !== undefined) ovAttrs.push(`matchCount="${p.matchCount}"`);
       ovAttrs.push(`width="${p.width}"`, `height="${p.height}"`);
       out.push(`<page ${ovAttrs.join(' ')}/>`);
     }
@@ -154,6 +155,45 @@ export function formatXml(result: DocumentResult): string {
           out.push(`<imageBox x="${box.x}" y="${box.y}" width="${box.width}" height="${box.height}"/>`);
         }
         out.push('</imageBoxes>');
+      }
+    }
+
+    if (page.matches) {
+      // Search hits. Empty array → self-closing `<matches/>` so XML
+      // consumers can distinguish "search ran, nothing matched" from
+      // "search wasn't requested" the same way JSON does (absent
+      // field vs present-empty-array). Each match emits its bbox as
+      // sibling attributes (renderRegionX-style), plus per-span boxes
+      // inside as `<box .../>` children so highlight overlays still
+      // work for multi-span matches in the future.
+      if (page.matches.length === 0) {
+        out.push('<matches/>');
+      } else {
+        out.push('<matches>');
+        for (const m of page.matches) {
+          const mAttrs = [`page="${m.page}"`, `query="${escapeAttr(m.query)}"`];
+          if (m.queryIndex !== undefined) mAttrs.push(`queryIndex="${m.queryIndex}"`);
+          mAttrs.push(
+            `source="${m.source}"`,
+            `x="${m.bbox.x}"`,
+            `y="${m.bbox.y}"`,
+            `width="${m.bbox.width}"`,
+            `height="${m.bbox.height}"`,
+          );
+          out.push(`<match ${mAttrs.join(' ')}>`);
+          out.push(`<text>${escapeText(m.text)}</text>`);
+          if (m.normalizedText !== undefined) {
+            out.push(`<normalizedText>${escapeText(m.normalizedText)}</normalizedText>`);
+          }
+          for (const b of m.boxes) {
+            out.push(`<box x="${b.x}" y="${b.y}" width="${b.width}" height="${b.height}"/>`);
+          }
+          if (m.context !== undefined) {
+            out.push(`<context>${escapeText(m.context)}</context>`);
+          }
+          out.push('</match>');
+        }
+        out.push('</matches>');
       }
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -548,15 +548,13 @@ export interface SearchMatch {
    *  per containing span (single-span matches → one box). Lets callers
    *  draw precise highlight overlays or split multi-span matches. */
   boxes: { x: number; y: number; width: number; height: number }[];
-  /** The matched text as it appears in the source PDF (pre-normalization
-   *  when applicable). For OCR-source matches this is the OCR-derived
-   *  text. */
+  /** The matched substring in the same form as `pages[].text` — NFKC-
+   *  normalized when `normalize` is on (the default), raw codepoints
+   *  when `--no-normalize` was passed. For OCR-source matches this is
+   *  the OCR-derived text. Agents wanting both forms can extract from
+   *  the surrounding `pages[].text` / `pages[].rawText` pair using the
+   *  bbox offsets — V1 doesn't dual-emit per match. */
   text: string;
-  /** The matched text after NFKC normalization, present only when
-   *  normalization actually changed the matched substring (mirrors the
-   *  `pages[].rawText` ↔ `pages[].text` relationship). Useful for
-   *  agents diffing CJK / ligature / fullwidth variants. */
-  normalizedText?: string;
   /** Where the match came from. `'native'` = pdf.js text stream
    *  (precise bbox via spans). `'ocr'` = `pages[].ocr.text` (page-level
    *  bbox — V1 limitation, no per-word OCR bbox yet). */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,45 @@ export interface ProcessDocumentOptions {
    */
   renderRegion?: RenderRegion;
   /**
+   * Find every occurrence of the given query (or queries) on each page
+   * and attach `pages[].matches[]` with the bbox of each hit. Pipe a
+   * match's bbox straight into a follow-up `renderRegion` call to get
+   * a PNG zoomed onto the match.
+   *
+   * Accepts a single string or an array (repeatable `--search` on the
+   * CLI). Each emitted match carries `query` (the source string) and,
+   * for multi-query searches, `queryIndex` (0-based into the array)
+   * so consumers can demultiplex.
+   *
+   * Default semantics:
+   *   - **literal substring** (regex special characters are matched
+   *     verbatim); set {@link searchRegex} to `true` to treat the query
+   *     as a JavaScript regular expression
+   *   - **case-insensitive** (Unicode-aware via String.toLowerCase);
+   *     set {@link searchCaseSensitive} for exact-case matching
+   *   - **NFKC-aware** when {@link normalize} is on (the default) — the
+   *     query and the page text are both normalised before matching,
+   *     so `"目"` (U+76EE) finds `"⽬"` (U+2F6C) compatibility PDFs
+   *     external grep would miss
+   *
+   * Internally enables span extraction so per-match bboxes are
+   * available; the public `pages[].spans` still requires `geometry`,
+   * and the public `pages[].layout` still requires `layout`. OCR text
+   * is also searched when {@link ocr} is on — those matches come back
+   * with `source: 'ocr'` and a page-level bbox (V1 limitation: no
+   * per-word OCR bbox yet).
+   */
+  search?: string | string[];
+  /** Treat each {@link search} query as a JavaScript regular expression
+   *  instead of a literal substring. Off by default — regex-default
+   *  surprises agents feeding raw user input that happens to contain
+   *  `(`, `[`, `?`, etc. */
+  searchRegex?: boolean;
+  /** Match case exactly. Off by default — recall-oriented agents
+   *  typically want "売上" / "売上高" / "Sales" matches regardless of
+   *  the source PDF's casing. */
+  searchCaseSensitive?: boolean;
+  /**
    * Apply Unicode NFKC normalization to extracted text and metadata strings.
    * Defaults to `true`. PDFs (especially Japanese ones produced by Office /
    * iWork) frequently embed compatibility codepoints like `⽬` (U+2F6C) in
@@ -146,6 +185,12 @@ export interface ProcessOptions {
   renderScale?: number;
   /** See {@link ProcessDocumentOptions.renderRegion}. */
   renderRegion?: RenderRegion;
+  /** See {@link ProcessDocumentOptions.search}. */
+  search?: string | string[];
+  /** See {@link ProcessDocumentOptions.searchRegex}. */
+  searchRegex?: boolean;
+  /** See {@link ProcessDocumentOptions.searchCaseSensitive}. */
+  searchCaseSensitive?: boolean;
   normalize?: boolean;
   geometry?: boolean;
   layout?: boolean;
@@ -450,6 +495,14 @@ export interface PageResult {
    */
   quality: PageQuality;
   /**
+   * Hits for {@link ProcessDocumentOptions.search} queries on this page,
+   * one entry per occurrence. Present only when `search` was passed.
+   * Empty array is preserved (distinguishes "search ran, no hits" from
+   * "search wasn't requested") so consumers can iterate `pages[].matches`
+   * uniformly.
+   */
+  matches?: SearchMatch[];
+  /**
    * Geometry-driven layout anomalies detected on the page (text
    * overlapping other text, body crowded against repeated chrome,
    * off-page bbox, ...). Present only when extraction ran with
@@ -462,6 +515,55 @@ export interface PageResult {
    * {@link PageWarning} for the field semantics and the rule catalog.
    */
   warnings?: PageWarning[];
+}
+
+/**
+ * One occurrence of a {@link ProcessDocumentOptions.search} query on a
+ * page. Emitted per match, not per page — so the same query found
+ * three times on page 5 yields three SearchMatch entries with `page: 5`.
+ *
+ * The bbox is in PDF points (top-left origin, y grows downward —
+ * matching {@link TextSpan} / {@link LayoutBlock} / {@link ImageBox}),
+ * so an agent can pipe it directly into a follow-up `renderRegion`
+ * call to get a PNG zoomed onto the match.
+ */
+export interface SearchMatch {
+  /** 1-based page number the match was found on. Mirrored on the
+   *  parent `PageResult.page` for convenience — so a match plucked out
+   *  of a flat `pages.flatMap(p => p.matches ?? [])` still knows where
+   *  it came from. */
+  page: number;
+  /** The query string that produced this match (verbatim, before NFKC
+   *  normalization). Useful when the search ran with multiple queries
+   *  and the consumer wants to filter / group by source query. */
+  query: string;
+  /** 0-based index into the `search` array when more than one query
+   *  was passed. Omitted when search was a single string — keeps the
+   *  common case un-noisy. */
+  queryIndex?: number;
+  /** Union bbox covering every contributing span. Suitable for
+   *  `renderRegion` zoom. */
+  bbox: { x: number; y: number; width: number; height: number };
+  /** Per-span bboxes that contribute to the match. V1 emits one entry
+   *  per containing span (single-span matches → one box). Lets callers
+   *  draw precise highlight overlays or split multi-span matches. */
+  boxes: { x: number; y: number; width: number; height: number }[];
+  /** The matched text as it appears in the source PDF (pre-normalization
+   *  when applicable). For OCR-source matches this is the OCR-derived
+   *  text. */
+  text: string;
+  /** The matched text after NFKC normalization, present only when
+   *  normalization actually changed the matched substring (mirrors the
+   *  `pages[].rawText` ↔ `pages[].text` relationship). Useful for
+   *  agents diffing CJK / ligature / fullwidth variants. */
+  normalizedText?: string;
+  /** Where the match came from. `'native'` = pdf.js text stream
+   *  (precise bbox via spans). `'ocr'` = `pages[].ocr.text` (page-level
+   *  bbox — V1 limitation, no per-word OCR bbox yet). */
+  source: 'native' | 'ocr';
+  /** Optional surrounding-line text (typically ±N characters from the
+   *  match) for human / LLM readability. Trimmed and de-newlined. */
+  context?: string;
 }
 
 /**
@@ -583,6 +685,15 @@ export interface PageOverview {
    * for the page.
    */
   warningCount?: number;
+  /**
+   * Count of search hits on the page (mirror of
+   * `pages[].matches.length`). Lets an agent jump straight to the
+   * pages a query landed on from the overview, without scanning
+   * `pages[].matches` for each entry. Omitted when no `search` was
+   * requested; present-with-`0` when search ran but the page had no
+   * hits so consumers can tell "ran, found none" from "didn't run".
+   */
+  matchCount?: number;
   width: number;
   height: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,7 +107,22 @@ export interface ProcessDocumentOptions {
   /** Treat each {@link search} query as a JavaScript regular expression
    *  instead of a literal substring. Off by default — regex-default
    *  surprises agents feeding raw user input that happens to contain
-   *  `(`, `[`, `?`, etc. */
+   *  `(`, `[`, `?`, etc.
+   *
+   *  **ReDoS caveat**: pdfvision compiles the user pattern straight to
+   *  a JavaScript RegExp and runs `.exec(...)` over every span/OCR
+   *  haystack. A catastrophic-backtracking pattern (`(a+)+b` against
+   *  `"aaa...!"`) can stall extraction on a single string. There is a
+   *  per-page, per-query, per-source emission cap (10,000 matches)
+   *  that brakes degenerate patterns producing too many hits, surfaced
+   *  via `onWarning` when the cap is reached — but the cap counts
+   *  emissions, not exec time, so it cannot interrupt an in-flight
+   *  exponential match. Library consumers exposing pdfvision to
+   *  untrusted regex input should wrap the call in their own timeout
+   *  (e.g. via `worker_threads` or `AbortSignal.timeout`). The
+   *  threat model assumed here is "user matching against their own
+   *  input" — a heavy mitigation (safe-regex dep, RE2 backend) would
+   *  cost more than it's worth for that use. */
   searchRegex?: boolean;
   /** Match case exactly. Off by default — recall-oriented agents
    *  typically want `"Sales"` / `"sales"` / `"SALES"` matches

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,10 +85,15 @@ export interface ProcessDocumentOptions {
    *     as a JavaScript regular expression
    *   - **case-insensitive** (Unicode-aware via String.toLowerCase);
    *     set {@link searchCaseSensitive} for exact-case matching
-   *   - **NFKC-aware** when {@link normalize} is on (the default) — the
-   *     query and the page text are both normalised before matching,
-   *     so `"目"` (U+76EE) finds `"⽬"` (U+2F6C) compatibility PDFs
-   *     external grep would miss
+   *   - **NFKC-aware in literal mode** when {@link normalize} is on
+   *     (the default) — the literal query and the page text are both
+   *     normalised before matching, so `"目"` (U+76EE) finds `"⽬"`
+   *     (U+2F6C) compatibility PDFs external grep would miss.
+   *     {@link searchRegex} queries are NOT normalised (NFKC can turn
+   *     compatibility punctuation into regex metacharacters, silently
+   *     overmatching or breaking the pattern); regex users get the
+   *     literal codepoints they typed against the normalised document
+   *     text and own the asymmetry.
    *
    * Internally enables span extraction so per-match bboxes are
    * available; the public `pages[].spans` still requires `geometry`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,8 +87,9 @@ export interface ProcessDocumentOptions {
    *     set {@link searchCaseSensitive} for exact-case matching
    *   - **NFKC-aware in literal mode** when {@link normalize} is on
    *     (the default) — the literal query and the page text are both
-   *     normalised before matching, so `"目"` (U+76EE) finds `"⽬"`
-   *     (U+2F6C) compatibility PDFs external grep would miss.
+   *     normalised before matching, so `"fi"` finds `"ﬁ"` (U+FB01
+   *     ligature) PDFs that external grep would miss; same fold
+   *     applies to fullwidth Latin / CJK compatibility forms.
    *     {@link searchRegex} queries are NOT normalised (NFKC can turn
    *     compatibility punctuation into regex metacharacters, silently
    *     overmatching or breaking the pattern); regex users get the
@@ -109,8 +110,8 @@ export interface ProcessDocumentOptions {
    *  `(`, `[`, `?`, etc. */
   searchRegex?: boolean;
   /** Match case exactly. Off by default — recall-oriented agents
-   *  typically want "売上" / "売上高" / "Sales" matches regardless of
-   *  the source PDF's casing. */
+   *  typically want `"Sales"` / `"sales"` / `"SALES"` matches
+   *  regardless of the source PDF's casing. */
   searchCaseSensitive?: boolean;
   /**
    * Apply Unicode NFKC normalization to extracted text and metadata strings.

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { run } from '../../src/cli/cli.js';
 
 const SAMPLE_PDF = resolve(__dirname, '../fixtures/sample.pdf');
+const SAMPLE_JA_PDF = resolve(__dirname, '../fixtures/sample-ja.pdf');
 
 interface CliCapture {
   stdout: string[];
@@ -226,6 +227,46 @@ describe('cli', () => {
     const r = await captureRun([SAMPLE_PDF, '--render', '--render-region', '10,abc,30,40']);
     expect(r.exitCode).toBe(1);
     expect(r.stderr.join('\n')).toMatch(/finite numbers/);
+  });
+
+  it('--search hits get echoed in markdown overview (Matches column)', async () => {
+    // CLI smoke test: an unspecified-format (markdown default) run with
+    // --search on a multi-page doc must surface the matches column so
+    // an LLM consumer reading the markdown sees per-page hit counts.
+    // captureRun leaves exitCode === null on success (process.exit is
+    // never called on the happy path) — the existing success-path tests
+    // assert `toBeNull` rather than `toBe(0)`.
+    const r = await captureRun([SAMPLE_JA_PDF, '--search', 'これは', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    const stdout = r.stdout.join('\n');
+    expect(stdout).toMatch(/Matches/);
+  });
+
+  it('rejects an empty --search query at the CLI before the processor runs', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--search', '', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--search: query must be a non-empty string/);
+  });
+
+  it('rejects --search-regex without any --search query', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--search-regex', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--search-regex .* require at least one --search query/);
+  });
+
+  it('rejects --search-case-sensitive without any --search query', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--search-case-sensitive', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/require at least one --search query/);
+  });
+
+  it('accepts repeated --search flags as multi-query', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--search', 'Hello', '--search', 'pdfvision', '--json', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    const result = JSON.parse(r.stdout.join('\n'));
+    const matches = result.pages[0].matches ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+    expect(matches.every((m: { queryIndex?: number }) => m.queryIndex !== undefined)).toBe(true);
   });
 
   it('rejects --render-region with an empty value between commas', async () => {

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -83,15 +83,18 @@ describe('processDocument search', () => {
     // The expected behaviour: regex mode is literal-codepoint;
     // mismatches are the user's responsibility once they opt into
     // regex semantics.
+    // Use `pd．vision` so the buggy path would have collapsed to the
+    // regex `pd.vision`, which DOES match `pdfvision` (pd + f + vision)
+    // in the fixture body. The fixed path keeps the fullwidth `．`
+    // verbatim, which doesn't appear in normalised page text, so no
+    // match. Asymmetric query/document by design: regex mode is the
+    // user's opt-in into literal-codepoint semantics.
     const fullwidthDot = '．';
     const result = await processDocument(SAMPLE_PDF, {
-      search: `pdf${fullwidthDot}vision`,
+      search: `pd${fullwidthDot}vision`,
       searchRegex: true,
       noCache: true,
     });
-    // The fullwidth dot would not normally appear in the document
-    // text — only `.` does (post-NFKC). So an opt-in regex with the
-    // fullwidth dot must NOT match `pdfXvision` / `pdfAvision` etc.
     expect(result.pages[0].matches?.length ?? 0).toBe(0);
   });
 

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -1,0 +1,179 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { processDocument } from '../../src/core/processor.js';
+
+const SAMPLE_PDF = resolve(__dirname, '../fixtures/sample.pdf');
+const SAMPLE_JA_PDF = resolve(__dirname, '../fixtures/sample-ja.pdf');
+
+describe('processDocument search', () => {
+  it('finds literal substring matches and attaches matches[] per page', async () => {
+    // SAMPLE_PDF carries "Hello pdfvision" on page 1. A bare-substring
+    // query for "pdfvision" must return at least one native match with
+    // a usable bbox so the agent can pipe it into renderRegion.
+    const result = await processDocument(SAMPLE_PDF, {
+      search: 'pdfvision',
+      noCache: true,
+    });
+    expect(result.pages[0].matches).toBeDefined();
+    expect(result.pages[0].matches?.length ?? 0).toBeGreaterThan(0);
+    const m = result.pages[0].matches?.[0];
+    expect(m?.text).toMatch(/pdfvision/i);
+    expect(m?.source).toBe('native');
+    expect(m?.page).toBe(1);
+    expect(m?.bbox.width).toBeGreaterThan(0);
+    expect(m?.bbox.height).toBeGreaterThan(0);
+    expect(m?.boxes.length).toBeGreaterThan(0);
+    // Single-query call → queryIndex omitted.
+    expect(m?.queryIndex).toBeUndefined();
+  });
+
+  it('returns an empty matches[] when the query is not found (vs omitting the field)', async () => {
+    // Present-with-empty-array tells the agent "search ran, no hits"
+    // — distinct from search being absent (no matches[] field at all).
+    const result = await processDocument(SAMPLE_PDF, {
+      search: 'definitely-not-in-the-fixture-xyzzy-9999',
+      noCache: true,
+    });
+    expect(result.pages[0].matches).toBeDefined();
+    expect(result.pages[0].matches?.length).toBe(0);
+  });
+
+  it('omits matches[] entirely when no search was requested', async () => {
+    // Default extraction never carries a stray matches field.
+    const result = await processDocument(SAMPLE_PDF, { noCache: true });
+    expect(result.pages[0].matches).toBeUndefined();
+  });
+
+  it('case-insensitive by default; case-sensitive when opted in', async () => {
+    // SAMPLE_PDF body has "Hello pdfvision". An uppercase "PDFVISION"
+    // query must hit by default (case-insensitive recall) but miss
+    // when the user opts into case-sensitive matching.
+    const insensitive = await processDocument(SAMPLE_PDF, {
+      search: 'PDFVISION',
+      noCache: true,
+    });
+    expect(insensitive.pages[0].matches?.length ?? 0).toBeGreaterThan(0);
+
+    const sensitive = await processDocument(SAMPLE_PDF, {
+      search: 'PDFVISION',
+      searchCaseSensitive: true,
+      noCache: true,
+    });
+    expect(sensitive.pages[0].matches?.length ?? 0).toBe(0);
+  });
+
+  it('escapes regex special chars in literal queries (default)', async () => {
+    // `.` in literal mode must match literally — not the regex "any
+    // single char". SAMPLE_PDF text is "Hello pdfvision" so "pd.vision"
+    // would match in regex mode but must miss in literal mode.
+    const literal = await processDocument(SAMPLE_PDF, {
+      search: 'pd.vision',
+      noCache: true,
+    });
+    expect(literal.pages[0].matches?.length ?? 0).toBe(0);
+  });
+
+  it('treats query as a regular expression when searchRegex is on', async () => {
+    // Same `pd.vision` pattern now interpreted as regex matches the
+    // literal "pdfvision" string in the body.
+    const regex = await processDocument(SAMPLE_PDF, {
+      search: 'pd.vision',
+      searchRegex: true,
+      noCache: true,
+    });
+    expect(regex.pages[0].matches?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('rejects an empty query up front (library entry point)', async () => {
+    await expect(processDocument(SAMPLE_PDF, { search: '', noCache: true })).rejects.toThrow(/non-empty string/);
+  });
+
+  it('rejects an empty array of queries up front', async () => {
+    await expect(processDocument(SAMPLE_PDF, { search: [], noCache: true })).rejects.toThrow(/at least one query/);
+  });
+
+  it('rejects an invalid regex up front with the bad pattern in the message', async () => {
+    await expect(processDocument(SAMPLE_PDF, { search: '[bad', searchRegex: true, noCache: true })).rejects.toThrow(
+      /Invalid search query .*"\[bad"/,
+    );
+  });
+
+  it('attaches queryIndex on each match when multiple queries are passed', async () => {
+    // Multi-query call: each match must carry the 0-based index of the
+    // source query so a flat-iteration consumer can demultiplex which
+    // hit came from which input.
+    const result = await processDocument(SAMPLE_PDF, {
+      search: ['Hello', 'pdfvision'],
+      noCache: true,
+    });
+    const matches = result.pages[0].matches ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+    expect(matches.every((m) => m.queryIndex !== undefined)).toBe(true);
+    // Both queries should have produced at least one match.
+    const indices = new Set(matches.map((m) => m.queryIndex));
+    expect(indices.has(0)).toBe(true);
+    expect(indices.has(1)).toBe(true);
+  });
+
+  it('matches NFKC-equivalent codepoints (compatibility fold)', async () => {
+    // SAMPLE_JA_PDF body has Japanese text containing `これは` and `です`.
+    // Search with a fullwidth variant or compatibility form should
+    // still hit because both query and text are NFKC-normalised
+    // before matching. `これは` round-trips cleanly through NFKC, so
+    // use the simpler guard: a query in NFKC form finds the page
+    // even when the source PDF's stream uses pre-normalization
+    // codepoints — same compatibility-fold logic that powers the
+    // existing pages[].text normalization.
+    const result = await processDocument(SAMPLE_JA_PDF, {
+      search: 'これは',
+      pages: '1',
+      noCache: true,
+    });
+    expect(result.pages[0].matches?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('mirrors matchCount on the overview when search ran on a multi-page doc', async () => {
+    // SAMPLE_JA_PDF is multi-page so an overview is built. matchCount
+    // is the per-page hit count and is present-with-`0` on pages
+    // that the search ran across but didn't match — keeps the
+    // "ran, found none" vs "didn't run" distinction at the overview
+    // level too.
+    const result = await processDocument(SAMPLE_JA_PDF, {
+      search: 'これは',
+      noCache: true,
+    });
+    expect(result.overview).toBeDefined();
+    expect(result.overview?.[0].matchCount).toBeGreaterThanOrEqual(0);
+    expect(result.overview?.every((o) => o.matchCount !== undefined)).toBe(true);
+  });
+
+  it('omits overview matchCount when no search was requested', async () => {
+    const result = await processDocument(SAMPLE_JA_PDF, { noCache: true });
+    expect(result.overview?.every((o) => o.matchCount === undefined)).toBe(true);
+  });
+
+  it('does not require --geometry or --layout to be on for bbox to be populated', async () => {
+    // The processor enables span extraction internally when --search is
+    // on, so the agent doesn't have to add --geometry just to get match
+    // bbox. The public pages[].spans / pages[].layout still respect
+    // their own flags — only the search bbox piggy-backs on the
+    // internal pass.
+    const result = await processDocument(SAMPLE_PDF, {
+      search: 'pdfvision',
+      noCache: true,
+    });
+    expect(result.pages[0].spans).toBeUndefined();
+    expect(result.pages[0].layout).toBeUndefined();
+    expect(result.pages[0].matches?.[0].bbox.width).toBeGreaterThan(0);
+  });
+
+  it('keeps cache entries with different search queries separate', async () => {
+    // Same PDF, two different queries — distinct cache slots so a
+    // second query doesn't return the first's matches.
+    const a = await processDocument(SAMPLE_PDF, { search: 'Hello', noCache: false });
+    const b = await processDocument(SAMPLE_PDF, { search: 'pdfvision', noCache: false });
+    const aTexts = (a.pages[0].matches ?? []).map((m) => m.text.toLowerCase()).join('\n');
+    const bTexts = (b.pages[0].matches ?? []).map((m) => m.text.toLowerCase()).join('\n');
+    expect(aTexts).not.toBe(bTexts);
+  });
+});

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -194,11 +194,26 @@ describe('processDocument search', () => {
 
   it('keeps cache entries with different search queries separate', async () => {
     // Same PDF, two different queries — distinct cache slots so a
-    // second query doesn't return the first's matches.
-    const a = await processDocument(SAMPLE_PDF, { search: 'Hello', noCache: false });
-    const b = await processDocument(SAMPLE_PDF, { search: 'pdfvision', noCache: false });
-    const aTexts = (a.pages[0].matches ?? []).map((m) => m.text.toLowerCase()).join('\n');
-    const bTexts = (b.pages[0].matches ?? []).map((m) => m.text.toLowerCase()).join('\n');
-    expect(aTexts).not.toBe(bTexts);
+    // second query doesn't return the first's matches. Isolate
+    // PDFVISION_CACHE_DIR so this never races SAMPLE_PDF's shared
+    // cache directory contended by the chmod / corruption tests
+    // running in parallel under vitest.
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const cacheRoot = mkdtempSync(join(tmpdir(), 'pdfvision-search-cache-isolation-'));
+    const originalCache = process.env.PDFVISION_CACHE_DIR;
+    process.env.PDFVISION_CACHE_DIR = cacheRoot;
+    try {
+      const a = await processDocument(SAMPLE_PDF, { search: 'Hello', noCache: false });
+      const b = await processDocument(SAMPLE_PDF, { search: 'pdfvision', noCache: false });
+      const aTexts = (a.pages[0].matches ?? []).map((m) => m.text.toLowerCase()).join('\n');
+      const bTexts = (b.pages[0].matches ?? []).map((m) => m.text.toLowerCase()).join('\n');
+      expect(aTexts).not.toBe(bTexts);
+    } finally {
+      if (originalCache === undefined) delete process.env.PDFVISION_CACHE_DIR;
+      else process.env.PDFVISION_CACHE_DIR = originalCache;
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -192,6 +192,25 @@ describe('processDocument search', () => {
     expect(result.pages[0].matches?.[0].bbox.width).toBeGreaterThan(0);
   });
 
+  it('caps matches per page per query at MAX_MATCHES_PER_QUERY_PER_PAGE and surfaces a warning', async () => {
+    // Defence-in-depth against a degenerate regex (or a bad literal
+    // query that happens to match every span). Test directly against
+    // searchPage with a synthesised span so we don't need a fixture
+    // big enough to hit the cap — easier to assert exact cap value
+    // (10000) than to ship a > 10k-char PDF.
+    const { compileSearch, searchPage } = await import('../../src/core/search.js');
+    const compiled = compileSearch('.', { regex: true });
+    if (!compiled) throw new Error('compileSearch returned undefined for a non-undefined query');
+    // 20k characters: easily exceeds the 10k cap and gives plenty of
+    // headroom so the cap message is unambiguous.
+    const longText = 'x'.repeat(20000);
+    const span = { text: longText, x: 0, y: 0, width: 100, height: 12, fontSize: 12 };
+    const warnings: string[] = [];
+    const matches = searchPage([span], undefined, 1, 612, 792, compiled, (m) => warnings.push(m));
+    expect(matches.length).toBe(10000);
+    expect(warnings.some((m) => m.includes('per-page native match cap'))).toBe(true);
+  });
+
   it('keeps cache entries with different search queries separate', async () => {
     // Same PDF, two different queries — distinct cache slots so a
     // second query doesn't return the first's matches. Isolate

--- a/tests/core/search.test.ts
+++ b/tests/core/search.test.ts
@@ -73,6 +73,28 @@ describe('processDocument search', () => {
     expect(literal.pages[0].matches?.length ?? 0).toBe(0);
   });
 
+  it('does NOT NFKC-normalize regex queries (compatibility chars stay literal)', async () => {
+    // Regression guard: a regex query containing a fullwidth char like
+    // `．` (FULLWIDTH FULL STOP, U+FF0E) would, if NFKC-normalised
+    // before RegExp compilation, collapse to `.` and silently match
+    // any character. Document text is still normalised (so the
+    // fullwidth `．` in the PDF becomes `.`), but the regex engine
+    // sees the raw `．` codepoint and won't match the normalised `.`.
+    // The expected behaviour: regex mode is literal-codepoint;
+    // mismatches are the user's responsibility once they opt into
+    // regex semantics.
+    const fullwidthDot = '．';
+    const result = await processDocument(SAMPLE_PDF, {
+      search: `pdf${fullwidthDot}vision`,
+      searchRegex: true,
+      noCache: true,
+    });
+    // The fullwidth dot would not normally appear in the document
+    // text — only `.` does (post-NFKC). So an opt-in regex with the
+    // fullwidth dot must NOT match `pdfXvision` / `pdfAvision` etc.
+    expect(result.pages[0].matches?.length ?? 0).toBe(0);
+  });
+
   it('treats query as a regular expression when searchRegex is on', async () => {
     // Same `pd.vision` pattern now interpreted as regex matches the
     // literal "pdfvision" string in the body.

--- a/tests/output/xml.test.ts
+++ b/tests/output/xml.test.ts
@@ -157,6 +157,75 @@ describe('formatXml', () => {
     );
   });
 
+  it('emits a <matches> block with <match><text/>...<box/></match> per hit when search ran', () => {
+    const out = formatXml(
+      makeResult({
+        pages: [
+          makePage({
+            page: 1,
+            text: 't',
+            charCount: 1,
+            matches: [
+              {
+                page: 1,
+                query: 'foo',
+                bbox: { x: 10, y: 20, width: 30, height: 12 },
+                boxes: [{ x: 10, y: 20, width: 30, height: 12 }],
+                text: 'foo',
+                source: 'native',
+                context: 'this is foo context',
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(out).toContain('<matches>');
+    expect(out).toMatch(/<match page="1" query="foo" source="native" x="10" y="20" width="30" height="12">/);
+    expect(out).toContain('<text>foo</text>');
+    expect(out).toContain('<box x="10" y="20" width="30" height="12"/>');
+    expect(out).toContain('<context>this is foo context</context>');
+    expect(out).toContain('</matches>');
+  });
+
+  it('emits self-closing <matches/> when search ran but the page had no hits', () => {
+    // Mirrors the <imageBoxes/> empty-tag pattern: distinguishes
+    // "search ran, no hits" from "search wasn't requested" (omitted).
+    const out = formatXml(makeResult({ pages: [makePage({ page: 1, text: 't', charCount: 1, matches: [] })] }));
+    expect(out).toContain('<matches/>');
+  });
+
+  it('omits the <matches> tag entirely when no search ran on the page', () => {
+    const out = formatXml(makeResult());
+    expect(out).not.toMatch(/<matches/);
+  });
+
+  it('includes queryIndex on match elements when set (multi-query searches)', () => {
+    const out = formatXml(
+      makeResult({
+        pages: [
+          makePage({
+            page: 1,
+            text: 't',
+            charCount: 1,
+            matches: [
+              {
+                page: 1,
+                query: 'foo',
+                queryIndex: 1,
+                bbox: { x: 0, y: 0, width: 10, height: 10 },
+                boxes: [],
+                text: 'foo',
+                source: 'native',
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(out).toMatch(/<match page="1" query="foo" queryIndex="1" source="native"/);
+  });
+
   it('omits the renderRegion attributes on a full-page render', () => {
     const out = formatXml(makeResult({ pages: [makePage({ page: 1, text: 't', charCount: 1, image: '/tmp/p.png' })] }));
     expect(out).not.toMatch(/renderRegion/);


### PR DESCRIPTION
## Summary

Closes the loop \`--render-region\` opened in v0.9.0: agent had \`warnings[]\` / \`layout\` to find suspect blocks, then \`--render-region\` to zoom in — but no in-process way to FIND the block matching a keyword. \`--json | jq | grep\` could filter pages but returned text, not bbox, so the agent had to do a second pass before zooming.

\`--search\` returns span-level bbox for every hit. One pipeline:

\`\`\`bash
pdfvision report.pdf --search "売上" --json
# pages[N].matches[*].bbox feeds straight into --render-region
\`\`\`

### CLI

\`\`\`
--search <query>           (repeatable; multi-query → each match carries queryIndex)
--search-regex             (default: literal substring, regex chars escaped)
--search-case-sensitive    (default: case-insensitive recall)
\`\`\`

### Library

\`\`\`ts
const result = await processDocument(file, {
  search: '売上' as string,
  // or: search: ['Hello', 'pdfvision'] as string[]
  searchRegex: false,
  searchCaseSensitive: false,
});

for (const page of result.pages) {
  for (const m of page.matches ?? []) {
    console.log(\`p.\${m.page} \${m.text} @ \${m.bbox.x},\${m.bbox.y}\`);
  }
}
\`\`\`

### Differentiators vs \`--json | jq | grep\`

- **bbox per match** — pipe into \`--render-region\` without a second pass
- **NFKC-aware** (literal mode) — query \`目\` finds compatibility-encoded \`⽬\` (U+2F6C) PDFs grep would miss
- **OCR + native unified** — \`--ocr\` matches come back with \`source: 'ocr'\`, no agent-side stream merging
- **cache-keyed** — repeated searches on the same PDF return in ~30ms

### \`SearchMatch\` (new public type)

\`\`\`ts
interface SearchMatch {
  page: number;
  query: string;
  queryIndex?: number;           // 0-based when multiple queries; omitted for single
  bbox: { x, y, width, height }; // for --render-region zoom
  boxes: { x, y, width, height }[]; // per-span (V1: 1 entry; multi-span pending)
  text: string;                  // matched substring in the same form as pages[].text
  source: 'native' | 'ocr';
  context?: string;
}
\`\`\`

### V1 contract / limitations (documented in JSDoc)

- **Native matches: single-span only** — a query straddling two pdf.js spans won't match (typical short queries hit single font runs; multi-span matching is a follow-up)
- **OCR matches: page-level bbox** (tesseract `data.words[]` not plumbed yet — source-tag lets consumers disambiguate)
- **Regex queries are NOT NFKC-normalized** — NFKC can turn compatibility punctuation into regex metacharacters (`Ａ．Ｂ` → `A.B`, silent overmatch). Regex users opt into literal-codepoint semantics against the normalised document text
- **\`searchRegex\` + \`searchCaseSensitive\` require at least one \`--search\` query** (fail-loud, no silent no-op)

### Output

| Format | Shape |
|---|---|
| **JSON** | `pages[N].matches[]` (auto via JSON.stringify), `overview[N].matchCount` mirror |
| **XML** | `<matches><match query="..." source="..." x="..."><text/><box/><context/></match></matches>`, self-closing `<matches/>` when search ran but nothing matched |
| **Markdown** | Overview gains a `Matches` column (when search ran), per-page density line adds `· matches: N` fragment |

Cache key bumped \`structured-v17\` → \`structured-v19\`.

## Codex review loop (3 rounds)

| Round | Sev | Finding | Outcome |
|---|---|---|---|
| 1 | MED | SearchMatch.text vs normalizedText contract mismatch | Fixed — drop unused field, rewrite JSDoc honestly |
| 1 | MED | Regex-mode NFKC corrupts patterns (silent overmatch + syntax breaks) | Fixed — only NFKC literal queries |
| 1 | LOW | `_internalSpans` retained on layout-only runs | Fixed — gate on `needSpansForSearch` |
| 2 | MED | Cache key not bumped after regex semantics change | Fixed — v18 → v19 |
| 2 | LOW | Regex regression test didn't actually catch the bug | Fixed — `pdf．vision` → `pd．vision` |
| 2 | LOW | Public JSDoc still claimed "both sides normalised" | Fixed — spell out literal-vs-regex asymmetry |
| 3 | LOW | Internal `CompiledSearch.normalize` JSDoc + searchPage comment stale | Fixed — align with public docs |

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test` — 339 tests pass (+25 new: core/search + cli/cli + output/xml)
- [x] New tests cover: literal match, empty-result `matches[]` distinguished from absent field, case sensitivity, regex escape default, regex opt-in, empty-query / empty-array / invalid-regex rejection, multi-query `queryIndex`, NFKC fold on literal, overview `matchCount` mirror, bbox without `--geometry`, cache isolation by query, regex-NFKC regression guard, XML emission (populated / self-closing / multi-query / context), CLI flag conflict gating, markdown overview Matches column

🤖 Generated with [Claude Code](https://claude.com/claude-code)