### PR TITLE
Remove npm link from docs navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -180,7 +180,6 @@ const guideSidebar = (prefix: string, labels: LocaleLabels): DefaultTheme.Sideba
 const nav = (prefix: string, labels: LocaleLabels): DefaultTheme.NavItem[] => [
   { text: labels.guide, link: withPrefix(prefix, '/guide/'), activeMatch: `${prefix}/guide/` },
   { text: 'GitHub', link: githubUrl },
-  { text: 'npm', link: npmUrl },
 ];
 
 const themeConfig = (prefix: string, labels: LocaleLabels): DefaultTheme.Config => ({


### PR DESCRIPTION
## Summary
- Remove the npm link from the top-level VitePress navigation
- Keep npm references in installation docs and structured metadata

## Verification
- npm run docs:build