### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Bumps the package version to 0.12.0 (package.json + package-lock.json), mirroring the structure of the previous release PRs (#57, #54, #47). No code changes — everything below already landed on `main` via the merged training-loop PRs (#79, #82, #85) and related work since v0.11.0.

Verification on this branch (rebased on `main` after #85): `npm run lint` (clean, no auto-fixes), `npm run build`, `npm test` (1135 tests, 56 files, all passing).

Publishing stays manual: after this merges, tag `v0.12.0` and run the `npm-publish` workflow via `workflow_dispatch` (neither happens automatically).

## Draft release notes

### What's New

v0.12.0 is the largest release yet: three training-loop rounds (#79, #82, #85) ran pdfvision against diverse real-world PDFs — financial reports, IRS/government forms, scanned documents, slide decks, Japanese books and forms, charts and maps — and fixed what broke. Headline features: Japanese vertical text (tategaki) extraction with ruby support, and glyph-garbage detection.

#### Japanese vertical text (tategaki) and ruby

- Vertical CJK body columns are now detected and joined right-to-left into `pages[].text` in human reading order — vertical books, government documents, and literary PDFs go from shredded single characters to searchable prose (a vertical government document went from 0 to 16 `--search` hits).
- Ruby (furigana) is recognized and attached inline as `基《よみ》` instead of corrupting the base text — for vertical text, horizontal (yokogaki) text, InDesign-style multi-character base spans, and split readings that are merged back into single groups (`京都《きょ》《う》` → `京都《きょう》`). Pinyin readings above CJK bases get the same treatment (`云何梵《yúnhéfàn》`).
- Search runs against both ruby-inclusive and ruby-stripped forms of the text, so `--search` finds terms whether or not the query includes readings, and ruby-reading hits report the true glyph geometry.
- Tatechuyoko (horizontal digits inside vertical columns) stays inline, gutter note marks no longer shred vertical columns, and gutter annotations require CJK text so ASCII fragments cannot masquerade as annotations.

#### Glyph-garbage pages now warn instead of passing silently

- Pages whose native text layer is raw glyph-index or private-use garbage (fonts without a usable ToUnicode CMap) now emit a `glyph_garbage_text` warning in `warnings[]`, steering agents to inspect the render or run OCR instead of trusting the extracted text. The published 0.11.0 reports `warningCount: 0` on such pages — verified on SEC EDGAR `apdpro012708-ars.pdf`, where 130 of 146 pages are affected.
- Related new detections: repeated/duplicated CJK glyph runs, mojibake glyph noise, Unicode replacement characters (`localized_glyph_noise`), fragmented scan text layers, OCR noise on blank renders, raster OCR token mismatches, OCR spacing loss on scanned text layers, raster pages without native text, and raw embedded source payloads.

#### New and refined warnings

- New `duplicate_text_layer` warning detects hidden duplicate native text layers (affine-fit between repeated span sets), so doubled text is surfaced instead of silently inflating extraction.
- New reading-order detection flags slide titles that are emitted last in the native text stream despite leading the visual layout.
- Fewer false alarms: `dense_vector_graphics` no longer fires on icon-decorated text pages, and empty-text scans no longer stack a redundant low-overlap warning on top of the raster warning.

#### Text normalization and content safety

- Non-visible C0 control characters are stripped in default normalization (NFKC as before), keeping grep/diff-friendly output without stray control bytes.
- Vertical edge chrome marking now requires corroboration (cross-page recurrence or marker text), so `--strip-repeated` no longer deletes real form margin content such as filing instructions on tax forms.

#### Form field labeling

- Much more accurate label resolution on real forms (IRS W-9 style, financial applications): row-scoped checkbox labels, stacked and currency-prefixed amount prompts, wrapped and numbered prompts, dot-leader row labels, and form section boundaries — labels no longer bleed in from unrelated instructions or neighboring fields.

#### Visual regions and layout

- Better chart/figure/diagram detection: captioned raster and vector figure grouping, chart text strips, timeline and node diagrams, map marker fields, and panel title attachment.
- Fewer false tables: tiny chart labels, sparse numeric map legends, mirrored chart axes, and tiny vector grids are no longer misread as tables; financial tables split and merge more faithfully (row labels, date headers, value gutters, footnotes).
- Markdown output now renders layout tables and search match tables in page output.

#### Search

- `--search` matches clickable link targets, dehyphenated OCR line breaks, and compact table header phrases, with tighter comb-field match boxes and duplicate suppression.

#### OCR and rendering

- OCR preserves recognition scale on low-res renders and silences benign tesseract worker warnings; the renderer preserves low-contrast visual traces and clamps crop boxes to render regions.

#### Other improvements

- Clearer encrypted-PDF password errors, rotated page context, stabilized span font aliases, pdf.js v6 adoption, a large internal refactor splitting the processor/layout/warnings modules into focused domain folders, and a multilingual VitePress documentation site.

**Full Changelog**: https://github.com/yamadashy/pdfvision/compare/v0.11.0...v0.12.0
