### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Minor release. Two agent-loop-closing additions since v0.9.0:

### TOON output format (#56)

\`-f toon\` / \`--toon\` — [Token-Oriented Object Notation](https://toonformat.dev), a lossless, schema-aware re-encoding of the same \`DocumentResult\` as \`-f json\`, tuned for tight LLM token budgets.

The win is concentrated in **uniform-array-heavy output**: \`--geometry\` (spans) drops ~40–48% of tokens vs pretty-printed JSON because spans collapse into a CSV-like tabular form that names fields once. On plain text-body extraction the saving is negligible (free text doesn't compress), and on \`--layout\` (nested, non-uniform blocks) \`-f xml\` is usually more compact than \`toon\`. Reach for \`toon\` specifically when handing span/geometry-dense output to an LLM; otherwise \`json\` / \`xml\` remain the defaults. Decode back to the JSON data model with the \`@toon-format/toon\` package, so programmatic consumers lose nothing.

\`\`\`bash
npx pdfvision doc.pdf -f toon --geometry
\`\`\`

### \`--search <query>\` — find with bbox, pipe into --render-region (#55)

The agent's missing piece in the \`--layout → --render-region\` find-then-zoom loop. Previously the agent could spot a suspect *block* via \`warnings[]\` and zoom into it; now they can spot a *keyword* and zoom into it the same way:

\`\`\`bash
pdfvision report.pdf --search "revenue" --json
# pages[N].matches[*].bbox feeds straight into --render-region
\`\`\`

**CLI**: \`--search <query>\` (repeatable for multi-query), \`--search-regex\`, \`--search-case-sensitive\`.

**Library**: \`processDocument(file, { search: 'foo' | ['foo', 'bar'], searchRegex?, searchCaseSensitive? })\`.

\`SearchMatch\` (new public type):

\`\`\`ts
interface SearchMatch {
  page: number;
  query: string;
  queryIndex?: number;           // 0-based when multiple queries
  bbox: { x, y, width, height }; // feeds directly into --render-region
  boxes: { x, y, width, height }[]; // per-span (V1: 1 entry)
  text: string;                  // in same form as pages[].text
  source: 'native' | 'ocr';
  context?: string;
}
\`\`\`

**Semantics**:
- Literal substring by default (regex chars escaped); \`--search-regex\` for JS regex
- Case-insensitive by default; \`--search-case-sensitive\` for exact-case
- **NFKC-aware in literal mode** — \`"fi"\` finds compatibility ligature \`"ﬁ"\` (U+FB01) PDFs external grep would miss
- Regex queries are NOT NFKC-normalised (NFKC can turn compatibility punctuation into regex metacharacters, silent overmatch / syntax break); regex users get literal codepoints against normalised document text
- OCR text is searched too when \`--ocr\` is on (matches tagged \`source: 'ocr'\`, page-level bbox)
- Per-page, per-query, per-source emission cap of 10,000 matches with \`onWarning\` notification — defence-in-depth against degenerate regex (does NOT mitigate catastrophic backtracking; documented caveat in JSDoc)

**Output**:
- JSON: \`pages[N].matches[]\`, \`overview[N].matchCount\` mirror
- XML: \`<matches><match><text/><box/><context/></match></matches>\` (self-closing \`<matches/>\` for empty)
- Markdown: overview gains \`Matches\` column, per-page density line adds \`· matches: N\`
- TOON: same data through the lossless re-encoder

**V1 limitations** (JSDoc-documented):
- Native matches are single-span only
- OCR matches use page-level bbox

### Other
- Skill (\`skills/pdfvision/\`) updated for both features
- Cache key bumped through \`v17\` → \`v19\` (TOON didn't bump; search bumps it)

## Install

\`\`\`bash
npm install pdfvision@0.10.0
\`\`\`

**Full Changelog**: https://github.com/yamadashy/pdfvision/compare/v0.9.0...v0.10.0

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 346 tests pass
- [ ] After merge: tag v0.10.0, trigger npm-publish workflow, cut GitHub release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)