### PR TITLE
feat: compact --matches-only search output, agent-ergonomics fixes, README/help sync CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,25 @@ jobs:
       - run: npm ci
       - run: npm run lint-secretlint
 
+  readme-usage-sync:
+    name: README usage in sync with --help
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .tool-versions
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      # Regenerate the README Usage block from `pdfvision --help`; a diff
+      # means help.ts changed without re-running the sync script.
+      - run: node scripts/sync-readme-usage.mjs
+      - run: git diff --exit-code README.md
+
   test:
     name: Test (${{ matrix.os }}, Node ${{ matrix.node-version }})
     strategy:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The skill covers the daily extraction flow, the density-Overview-based silent-fa
 <!-- usage:start -->
 <!-- Generated from `pdfvision --help` by scripts/sync-readme-usage.mjs. Do not edit by hand; run `node scripts/sync-readme-usage.mjs`. -->
 
-```
+```text
 pdfvision - Extract text, images, metadata, and layout from PDF files for AI agents
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -75,77 +75,197 @@ The skill covers the daily extraction flow, the density-Overview-based silent-fa
 
 ## 📖 Usage
 
-```
-pdfvision <file.pdf> [options]
-pdfvision --remote <url> [options]
-pdfvision --clear-cache
+<!-- usage:start -->
+<!-- Generated from `pdfvision --help` by scripts/sync-readme-usage.mjs. Do not edit by hand; run `node scripts/sync-readme-usage.mjs`. -->
 
-Options:
-  -p, --pages <range>     Page range (e.g. "1-5", "3", "1,3,5")
-  -f, --format <type>     Output format: markdown (default), json, xml, toon
-      --markdown / --json / --xml / --toon
-                          Shortcuts for --format <type>
-  -r, --render            Render pages as PNG images
+```
+pdfvision - Extract text, images, metadata, and layout from PDF files for AI agents
+
+Usage:
+  pdfvision <file.pdf> [options]
+  pdfvision --remote <url> [options]
+  pdfvision --clear-cache
+
+Options
+  -p, --pages <range>     Pages to extract: "1", "1-5", "1,3,5", "2-4,7". Default: all pages.
+  -f, --format <type>     Output format: markdown (default), json, xml, toon.
+      --markdown          Shortcut for --format markdown.
+      --json              Shortcut for --format json.
+      --xml               Shortcut for --format xml.
+      --toon              Shortcut for --format toon.
+                          (Specifying more than one format, or mixing a shortcut with a different
+                          --format, is an error — pdfvision does not last-wins-resolve them.)
+  -r, --render            Render each selected page to a PNG and include the path on every page result.
       --render-output <dir>
-                          Directory for rendered page or visual-region PNGs
-                          (requires --render or --render-visual-regions)
-      --render-scale <n>  Rasterisation multiplier (default 2; bounds (0, 4]);
-                          OCR keeps at least scale 2 for recognition quality.
-                          Requires --render, --render-visual-regions, or --ocr.
+                          Directory to write rendered page PNGs or visual-region PNGs into, created
+                          if missing. Requires --render or --render-visual-regions.
+                          PNGs land flat as `<dir>/page-N.png` (`--render-region` keeps its
+                          coordinate-suffixed name); a filename already taken by another PDF in the
+                          same dir is written with a `-2` suffix and a note on stderr.
+                          Without this, PNGs land under the cache (or OS tmp with --no-cache).
+      --render-scale <n>  Rasterisation multiplier for --render / --render-visual-regions / --ocr.
+                          Default 2 (≈144 DPI on a letter page). Smaller values shrink the PNG
+                          (and vision-model payload); OCR keeps at least scale 2 for recognition
+                          quality; larger values capture more detail.
+                          Accepts decimals; bounds (0, 4].
       --render-region <x,y,width,height>
-                          Render only the given sub-rectangle of a single page
-                          (PDF points, top-left origin — same coordinates as
-                          search matches, imageBoxes, and layout blocks);
-                          composes with --render-scale for a high-res zoom
-      --geometry          Emit per-text-item bbox + font size in pages[].spans (json/xml/toon)
-      --layout            Reconstruct lines + blocks + numeric-table hints in pages[].layout;
-                          detects CJK vertical text stacks as writingMode='vertical'
-                          and uses recovered blocks/tables in Markdown text;
-                          also enables layout warnings (text_overlap / near_bottom_edge /
-                          body_near_repeated_chrome / off_page / tabular_numeric_layout /
-                          reading_order_divergence)
-      --strip-repeated    Drop running headers / footers / page numbers from the
-                          Markdown body (markdown only; requires --layout)
-      --image-boxes       Emit per-image bbox in pages[].imageBoxes;
-                          enables imageBoxIndex details on large-raster warnings
-      --vector-boxes      Emit vector drawing bboxes in pages[].vectorBoxes
-      --visual-regions    Emit crop-ready figure/chart/table/form regions in pages[].visualRegions
+                          Render only the given sub-rectangle (PDF points, top-left origin, y
+                          grows downward — same coordinate system as imageBoxes / layout.blocks).
+                          Composes with --render-scale: a 400×300pt region at scale 3 yields a
+                          1200×900px PNG. Single-page only: --pages must resolve to exactly one
+                          page (errors otherwise). Region must fit within the page bounds.
+                          Typical use: --layout to find a suspect block, then re-run with that
+                          block's bbox here to zoom in.
+      --no-normalize      Disable Unicode NFKC normalization and C0-control cleanup. Default ON;
+                          pre-normalization text is surfaced in `rawText` (json/xml) when
+                          normalization changed the string. Markdown output shows only the
+                          normalized form — pass --no-normalize if original codepoint fidelity
+                          (e.g. fullwidth punctuation `（`, ligatures `ﬁ`, control bytes)
+                          matters for downstream diff / forensics.
+      --password <value>  Password for encrypted PDFs. The password is used only for pdf.js
+                          decryption and is never emitted in output.
+      --password-stdin    Read the encrypted PDF password from piped stdin, stripping one
+                          trailing newline. If stdin is empty, --password is used as fallback.
+      --geometry          Emit per-text-item bbox + font size in `pages[].spans`.
+                          Only takes effect with -f json / -f xml / -f toon.
+      --layout            Reconstruct `pages[].layout` (lines, blocks, vertical CJK stacks,
+                          and numeric-table hints
+                          in approximate reading order) from the same span data. Structured layout fields
+                          appear in -f json / -f xml / -f toon; Markdown uses recovered vertical text
+                          blocks, and rebuilds the page body in layout order when the native text
+                          stream diverges from the visual reading order.
+                          Also enables layout warnings: overlapping text, off-page bboxes,
+                          body crowded against repeated chrome, flattened numeric tables,
+                          or native-vs-visual reading-order divergence in `pages[].warnings`.
+      --image-boxes       Emit `pages[].imageBoxes` — bounding box of every raster image
+                          draw on the page. Enables large-raster warnings with --layout or
+                          --geometry. Only -f json / -f xml / -f toon.
+                          Full-page scan/OCR-layer and dense-vector warnings can appear
+                          even without this flag.
+      --vector-boxes      Emit `pages[].vectorBoxes` — bounding boxes of vector drawings
+                          such as map symbols, chart paths, clipped shading fills, table
+                          rules, form boxes, and slide shapes. Only -f json / -f xml / -f toon.
+      --visual-regions    Emit `pages[].visualRegions` — padded, crop-ready bboxes
+                          for important figures, charts, diagrams, tables, forms, and
+                          raster/vector clusters. Feed x,y,width,height directly into
+                          --render-region for a visual zoom.
       --render-visual-regions
-                          Render visual region crops to PNG and attach paths,
-                          renderContentRatio, and renderedContentBox hints
-      --password <value>  Password for encrypted PDFs; never emitted in output
-      --password-stdin    Read the encrypted PDF password from piped stdin; falls back to --password if empty
-      --form-fields       Emit interactive PDF widget fields, flags, actions, export values, choice options, and labels in pages[].formFields
-      --links             Emit clickable link annotations in pages[].links with bboxes and resolved destination pages
-      --annotations       Emit non-link PDF annotations, flags, attachments, and shape geometry in pages[].annotations
-      --structure         Emit tagged-PDF structure trees in pages[].structure
-      --page-labels       Emit viewer page labels in pageLabels and pages[].pageLabel
-      --attachments       Emit embedded file attachment metadata in attachments
+                          Render each visual region crop to PNG and attach
+                          `visualRegions[].image`, `renderContentRatio`,
+                          and `renderedContentBox` when visible pixels are tighter.
+                          Implies --visual-regions and does not require --render.
+      --form-fields       Emit `pages[].formFields` — interactive PDF widget fields
+                          such as text boxes, checkboxes, radio buttons, choices,
+                          buttons, and signatures with values, export values,
+                          flags, actions, choice options, bboxes, and nearby visible labels.
+                          Useful for government forms.
+                          Markdown also renders a form-field table.
+      --links             Emit `pages[].links` — clickable PDF link annotations such as
+                          external URLs, citation jumps, and table-of-contents destinations
+                          with bboxes and resolved destination pages when available.
+                          Markdown also renders a links table.
+      --annotations       Emit `pages[].annotations` — non-link PDF annotations such as
+                          comments, sticky notes, highlights, underlines, strikeouts, stamps,
+                          file-attachment icons, shape markup, and ink with bboxes, comment
+                          text, icon names, PDF flags such as hidden/print, attachment
+                          metadata, and shape geometry when available.
+      --structure         Emit tagged-PDF structure trees in `pages[].structure`,
+                          including role hierarchy, figure alt text, language hints,
+                          bboxes, and marked-content ids when the PDF provides them.
+      --page-labels       Emit viewer page labels in `pageLabels` and `pages[].pageLabel`;
+                          useful when front matter uses roman numerals or page numbering
+                          restarts apart from the physical page number.
+      --attachments       Emit document-level embedded file attachment metadata in
+                          `attachments` without embedding attachment bytes in output.
       --attachment-output <dir>
-                          Write embedded attachment files and include attachments[].path
-      --outline           Emit document outline/bookmarks, URLs, and actions in outline
-      --viewer            Emit viewer settings and JavaScript actions in viewer
-      --layers            Emit PDF optional content groups in layers
-      --ocr               Run tesseract.js OCR; attach pages[].ocr (text/confidence/lang)
-      --ocr-lang <lang>   Tesseract lang(s), plus-separated (e.g. eng+jpn). Default: eng
-      --search <query>    Find every occurrence and emit pages[].matches with the bbox
-                          of each hit — feed it into --render-region for a visual zoom.
-                          Repeatable (--search A --search B); literal, case-insensitive,
-                          NFKC-aware by default. Also matches form field values, link
-                          targets, visible annotations, and OCR text when --ocr is on
+                          Directory to write embedded attachment files into. Requires
+                          --attachments; files land under a per-PDF fingerprint subdir.
+      --outline           Emit top-level `outline` document bookmarks, preserving hierarchy,
+                          URLs, named actions, and resolved destination pages when possible.
+                          Markdown also renders an outline section.
+      --viewer            Emit top-level `viewer` settings: initial page mode/layout,
+                          viewer preferences, open action, document/page JavaScript
+                          actions, permissions, and MarkInfo.
+      --layers            Emit top-level `layers` from PDF optional content groups:
+                          layer names, visibility, usage states, radio groups, and
+                          viewer panel order for maps, CAD/design PDFs, and variants.
+      --strip-repeated    Drop running headers / footers / page numbers (blocks the layout
+                          pass tagged as `repeated`) from the rendered Markdown body so
+                          LLM readers don't have to wade through the same footer N times.
+                          Markdown only; JSON / XML already expose `repeated: true` per
+                          block. Requires --layout.
+      --ocr               Run OCR on each selected page and attach `pages[].ocr`
+                          (text + confidence + lang). Slow; opt-in. Requires the
+                          optional `tesseract.js` dependency. `pages[].text` is
+                          preserved alongside so callers can compare native vs OCR.
+      --ocr-lang <lang>   Tesseract language code(s), plus-separated for multi-lang
+                          (e.g. `eng+jpn`). Default: eng. Only used with --ocr.
+      --search <query>    Find every occurrence of <query> on each page and emit
+                          `pages[].matches[]` with the bbox of each hit. Pipe a
+                          match's bbox into a follow-up --render-region for visual
+                          zoom. Repeatable: `--search A --search B` searches both
+                          (each match carries the source query). Literal substring
+                          by default; case-insensitive; NFKC-aware (matches
+                          compatibility codepoints like `ﬁ` (U+FB01 ligature) for
+                          `fi`). Also searches text/choice form field values
+                          (marked source:'formField'), clickable link targets
+                          (source:'link'), visible FreeText annotations
+                          (source:'annotation'), and OCR text when --ocr is on
+                          (source:'ocr'); duplicate OCR hits already covered by
+                          non-OCR matches are suppressed.
       --search-regex      Treat each --search query as a JavaScript regular expression
+                          (default: literal substring).
       --search-case-sensitive
-                          Match case exactly (default: insensitive)
-      --remote <url>      Download an http(s) PDF into the cache, validate the PDF header, then extract
-      --no-cache          Skip the on-disk cache
-      --no-normalize      Disable Unicode NFKC normalization and C0-control cleanup (default: on;
-                          pre-normalization text is preserved in JSON/XML \`rawText\` only when
-                          normalization changed the string — pass this if you need raw codepoints
-                          in markdown too)
-      --clear-cache       Wipe every cached extraction, render, and remote download, then exit
+                          Match case exactly (default: insensitive).
+      --matches-only      Emit only the search hits — a flat list of every match with its
+                          page, source, text, context, and bbox — instead of the full
+                          per-page document. Requires --search. Pages with no match are
+                          omitted; zero matches overall still exits 0 with a minimal report.
+                          Works in every format; keeps search output well under 1 KB so an
+                          agent can find-then-zoom without spending its context on body text.
+      --remote <url>      Download an http(s) PDF, validate the PDF header, and run extraction
+                          on it. Same URL → same cache slot unless --no-cache streams the
+                          bytes directly without writing the remote-PDF cache.
+      --no-cache          Skip the on-disk cache (re-download / re-extract every run).
+      --clear-cache       Remove every cached extraction, rendered PNG, and downloaded
+                          remote PDF, then exit. No file argument required.
   -v, --version           Show version
   -h, --help              Show this help
+
+Output formats
+  markdown (default)  Per-page sections, density Overview table, image links inline. For LLM context.
+  json                Full DocumentResult schema. For programmatic parsing.
+  xml                 Tag-shaped variant of json. For LLMs that parse tags more reliably than JSON.
+  toon                Token-Oriented Object Notation: lossless, tabular encoding of the json schema
+                      that cuts tokens (~40% on geometry/layout-heavy output). For tight LLM budgets.
+
+Examples
+  pdfvision document.pdf                                                       # markdown to stdout
+  pdfvision document.pdf --json                                                # JSON shortcut
+  pdfvision document.pdf -p 1-3 --json                                         # specific pages, JSON
+  pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
+  pdfvision slides.pdf -r --render-scale 1                                     # 1× raster (smaller PNGs)
+  pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150pt box on page 3
+  pdfvision report.pdf --search "revenue" --json                               # find every "revenue" with bbox; pipe to --render-region
+  pdfvision paper.pdf --search "GPT" --search "transformer" --json             # multi-query (each match keeps its source query)
+  pdfvision paper.pdf --search "BLEU" --matches-only                           # just the hits + bboxes (compact, <1KB)
+  pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry --json    # PNGs + spans for 3-5
+  pdfvision slides.pdf --xml --geometry                                        # layout / geometry as XML
+  pdfvision report.pdf --toon --geometry                                       # token-efficient spans (TOON)
+  pdfvision report.pdf --layout --strip-repeated                               # markdown w/o repeated chrome
+  pdfvision encrypted.pdf --password "secret" --json                           # encrypted PDF
+  printf "secret\n" | pdfvision encrypted.pdf --password-stdin --json          # avoid password in argv
+  pdfvision scan.pdf --ocr --json                                              # OCR a scanned PDF
+  pdfvision scan-ja.pdf --ocr --ocr-lang eng+jpn --json                        # multi-lang OCR
+  pdfvision --remote https://example.com/paper.pdf --json                      # fetch + extract JSON
+  pdfvision --clear-cache                                                      # wipe the on-disk cache
+
+Exit codes
+  0  Success
+  1  Argument error, file not found, network error, or extraction failure (error message on stderr)
 ```
+
+<!-- usage:end -->
 
 ### Output formats
 

--- a/scripts/sync-readme-usage.mjs
+++ b/scripts/sync-readme-usage.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Regenerate the README "Usage" block from the CLI `--help` output so the
+// two never drift. The block between the `<!-- usage:start -->` /
+// `<!-- usage:end -->` markers in README.md is replaced with a fenced code
+// block holding the exact `pdfvision --help` text (Usage + Options +
+// Output formats + Examples + Exit codes).
+//
+// CI runs this then `git diff --exit-code README.md`, so any change to the
+// help text that isn't reflected in the README fails the build.
+//
+// Reads the built CLI at dist/bin/pdfvision.mjs — run `npm run build`
+// first (CI does). Kept build-free itself so it works on every Node in the
+// support matrix without relying on TypeScript type-stripping.
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const readmePath = resolve(repoRoot, 'README.md');
+const cliPath = resolve(repoRoot, 'dist/bin/pdfvision.mjs');
+
+const START = '<!-- usage:start -->';
+const END = '<!-- usage:end -->';
+const NOTE =
+  '<!-- Generated from `pdfvision --help` by scripts/sync-readme-usage.mjs. Do not edit by hand; run `node scripts/sync-readme-usage.mjs`. -->';
+
+function fail(message) {
+  console.error(`sync-readme-usage: ${message}`);
+  process.exit(1);
+}
+
+if (!existsSync(cliPath)) {
+  fail(`built CLI not found at ${cliPath}. Run \`npm run build\` first.`);
+}
+
+const help = spawnSync(process.execPath, [cliPath, '--help'], { cwd: repoRoot, encoding: 'utf8' });
+if (help.error) fail(`failed to run the CLI: ${help.error.message}`);
+if (help.status !== 0) fail(`\`pdfvision --help\` exited with status ${help.status}`);
+const helpText = (help.stdout ?? '').replace(/\s+$/, '');
+if (!helpText) fail('`pdfvision --help` produced no output');
+
+const readme = readFileSync(readmePath, 'utf8');
+const startIdx = readme.indexOf(START);
+const endIdx = readme.indexOf(END);
+if (startIdx === -1 || endIdx === -1) {
+  fail(`could not find the ${START} / ${END} markers in README.md`);
+}
+if (endIdx < startIdx) fail(`${END} appears before ${START} in README.md`);
+
+const block = `${START}\n${NOTE}\n\n\`\`\`\n${helpText}\n\`\`\`\n\n${END}`;
+const next = readme.slice(0, startIdx) + block + readme.slice(endIdx + END.length);
+
+if (next === readme) {
+  console.log('README usage block already up to date.');
+  process.exit(0);
+}
+
+writeFileSync(readmePath, next);
+console.log('README usage block updated from `pdfvision --help`.');

--- a/scripts/sync-readme-usage.mjs
+++ b/scripts/sync-readme-usage.mjs
@@ -48,7 +48,8 @@ if (startIdx === -1 || endIdx === -1) {
 }
 if (endIdx < startIdx) fail(`${END} appears before ${START} in README.md`);
 
-const block = `${START}\n${NOTE}\n\n\`\`\`\n${helpText}\n\`\`\`\n\n${END}`;
+// `text` info string keeps markdownlint MD040 (fenced-code-language) happy.
+const block = `${START}\n${NOTE}\n\n\`\`\`text\n${helpText}\n\`\`\`\n\n${END}`;
 const next = readme.slice(0, startIdx) + block + readme.slice(endIdx + END.length);
 
 if (next === readme) {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -66,6 +66,7 @@ export async function run(argv: string[] = process.argv.slice(2), options: RunOp
         search: { type: 'string', multiple: true },
         'search-regex': { type: 'boolean' },
         'search-case-sensitive': { type: 'boolean' },
+        'matches-only': { type: 'boolean' },
       },
     });
     values = parsed.values as ParsedCliValues;
@@ -95,11 +96,19 @@ export async function run(argv: string[] = process.argv.slice(2), options: RunOp
   }
 
   const remoteUrl = values.remote as string | undefined;
-  // --help is requested explicitly OR there's no input source at all
-  // (no positional and no --remote URL). Print help and bail.
-  if (values.help || (positionals.length === 0 && !remoteUrl)) {
+  // Explicit --help prints to stdout and exits 0 — the user asked for it.
+  if (values.help) {
     console.log(HELP_TEXT);
     return;
+  }
+  // No input source at all (no positional and no --remote URL) is a
+  // usage error, not a help request: print to stderr and exit 2 so a
+  // caller can tell "showed help on request" (stdout / 0) apart from
+  // "invoked with nothing to do" (stderr / 2), matching common CLI
+  // conventions (git, curl, ...).
+  if (positionals.length === 0 && !remoteUrl) {
+    console.error(HELP_TEXT);
+    process.exit(2);
   }
 
   if (positionals.length > 1) {
@@ -112,6 +121,13 @@ export async function run(argv: string[] = process.argv.slice(2), options: RunOp
   }
 
   const format = resolveOutputFormat(values);
+  if ((values.geometry as boolean | undefined) && format === 'markdown') {
+    // --geometry only populates pages[].spans in json / xml / toon;
+    // markdown has no place to surface per-item geometry. Note rather
+    // than error so a composed flag set (geometry + default markdown)
+    // still produces its markdown output (exit 0).
+    console.error('note: --geometry has no effect with markdown output; use -f json/xml/toon');
+  }
   const { render, renderOutput, renderScale, renderRegion, renderVisualRegions } = resolveRenderOptions(values);
 
   const layout = (values.layout as boolean | undefined) ?? false;
@@ -148,6 +164,13 @@ export async function run(argv: string[] = process.argv.slice(2), options: RunOp
   if (searchQueries?.some((q) => q === '')) {
     exitWithError('--search: query must be a non-empty string');
   }
+  // --matches-only reshapes the output into a flat match list; it only
+  // makes sense alongside a query. Fail loud rather than emit an empty
+  // "0 matches" shell for a run that never searched anything.
+  const matchesOnly = (values['matches-only'] as boolean | undefined) ?? false;
+  if (matchesOnly && !searchQueries) {
+    exitWithError('--matches-only requires --search');
+  }
 
   const noCache = (values['no-cache'] as boolean | undefined) ?? false;
   const passwordFromArg = values.password as string | undefined;
@@ -180,6 +203,7 @@ export async function run(argv: string[] = process.argv.slice(2), options: RunOp
       search: searchQueries,
       searchRegex,
       searchCaseSensitive,
+      matchesOnly,
       noCache,
       // NFKC normalization and C0-control cleanup are on by default —
       // agents almost always want canonical, human-visible Unicode.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -26,6 +26,9 @@ Options
       --render-output <dir>
                           Directory to write rendered page PNGs or visual-region PNGs into, created
                           if missing. Requires --render or --render-visual-regions.
+                          PNGs land flat as \`<dir>/page-N.png\` (\`--render-region\` keeps its
+                          coordinate-suffixed name); a filename already taken by another PDF in the
+                          same dir is written with a \`-2\` suffix and a note on stderr.
                           Without this, PNGs land under the cache (or OS tmp with --no-cache).
       --render-scale <n>  Rasterisation multiplier for --render / --render-visual-regions / --ocr.
                           Default 2 (≈144 DPI on a letter page). Smaller values shrink the PNG
@@ -141,6 +144,12 @@ Options
                           (default: literal substring).
       --search-case-sensitive
                           Match case exactly (default: insensitive).
+      --matches-only      Emit only the search hits — a flat list of every match with its
+                          page, source, text, context, and bbox — instead of the full
+                          per-page document. Requires --search. Pages with no match are
+                          omitted; zero matches overall still exits 0 with a minimal report.
+                          Works in every format; keeps search output well under 1 KB so an
+                          agent can find-then-zoom without spending its context on body text.
       --remote <url>      Download an http(s) PDF, validate the PDF header, and run extraction
                           on it. Same URL → same cache slot unless --no-cache streams the
                           bytes directly without writing the remote-PDF cache.
@@ -166,6 +175,7 @@ Examples
   pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150pt box on page 3
   pdfvision report.pdf --search "revenue" --json                               # find every "revenue" with bbox; pipe to --render-region
   pdfvision paper.pdf --search "GPT" --search "transformer" --json             # multi-query (each match keeps its source query)
+  pdfvision paper.pdf --search "BLEU" --matches-only                           # just the hits + bboxes (compact, <1KB)
   pdfvision report.pdf -p 3-5 -r --render-output ./images --geometry --json    # PNGs + spans for 3-5
   pdfvision slides.pdf --xml --geometry                                        # layout / geometry as XML
   pdfvision report.pdf --toon --geometry                                       # token-efficient spans (TOON)

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -237,7 +237,9 @@ export async function processDocument(filePath: string, options: ProcessDocument
       renderContentBoxesByPage,
       doc,
       imagesDir,
+      flatImagesDir: options.renderOutput !== undefined,
       renderScale,
+      onWarning: options.onWarning,
     });
     // OCR runs after the main pass so it can attach to already-built
     // PageResults. The pdfjs-derived `text` stays untouched — agents that

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -14,6 +14,7 @@ import type {
 import { getCacheDir, pdfFingerprint } from './io/cache.js';
 import { buildCacheKey } from './processor/cacheKey.js';
 import { extractDocumentFeatures } from './processor/documentFeatures.js';
+import { resolveFlatRenderPaths } from './processor/flatRenderPaths.js';
 import { buildOverview } from './processor/overview.js';
 import { extractPageData } from './processor/pageExtraction.js';
 import { buildPageFlags } from './processor/pageFlags.js';
@@ -83,11 +84,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
   // the most expensive sync step in this function, so do it once and
   // share — the cache layer accepts a precomputed fingerprint to avoid
   // re-reading the same file.
-  const needFingerprint =
-    !options.noCache ||
-    !!(options.render && options.renderOutput) ||
-    !!(renderVisualRegions && options.renderOutput) ||
-    !!(options.attachments && options.attachmentOutput);
+  const needFingerprint = !options.noCache || !!(options.attachments && options.attachmentOutput);
   const fingerprint = needFingerprint ? (pdfData ? fingerprintData(pdfData) : pdfFingerprint(filePath)) : null;
   const cacheDir = options.noCache ? null : getCacheDir(filePath, fingerprint ?? undefined);
   const attachmentOutputDir =
@@ -147,7 +144,6 @@ export async function processDocument(filePath: string, options: ProcessDocument
         ? prepareRenderImagesDir({
             renderOutput: options.renderOutput,
             cacheDir,
-            fingerprint,
             renderScale,
           })
         : null;
@@ -155,7 +151,23 @@ export async function processDocument(filePath: string, options: ProcessDocument
       // renderer pulls in @napi-rs/canvas (native binding); only load it
       // when --render is requested.
       const { renderPagesWithStats } = await import('./renderer/index.js');
-      const rendered = await renderPagesWithStats(doc, pageNumbers, imagesDir as string, renderScale, renderRegion);
+      // Explicit --render-output writes flat into the caller's dir, so
+      // pre-resolve collision-safe paths (and disable disk reuse: a
+      // same-named PNG there may belong to a different PDF).
+      const pagesOptions = options.renderOutput
+        ? {
+            outputPaths: resolveFlatRenderPaths(imagesDir as string, pageNumbers, renderRegion, options.onWarning),
+            reuse: false,
+          }
+        : undefined;
+      const rendered = await renderPagesWithStats(
+        doc,
+        pageNumbers,
+        imagesDir as string,
+        renderScale,
+        renderRegion,
+        pagesOptions,
+      );
       imagePaths = rendered.map((r) => r.path);
       renderRatios = rendered.map((r) => r.contentRatio);
       renderContentBoxes = rendered.map((r) => r.renderedContentBox);

--- a/src/core/processor/flatRenderPaths.ts
+++ b/src/core/processor/flatRenderPaths.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { RenderRegion } from '../../types/index.js';
+import { pngFilename } from '../renderer/pngFilename.js';
+
+/**
+ * Resolve the flat on-disk PNG paths for an explicit `--render-output`
+ * directory, disambiguating filename collisions.
+ *
+ * Flat output writes `<dir>/page-N.png` with no per-PDF hash subdir, so a
+ * name can already be taken by an earlier render of a *different* PDF into
+ * the same dir. When that happens we don't overwrite it — we bump a
+ * numeric suffix (`page-1.png` → `page-1-2.png` → `page-1-3.png`) and emit
+ * a one-line note so the user knows a rename happened. A `reserved` set
+ * keeps the pages of a single run from colliding with each other's picks.
+ *
+ * @param onNote optional sink for the per-rename note (wired to stderr by
+ *   the CLI). Not called when no collision occurs.
+ */
+export function resolveFlatRenderPaths(
+  dir: string,
+  pageNumbers: number[],
+  region: RenderRegion | undefined,
+  onNote?: (message: string) => void,
+): string[] {
+  const reserved = new Set<string>();
+  return pageNumbers.map((pageNum) => {
+    const base = pngFilename(pageNum, region);
+    const taken = (name: string) => reserved.has(name) || existsSync(join(dir, name));
+    let chosen = base;
+    if (taken(chosen)) {
+      const dot = base.lastIndexOf('.');
+      const stem = base.slice(0, dot);
+      const ext = base.slice(dot);
+      let n = 2;
+      do {
+        chosen = `${stem}-${n}${ext}`;
+        n += 1;
+      } while (taken(chosen));
+      onNote?.(`--render-output: wrote ${chosen} instead of ${base} (a file named ${base} already exists in ${dir})`);
+    }
+    reserved.add(chosen);
+    return join(dir, chosen);
+  });
+}

--- a/src/core/processor/flatRenderPaths.ts
+++ b/src/core/processor/flatRenderPaths.ts
@@ -4,18 +4,59 @@ import type { RenderRegion } from '../../types/index.js';
 import { pngFilename } from '../renderer/pngFilename.js';
 
 /**
- * Resolve the flat on-disk PNG paths for an explicit `--render-output`
- * directory, disambiguating filename collisions.
+ * Pick the first free filename, bumping a numeric suffix past collisions:
+ * `page-1.png` → `page-1-2.png` → `page-1-3.png`. Defensive on names
+ * without an extension (suffix goes at the end). Exported for tests.
+ */
+export function nextAvailableName(base: string, taken: (name: string) => boolean): string {
+  if (!taken(base)) return base;
+  const dot = base.lastIndexOf('.');
+  const stem = dot === -1 ? base : base.slice(0, dot);
+  const ext = dot === -1 ? '' : base.slice(dot);
+  let n = 2;
+  let chosen: string;
+  do {
+    chosen = `${stem}-${n}${ext}`;
+    n += 1;
+  } while (taken(chosen));
+  return chosen;
+}
+
+/**
+ * Create a resolver that hands out collision-free flat PNG paths inside an
+ * explicit `--render-output` directory.
  *
- * Flat output writes `<dir>/page-N.png` with no per-PDF hash subdir, so a
- * name can already be taken by an earlier render of a *different* PDF into
- * the same dir. When that happens we don't overwrite it — we bump a
- * numeric suffix (`page-1.png` → `page-1-2.png` → `page-1-3.png`) and emit
- * a one-line note so the user knows a rename happened. A `reserved` set
- * keeps the pages of a single run from colliding with each other's picks.
+ * Flat output writes `<dir>/page-N.png` (or the coordinate-suffixed region
+ * name) with no per-PDF hash subdir, so a name can already be taken by an
+ * earlier render of a *different* PDF into the same dir. When that happens
+ * we don't overwrite it — we bump a numeric suffix and emit a one-line
+ * note so the user knows a rename happened. The resolver's internal
+ * `reserved` set keeps the picks of a single pass (page renders or
+ * visual-region crops) from colliding with each other.
  *
  * @param onNote optional sink for the per-rename note (wired to stderr by
  *   the CLI). Not called when no collision occurs.
+ */
+export function createFlatRenderPathResolver(
+  dir: string,
+  onNote?: (message: string) => void,
+): (pageNum: number, region: RenderRegion | undefined) => string {
+  const reserved = new Set<string>();
+  return (pageNum, region) => {
+    const base = pngFilename(pageNum, region);
+    const chosen = nextAvailableName(base, (name) => reserved.has(name) || existsSync(join(dir, name)));
+    if (chosen !== base) {
+      onNote?.(`--render-output: wrote ${chosen} instead of ${base} (a file named ${base} already exists in ${dir})`);
+    }
+    reserved.add(chosen);
+    return join(dir, chosen);
+  };
+}
+
+/**
+ * Resolve the flat on-disk PNG paths for a full-page render batch into an
+ * explicit `--render-output` directory. See
+ * {@link createFlatRenderPathResolver} for the collision semantics.
  */
 export function resolveFlatRenderPaths(
   dir: string,
@@ -23,23 +64,6 @@ export function resolveFlatRenderPaths(
   region: RenderRegion | undefined,
   onNote?: (message: string) => void,
 ): string[] {
-  const reserved = new Set<string>();
-  return pageNumbers.map((pageNum) => {
-    const base = pngFilename(pageNum, region);
-    const taken = (name: string) => reserved.has(name) || existsSync(join(dir, name));
-    let chosen = base;
-    if (taken(chosen)) {
-      const dot = base.lastIndexOf('.');
-      const stem = base.slice(0, dot);
-      const ext = base.slice(dot);
-      let n = 2;
-      do {
-        chosen = `${stem}-${n}${ext}`;
-        n += 1;
-      } while (taken(chosen));
-      onNote?.(`--render-output: wrote ${chosen} instead of ${base} (a file named ${base} already exists in ${dir})`);
-    }
-    reserved.add(chosen);
-    return join(dir, chosen);
-  });
+  const resolvePath = createFlatRenderPathResolver(dir, onNote);
+  return pageNumbers.map((pageNum) => resolvePath(pageNum, region));
 }

--- a/src/core/processor/processFileOptions.ts
+++ b/src/core/processor/processFileOptions.ts
@@ -17,6 +17,13 @@ export function validateProcessFileOptions(options: ProcessOptions): void {
     // the flag had no effect.
     throw new Error(`stripRepeated only applies to markdown output (got format: ${options.format})`);
   }
+  // matchesOnly reshapes output into a flat match list — meaningless
+  // without a query. Mirror the CLI's `--matches-only requires --search`
+  // guard so library callers fail fast too.
+  const hasSearch = options.search !== undefined && (!Array.isArray(options.search) || options.search.length > 0);
+  if (options.matchesOnly && !hasSearch) {
+    throw new Error('matchesOnly requires search');
+  }
 }
 
 export function buildProcessDocumentOptions(options: ProcessOptions): ProcessDocumentOptions {

--- a/src/core/processor/renderOptions.ts
+++ b/src/core/processor/renderOptions.ts
@@ -49,7 +49,6 @@ function scaleDirSuffix(scale: number): string {
 interface RenderImagesDirInput {
   renderOutput?: string;
   cacheDir: string | null;
-  fingerprint: string | null;
   renderScale?: number;
 }
 
@@ -105,32 +104,18 @@ function ensureSafeRenderRoot(dir: string): void {
   }
 }
 
-function ensureSafeRenderChildDir(dir: string): void {
-  try {
-    assertSafeRenderDir(dir);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-    mkdirSync(dir);
-    assertSafeRenderDir(dir);
-  }
-}
-
 export function prepareRenderImagesDir(input: RenderImagesDirInput): string {
   const effectiveScale = input.renderScale ?? DEFAULT_RENDER_SCALE;
   const scaleSubdir = effectiveScale === DEFAULT_RENDER_SCALE ? null : scaleDirSuffix(effectiveScale);
   if (input.renderOutput) {
-    if (!input.fingerprint) {
-      throw new Error('renderOutput requires a PDF fingerprint');
-    }
+    // Explicit --render-output writes PNGs *flat* into the caller's dir
+    // (`<dir>/page-N.png`) — no per-PDF hash or scale subdirectories, so
+    // the paths are predictable and paste-able. Isolation between two
+    // PDFs (or two scales) sharing one dir is handled by the caller's
+    // filename-collision disambiguation instead of directory nesting.
     const outputRoot = resolve(input.renderOutput);
     ensureSafeRenderRoot(outputRoot);
-    const fingerprintDir = join(outputRoot, input.fingerprint);
-    ensureSafeRenderChildDir(fingerprintDir);
-    if (!scaleSubdir) return fingerprintDir;
-
-    const scaledDir = join(fingerprintDir, scaleSubdir);
-    ensureSafeRenderChildDir(scaledDir);
-    return scaledDir;
+    return outputRoot;
   }
 
   if (input.cacheDir) {

--- a/src/core/processor/renderResult.ts
+++ b/src/core/processor/renderResult.ts
@@ -1,12 +1,25 @@
 import { formatJson } from '../../output/json.js';
 import { formatMarkdown } from '../../output/markdown.js';
+import { formatMatchesOnly } from '../../output/matchesOnly.js';
 import { formatToon } from '../../output/toon.js';
 import { formatXml } from '../../output/xml.js';
 import type { DocumentResult, ProcessOptions } from '../../types/index.js';
 
+/** Normalize the `search` option (string | string[] | undefined) into a
+ *  flat query array for the matches-only formatter. */
+function searchQueries(search: ProcessOptions['search']): string[] {
+  if (search === undefined) return [];
+  return Array.isArray(search) ? search : [search];
+}
+
 /** Render a structured DocumentResult into the caller-requested string format. */
 export function renderResult(result: DocumentResult, options: ProcessOptions): string {
   const { format } = options;
+  if (options.matchesOnly) {
+    // Compact search-only output shares the same flat shape across all
+    // four formats; dispatch before the per-format document formatters.
+    return formatMatchesOnly(result, format, searchQueries(options.search));
+  }
   switch (format) {
     case 'json':
       return formatJson(result);

--- a/src/core/processor/visualRegionPostProcessing.ts
+++ b/src/core/processor/visualRegionPostProcessing.ts
@@ -3,6 +3,7 @@ import type { PageResult, RenderedContentBox, VisualRegion } from '../../types/i
 import { markPageEdgeChromeBlocks, markRepeatedBlocks } from '../layout/index.js';
 import { runParallel } from '../runtime/parallel.js';
 import { type BuildVisualRegionsInput, buildVisualRegions } from '../visualRegions/index.js';
+import { createFlatRenderPathResolver } from './flatRenderPaths.js';
 
 const BLANK_REGION_RENDER_THRESHOLD = 0.001;
 const FULL_PAGE_REGION_AREA_RATIO_THRESHOLD = 0.9;
@@ -16,7 +17,14 @@ interface ApplyVisualRegionPostProcessingOptions {
   renderContentBoxesByPage: ReadonlyMap<number, RenderedContentBox>;
   doc: PDFDocumentProxy;
   imagesDir: string | null;
+  /** True when `imagesDir` is a user-supplied `--render-output` dir (flat
+   *  layout, shared across PDFs) rather than the per-PDF cache hierarchy.
+   *  Region crops must then go through the collision-safe path resolver
+   *  with disk reuse off — a same-named PNG there may belong to a
+   *  different PDF. */
+  flatImagesDir: boolean;
   renderScale?: number;
+  onWarning?: (message: string) => void;
 }
 
 export async function applyVisualRegionPostProcessing({
@@ -28,7 +36,9 @@ export async function applyVisualRegionPostProcessing({
   renderContentBoxesByPage,
   doc,
   imagesDir,
+  flatImagesDir,
   renderScale,
+  onWarning,
 }: ApplyVisualRegionPostProcessingOptions): Promise<void> {
   // Chrome detection has to wait until every selected page is populated,
   // since most chrome needs cross-page evidence. Run it on public layout
@@ -67,8 +77,26 @@ export async function applyVisualRegionPostProcessing({
   if (jobs.length === 0) return;
 
   const { renderPageWithStats } = await import('../renderer/index.js');
-  await runParallel(jobs, async ({ page, region }) => {
-    const rendered = await renderPageWithStats(doc, page.page, imagesDir as string, renderScale, region);
+  // Flat --render-output: pre-resolve collision-safe paths for every crop
+  // (sequentially, before the parallel renders race existsSync) and turn
+  // off disk reuse. Otherwise a pre-existing PNG with the same
+  // page+region name — written by a DIFFERENT PDF into the shared dir —
+  // would be handed back as this document's crop.
+  const flatOutputPaths = flatImagesDir
+    ? (() => {
+        const resolvePath = createFlatRenderPathResolver(imagesDir as string, onWarning);
+        return jobs.map(({ page, region }) => resolvePath(page.page, region));
+      })()
+    : undefined;
+  await runParallel(jobs, async ({ page, region }, i) => {
+    const rendered = await renderPageWithStats(
+      doc,
+      page.page,
+      imagesDir as string,
+      renderScale,
+      region,
+      flatOutputPaths ? { outputPath: flatOutputPaths[i], reuse: false } : undefined,
+    );
     region.image = rendered.path;
     region.renderContentRatio = rendered.contentRatio;
     if (rendered.renderedContentBox) region.renderedContentBox = rendered.renderedContentBox;

--- a/src/core/renderer/index.ts
+++ b/src/core/renderer/index.ts
@@ -8,9 +8,11 @@ import { runParallel } from '../runtime/parallel.js';
 import { contentBoxFromViewportPixels } from './contentBox.js';
 import { computeContentStats, type RenderStats } from './contentStats.js';
 import { type ViewportCrop, viewportCropForRegion } from './crop.js';
+import { pngFilename } from './pngFilename.js';
 
 export { computeContentRatio } from './contentStats.js';
 export { viewportCropForRegion } from './crop.js';
+export { pngFilename } from './pngFilename.js';
 // Re-export so render-domain callers can import the render types from the
 // same entrypoint. The canonical declaration lives in `src/types/index.ts`.
 export type { RenderRegion, ViewportCrop };
@@ -117,17 +119,17 @@ async function computeContentStatsFromPng(path: string): Promise<RenderStats> {
   return computeContentStats(rgba, img.width, img.height);
 }
 
-/**
- * Build the on-disk filename for a rendered page. Region-bearing renders
- * encode the bbox in the filename so multiple regions per page can
- * coexist on disk: `page-3_x50_y100_w400_h300.png`. Without a region the
- * legacy `page-N.png` shape is preserved so existing consumers don't
- * have to learn a new pattern. Numbers are normalised through `String`
- * which drops trailing zeros (`50.5` stays `50.5`, `50.0` becomes `50`).
- */
-function pngFilename(pageNum: number, region: RenderRegion | undefined): string {
-  if (!region) return `page-${pageNum}.png`;
-  return `page-${pageNum}_x${region.x}_y${region.y}_w${region.width}_h${region.height}.png`;
+/** Per-page render tuning for the disk writers. */
+export interface RenderPageOptions {
+  /** Absolute output path override. When set, bypasses the default
+   *  `<dir>/page-N.png` naming — used for flat `--render-output` where
+   *  collisions are disambiguated up front by the caller. */
+  outputPath?: string;
+  /** When false, always re-raster instead of reusing an existing PNG on
+   *  disk. Set for flat `--render-output`: a pre-existing same-named file
+   *  may belong to a different PDF, so it must not be handed back as a
+   *  cache hit. Default true (cache-dir path relies on reuse). */
+  reuse?: boolean;
 }
 
 /**
@@ -146,9 +148,10 @@ export async function renderPageWithStats(
   outputDir: string,
   scale = DEFAULT_SCALE,
   region?: RenderRegion,
+  pageOptions?: RenderPageOptions,
 ): Promise<{ path: string; contentRatio: number; renderedContentBox?: RenderedContentBox }> {
-  const outputPath = join(outputDir, pngFilename(pageNum, region));
-  if (isReusableImage(outputPath)) {
+  const outputPath = pageOptions?.outputPath ?? join(outputDir, pngFilename(pageNum, region));
+  if ((pageOptions?.reuse ?? true) && isReusableImage(outputPath)) {
     try {
       const stats = await computeContentStatsFromPng(outputPath);
       if (!stats.contentBoxPx) return { path: outputPath, contentRatio: stats.contentRatio };
@@ -186,14 +189,29 @@ export async function renderPage(
   return path;
 }
 
+/** Batch render tuning. `outputPaths` (when set) supplies a pre-resolved
+ *  absolute path per page, aligned to `pageNumbers` by index — used for
+ *  flat `--render-output` where the caller has already disambiguated any
+ *  filename collisions. `reuse` applies to every page. */
+export interface RenderPagesOptions {
+  outputPaths?: string[];
+  reuse?: boolean;
+}
+
 export async function renderPagesWithStats(
   doc: PDFDocumentProxy,
   pageNumbers: number[],
   outputDir: string,
   scale?: number,
   region?: RenderRegion,
+  pagesOptions?: RenderPagesOptions,
 ): Promise<{ path: string; contentRatio: number; renderedContentBox?: RenderedContentBox }[]> {
-  return runParallel(pageNumbers, (pageNum) => renderPageWithStats(doc, pageNum, outputDir, scale, region));
+  return runParallel(pageNumbers, (pageNum, i) =>
+    renderPageWithStats(doc, pageNum, outputDir, scale, region, {
+      outputPath: pagesOptions?.outputPaths?.[i],
+      reuse: pagesOptions?.reuse,
+    }),
+  );
 }
 
 export async function renderPages(

--- a/src/core/renderer/pngFilename.ts
+++ b/src/core/renderer/pngFilename.ts
@@ -1,0 +1,18 @@
+import type { RenderRegion } from '../../types/index.js';
+
+/**
+ * Build the on-disk filename for a rendered page. Region-bearing renders
+ * encode the bbox in the filename so multiple regions per page can
+ * coexist on disk: `page-3_x50_y100_w400_h300.png`. Without a region the
+ * legacy `page-N.png` shape is preserved so existing consumers don't
+ * have to learn a new pattern. Numbers are normalised through `String`
+ * which drops trailing zeros (`50.5` stays `50.5`, `50.0` becomes `50`).
+ *
+ * Lives in its own module (no `@napi-rs/canvas` import) so the collision
+ * resolver in `processor/flatRenderPaths.ts` can reuse it without eagerly
+ * loading the native canvas binding.
+ */
+export function pngFilename(pageNum: number, region: RenderRegion | undefined): string {
+  if (!region) return `page-${pageNum}.png`;
+  return `page-${pageNum}_x${region.x}_y${region.y}_w${region.width}_h${region.height}.png`;
+}

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -195,7 +195,12 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
     if (page.layout?.tables && page.layout.tables.length > 0) {
       appendLayoutTables(lines, page.layout.tables);
     }
-    if (page.matches) {
+    // Only render the match table for pages that actually matched. A
+    // zero-match page under --search used to emit a noisy
+    // `### Search matches / _No search matches found._` block on every
+    // clean page; the per-page density line already carries `matches: 0`
+    // for the "search ran, nothing here" signal.
+    if (page.matches && page.matches.length > 0) {
       appendSearchMatches(lines, page.matches);
     }
     if (page.structure !== undefined) {

--- a/src/output/markdown/pageSections.ts
+++ b/src/output/markdown/pageSections.ts
@@ -3,15 +3,14 @@ import { escapeTableCell, formatBox } from './helpers.js';
 
 type SearchMatches = NonNullable<PageResult['matches']>;
 
+/** Render the per-page search-match table. Callers only invoke this for
+ *  pages that actually matched (`matches.length > 0`); a zero-match page
+ *  is silent — its density line already reports `matches: 0`. */
 export function appendSearchMatches(lines: string[], matches: SearchMatches): void {
+  if (matches.length === 0) return;
+
   lines.push('');
   lines.push('### Search matches');
-  if (matches.length === 0) {
-    lines.push('');
-    lines.push('_No search matches found._');
-    return;
-  }
-
   lines.push('');
   const showQueryIndex = matches.some((match) => match.queryIndex !== undefined);
   lines.push(`| Query |${showQueryIndex ? ' Query# |' : ''} Source | Text | Context | BBox |`);

--- a/src/output/matchesOnly.ts
+++ b/src/output/matchesOnly.ts
@@ -1,0 +1,172 @@
+import { encode } from '@toon-format/toon';
+import type { DocumentResult, OutputFormat, SearchMatch } from '../types/index.js';
+import { escapeTableCell, formatBox } from './markdown/helpers.js';
+import { escapeAttr, escapeText } from './xml/helpers.js';
+
+/**
+ * Compact search-only output. Instead of the full per-page document, emit
+ * a flat list of every search hit with its page, source, text, context,
+ * and bbox — so an agent that only wants "where does BLEU appear" gets a
+ * sub-kilobyte answer it can pipe straight into `--render-region`, rather
+ * than a 40 KB document dump.
+ *
+ * Pages that matched nothing do not appear at all. A run that matched
+ * nothing anywhere still succeeds (exit 0) and emits a minimal 0-match
+ * payload — a zero count is a valid observation for an agent, distinct
+ * from grep's exit-1 "not found" convention.
+ *
+ * The four formatters share one flat shape:
+ *   { file, totalPages, queries, totalMatches, matches: [{ page,
+ *     queryIndex, source, text, context?, bbox: {x,y,width,height} }] }
+ */
+
+/** One flattened match, carrying the parent query string (markdown shows
+ *  it; json/xml/toon key off `queryIndex` instead). */
+interface FlatMatch {
+  page: number;
+  query: string;
+  queryIndex: number;
+  source: SearchMatch['source'];
+  text: string;
+  context?: string;
+  bbox: SearchMatch['bbox'];
+}
+
+interface MatchesOnlyModel {
+  file: string;
+  totalPages: number;
+  queries: string[];
+  totalMatches: number;
+  matches: FlatMatch[];
+}
+
+function buildModel(result: DocumentResult, queries: string[]): MatchesOnlyModel {
+  const matches: FlatMatch[] = [];
+  for (const page of result.pages) {
+    for (const m of page.matches ?? []) {
+      matches.push({
+        page: m.page,
+        query: m.query,
+        // Single-query runs omit queryIndex on the match; the flat shape
+        // always carries it (defaulting to 0) so consumers can map back
+        // into `queries` uniformly regardless of query count.
+        queryIndex: m.queryIndex ?? 0,
+        source: m.source,
+        text: m.text,
+        ...(m.context !== undefined && { context: m.context }),
+        bbox: m.bbox,
+      });
+    }
+  }
+  return { file: result.file, totalPages: result.totalPages, queries, totalMatches: matches.length, matches };
+}
+
+/** Serialisable entry with the query string dropped — json/xml/toon key
+ *  off `queryIndex` against the top-level `queries` array instead. */
+function serializableEntry(m: FlatMatch) {
+  return {
+    page: m.page,
+    queryIndex: m.queryIndex,
+    source: m.source,
+    text: m.text,
+    ...(m.context !== undefined && { context: m.context }),
+    bbox: m.bbox,
+  };
+}
+
+function serializableModel(model: MatchesOnlyModel) {
+  return {
+    file: model.file,
+    totalPages: model.totalPages,
+    queries: model.queries,
+    totalMatches: model.totalMatches,
+    matches: model.matches.map(serializableEntry),
+  };
+}
+
+/** Human-readable summary of the match count, quoted queries, and the
+ *  pages they landed on: `3 ("BLEU") on page 1`. Zero matches → `0`. */
+function summaryLine(model: MatchesOnlyModel): string {
+  if (model.totalMatches === 0) return '0';
+  const quoted = model.queries.map((q) => `"${q}"`).join(', ');
+  const pages = [...new Set(model.matches.map((m) => m.page))].sort((a, b) => a - b);
+  const pagesFragment = pages.length === 1 ? ` on page ${pages[0]}` : ` on pages ${pages.join(', ')}`;
+  return `${model.totalMatches} (${quoted})${pagesFragment}`;
+}
+
+function formatMarkdown(model: MatchesOnlyModel): string {
+  const lines: string[] = [];
+  lines.push(`# ${model.file}`);
+  lines.push('');
+  lines.push(`- **Pages:** ${model.totalPages}`);
+  lines.push(`- **Matches:** ${summaryLine(model)}`);
+  if (model.totalMatches === 0) return lines.join('\n');
+
+  lines.push('');
+  lines.push('| Page | Query | Source | Text | Context | BBox |');
+  lines.push('| ---: | --- | --- | --- | --- | --- |');
+  for (const m of model.matches) {
+    lines.push(
+      `| ${m.page} | ${escapeTableCell(m.query)} | ${m.source} | ${escapeTableCell(m.text)} | ${escapeTableCell(m.context ?? '')} | ${formatBox(m.bbox)} |`,
+    );
+  }
+  return lines.join('\n');
+}
+
+function formatJson(model: MatchesOnlyModel): string {
+  return JSON.stringify(serializableModel(model), null, 2);
+}
+
+function formatToon(model: MatchesOnlyModel): string {
+  // Encode the JSON-normalized form for the same reason the full toon
+  // formatter does: the encoder renders `undefined` as explicit `null`,
+  // so round-tripping through JSON keeps optional fields (context) off
+  // when absent instead of emitting spurious `context: null` rows.
+  return encode(JSON.parse(JSON.stringify(serializableModel(model))));
+}
+
+function formatXml(model: MatchesOnlyModel): string {
+  const out: string[] = [];
+  out.push(
+    `<matches file="${escapeAttr(model.file)}" totalPages="${model.totalPages}" totalMatches="${model.totalMatches}">`,
+  );
+  out.push('<queries>');
+  for (const q of model.queries) out.push(`<query>${escapeText(q)}</query>`);
+  out.push('</queries>');
+  for (const m of model.matches) {
+    const attrs = [
+      `page="${m.page}"`,
+      `queryIndex="${m.queryIndex}"`,
+      `source="${m.source}"`,
+      `x="${m.bbox.x}"`,
+      `y="${m.bbox.y}"`,
+      `width="${m.bbox.width}"`,
+      `height="${m.bbox.height}"`,
+    ];
+    out.push(`<match ${attrs.join(' ')}>`);
+    out.push(`<text>${escapeText(m.text)}</text>`);
+    if (m.context !== undefined) out.push(`<context>${escapeText(m.context)}</context>`);
+    out.push('</match>');
+  }
+  out.push('</matches>');
+  return out.join('\n');
+}
+
+/**
+ * Render a {@link DocumentResult} as a compact matches-only payload in the
+ * requested format. `queries` is the verbatim search query list (used for
+ * the markdown query column and the top-level `queries` array).
+ */
+export function formatMatchesOnly(result: DocumentResult, format: OutputFormat, queries: string[]): string {
+  const model = buildModel(result, queries);
+  switch (format) {
+    case 'json':
+      return formatJson(model);
+    case 'xml':
+      return formatXml(model);
+    case 'toon':
+      return formatToon(model);
+    default:
+      return formatMarkdown(model);
+  }
+}

--- a/src/types/processOptions.ts
+++ b/src/types/processOptions.ts
@@ -20,6 +20,18 @@ export interface ProcessOptions {
   searchRegex?: boolean;
   /** See {@link ProcessDocumentOptions.searchCaseSensitive}. */
   searchCaseSensitive?: boolean;
+  /**
+   * Collapse the output to just the search matches — a flat list of
+   * every hit with its page, source, text, context, and bbox — instead
+   * of the full per-page document. Requires `search`; throws otherwise.
+   *
+   * Purely a rendering concern (like {@link stripRepeated}): the
+   * extraction is unchanged, only the formatter output differs. Applies
+   * to all four formats. A run that finds nothing still succeeds and
+   * emits a minimal "0 matches" payload — a zero count is a valid
+   * observation, not an error.
+   */
+  matchesOnly?: boolean;
   normalize?: boolean;
   geometry?: boolean;
   layout?: boolean;

--- a/tests/cli/cli.test.ts
+++ b/tests/cli/cli.test.ts
@@ -82,15 +82,20 @@ describe('cli', () => {
     vi.restoreAllMocks();
   });
 
-  it('prints help when no args are given', async () => {
+  it('prints usage to stderr and exits 2 when no args are given', async () => {
+    // No input source is a usage error, not a help request: usage goes to
+    // stderr with exit 2 so callers can tell it apart from an explicit
+    // --help (stdout, exit 0).
     const r = await captureRun([]);
-    expect(r.stdout.join('\n')).toContain('Usage:');
-    expect(r.exitCode).toBeNull();
+    expect(r.stderr.join('\n')).toContain('Usage:');
+    expect(r.stdout.join('\n')).not.toContain('Usage:');
+    expect(r.exitCode).toBe(2);
   });
 
-  it('prints help with --help', async () => {
+  it('prints help to stdout with exit 0 for explicit --help', async () => {
     const r = await captureRun(['--help']);
     expect(r.stdout.join('\n')).toContain('Usage:');
+    expect(r.exitCode).toBeNull();
   });
 
   it('prints version with --version', async () => {
@@ -437,6 +442,57 @@ describe('cli', () => {
     const r = await captureRun([SAMPLE_PDF, '--search-case-sensitive', '--no-cache']);
     expect(r.exitCode).toBe(1);
     expect(r.stderr.join('\n')).toMatch(/require at least one --search query/);
+  });
+
+  it('rejects --matches-only without --search', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--matches-only', '--no-cache']);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr.join('\n')).toMatch(/--matches-only requires --search/);
+  });
+
+  it('emits a compact flat match list with --matches-only (markdown)', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--search', 'pdfvision', '--matches-only', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    const out = r.stdout.join('\n');
+    expect(out).toContain('- **Matches:**');
+    expect(out).toContain('| Page | Query | Source | Text | Context | BBox |');
+    // No full-document scaffolding.
+    expect(out).not.toContain('## Page');
+  });
+
+  it('--matches-only json is flat (no pages[])', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--search', 'pdfvision', '--matches-only', '--json', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    const parsed = JSON.parse(r.stdout.join('\n'));
+    expect(parsed.pages).toBeUndefined();
+    expect(parsed.queries).toEqual(['pdfvision']);
+    expect(Array.isArray(parsed.matches)).toBe(true);
+  });
+
+  it('--matches-only with zero hits still exits 0 (a zero count is a valid observation)', async () => {
+    const r = await captureRun([
+      SAMPLE_PDF,
+      '--search',
+      'definitely-absent-xyzzy-9999',
+      '--matches-only',
+      '--no-cache',
+    ]);
+    expect(r.exitCode).toBeNull();
+    expect(r.stdout.join('\n')).toContain('- **Matches:** 0');
+  });
+
+  it('notes that --geometry has no effect with markdown output (but still succeeds)', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--geometry', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    expect(r.stderr.join('\n')).toContain('note: --geometry has no effect with markdown output; use -f json/xml/toon');
+    // Markdown still produced on stdout.
+    expect(r.stdout.join('\n')).toMatch(/## Page 1/);
+  });
+
+  it('does not print the geometry note when --geometry is paired with a structured format', async () => {
+    const r = await captureRun([SAMPLE_PDF, '--geometry', '--json', '--no-cache']);
+    expect(r.exitCode).toBeNull();
+    expect(r.stderr.join('\n')).not.toContain('--geometry has no effect');
   });
 
   it('accepts repeated --search flags as multi-query', async () => {

--- a/tests/core/flatRenderPaths.unit.test.ts
+++ b/tests/core/flatRenderPaths.unit.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveFlatRenderPaths } from '../../src/core/processor/flatRenderPaths.js';
+import { nextAvailableName, resolveFlatRenderPaths } from '../../src/core/processor/flatRenderPaths.js';
 
 describe('resolveFlatRenderPaths', () => {
   let dir: string;
@@ -48,5 +48,22 @@ describe('resolveFlatRenderPaths', () => {
   it('preserves the coordinate-suffixed name for region renders', () => {
     const paths = resolveFlatRenderPaths(dir, [3], { x: 50, y: 100, width: 400, height: 300 });
     expect(basename(paths[0])).toBe('page-3_x50_y100_w400_h300.png');
+  });
+});
+
+describe('nextAvailableName', () => {
+  it('appends the suffix at the end when the name has no extension', () => {
+    // Every current caller passes `.png` names, but the helper must not
+    // mangle an extension-less base (lastIndexOf('.') === -1 would
+    // otherwise slice at -1 and corrupt the stem).
+    expect(nextAvailableName('page-1', (name) => name === 'page-1')).toBe('page-1-2');
+  });
+
+  it('keeps the extension in place for dotted names', () => {
+    expect(nextAvailableName('page-1.png', (name) => name === 'page-1.png')).toBe('page-1-2.png');
+  });
+
+  it('returns the base name untouched when it is free', () => {
+    expect(nextAvailableName('page-1.png', () => false)).toBe('page-1.png');
   });
 });

--- a/tests/core/flatRenderPaths.unit.test.ts
+++ b/tests/core/flatRenderPaths.unit.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveFlatRenderPaths } from '../../src/core/processor/flatRenderPaths.js';
+
+describe('resolveFlatRenderPaths', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pdfvision-flat-paths-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('uses the plain page-N.png names in an empty dir and emits no note', () => {
+    const notes: string[] = [];
+    const paths = resolveFlatRenderPaths(dir, [1, 2, 3], undefined, (m) => notes.push(m));
+    expect(paths.map((p) => basename(p))).toEqual(['page-1.png', 'page-2.png', 'page-3.png']);
+    expect(notes).toEqual([]);
+  });
+
+  it('disambiguates against a pre-existing file and notes the rename', () => {
+    writeFileSync(join(dir, 'page-1.png'), 'x');
+    const notes: string[] = [];
+    const paths = resolveFlatRenderPaths(dir, [1], undefined, (m) => notes.push(m));
+    expect(basename(paths[0])).toBe('page-1-2.png');
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain('page-1-2.png');
+    expect(notes[0]).toContain('page-1.png');
+  });
+
+  it('keeps bumping the suffix past multiple pre-existing collisions', () => {
+    writeFileSync(join(dir, 'page-1.png'), 'x');
+    writeFileSync(join(dir, 'page-1-2.png'), 'x');
+    const paths = resolveFlatRenderPaths(dir, [1], undefined);
+    expect(basename(paths[0])).toBe('page-1-3.png');
+  });
+
+  it('reserves within-run picks so two pages never resolve to the same file', () => {
+    // Pre-plant page-2.png so page-2 has to move; page-1 keeps its base
+    // name and the two never collide with each other.
+    writeFileSync(join(dir, 'page-2.png'), 'x');
+    const paths = resolveFlatRenderPaths(dir, [1, 2], undefined);
+    expect(paths.map((p) => basename(p))).toEqual(['page-1.png', 'page-2-2.png']);
+  });
+
+  it('preserves the coordinate-suffixed name for region renders', () => {
+    const paths = resolveFlatRenderPaths(dir, [3], { x: 50, y: 100, width: 400, height: 300 });
+    expect(basename(paths[0])).toBe('page-3_x50_y100_w400_h300.png');
+  });
+});

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -1028,10 +1028,10 @@ describe('processDocument', () => {
     expect(Math.abs(smallImg.height - defImg.height / 2)).toBeLessThanOrEqual(1);
   });
 
-  it('isolates non-default renderScale output from the default-scale dir under renderOutput', async () => {
-    // Two scales must not stomp each other's PNGs. The non-default scale
-    // gets a `s<scale>` subdir so the default-scale path stays stable for
-    // existing user workflows.
+  it('does not stomp two scales sharing a flat renderOutput dir (collision suffix)', async () => {
+    // Flat renderOutput drops the per-scale subdir, so two scales of the
+    // same page collide on `page-1.png`. The second render must not
+    // overwrite the first — it lands on the `-2` disambiguated name.
     const { mkdtempSync, rmSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
     const { basename, dirname, join } = await import('node:path');
@@ -1049,10 +1049,11 @@ describe('processDocument', () => {
         noCache: true,
       });
       expect(def.pages[0].image).not.toBe(small.pages[0].image);
-      // Non-default scale lives under an extra subdir. Use path utilities
-      // rather than a hardcoded `/` split so the assertion stays valid on
-      // Windows runners (where the separator is `\`).
-      expect(basename(dirname(small.pages[0].image as string))).toBe('s1');
+      // Both land flat in the requested dir (no scale subdir).
+      expect(dirname(def.pages[0].image as string)).toBe(baseTmp);
+      expect(dirname(small.pages[0].image as string)).toBe(baseTmp);
+      expect(basename(def.pages[0].image as string)).toBe('page-1.png');
+      expect(basename(small.pages[0].image as string)).toBe('page-1-2.png');
     } finally {
       rmSync(baseTmp, { recursive: true, force: true });
     }
@@ -1294,15 +1295,14 @@ describe('processDocument', () => {
     expect(a.pages[0].image).not.toBe(b.pages[0].image);
   });
 
-  it('writes rendered PNGs into a per-PDF subdirectory of the caller-supplied renderOutput', async () => {
-    // Agent ergonomics: with renderOutput the PNGs land under the caller's
-    // chosen directory (created if missing) rather than tmp. They sit in a
-    // per-PDF subdirectory (keyed by content fingerprint) so two different
-    // PDFs sharing the same `--render-output ./images` never overwrite each
-    // other — see the "keeps per-PDF rendered PNGs isolated" test below.
+  it('writes rendered PNGs flat as page-N.png directly under the caller-supplied renderOutput', async () => {
+    // Agent ergonomics: with an explicit renderOutput the PNGs land flat
+    // in the caller's chosen directory (created if missing) as
+    // `<dir>/page-N.png` — no per-PDF hash or scale subdir — so the path
+    // is predictable and paste-able.
     const { mkdtempSync, rmSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
-    const { join, dirname, relative } = await import('node:path');
+    const { join, basename, dirname } = await import('node:path');
     const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-output-test-'));
     const outDir = join(baseTmp, 'nested', 'images'); // not yet created
     try {
@@ -1314,12 +1314,10 @@ describe('processDocument', () => {
       const imagePath = result.pages[0].image as string;
       expect(imagePath).toBeTypeOf('string');
       expect(existsSync(imagePath)).toBe(true);
-      // The PNG sits one level below the requested dir (in a fingerprint
-      // subdir), not anywhere outside it.
-      const rel = relative(outDir, imagePath);
-      expect(rel.startsWith('..')).toBe(false);
-      expect(dirname(imagePath).startsWith(outDir)).toBe(true);
-      expect(dirname(imagePath)).not.toBe(outDir);
+      // Flat: the PNG sits directly in the requested dir with the
+      // legacy `page-N.png` name, no intermediate subdir.
+      expect(dirname(imagePath)).toBe(outDir);
+      expect(basename(imagePath)).toBe('page-1.png');
     } finally {
       rmSync(baseTmp, { recursive: true, force: true });
     }
@@ -1373,19 +1371,14 @@ describe('processDocument', () => {
     }
   });
 
-  it('keeps per-PDF rendered PNGs isolated when two PDFs share the same renderOutput directory', async () => {
-    // Regression: previously `renderer` always wrote `page-${n}.png` into the
-    // caller-supplied renderOutput dir verbatim. Running two different PDFs
-    // against the same `--render-output ./img` overwrote A's page-1.png with
-    // B's bytes — and worse, `isReusableImage` then handed B's PNG back as
-    // A's image on subsequent runs because the filename matched.
-    //
-    // Contract: distinct PDFs sharing a renderOutput directory MUST end up
-    // with distinct on-disk PNG paths, and the first PDF's image bytes
-    // MUST survive a subsequent render of the second PDF.
+  it('disambiguates a filename collision (and notes it) when two PDFs share a flat renderOutput dir', async () => {
+    // Flat renderOutput writes `page-N.png` directly into the caller's
+    // dir. Running a second, different PDF into the same dir would collide
+    // on `page-1.png`; pdfvision must not overwrite the first PDF's PNG —
+    // it disambiguates to `page-1-2.png` and emits a one-line note.
     const { mkdtempSync, rmSync, readFileSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
-    const { join } = await import('node:path');
+    const { basename, join } = await import('node:path');
     const { createHash } = await import('node:crypto');
     const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-collision-test-'));
     const sharedOut = join(baseTmp, 'images');
@@ -1397,17 +1390,21 @@ describe('processDocument', () => {
       });
       const aImagePath = a.pages[0].image as string;
       const aBytesBefore = createHash('sha256').update(readFileSync(aImagePath)).digest('hex');
+      expect(basename(aImagePath)).toBe('page-1.png');
 
+      const notes: string[] = [];
       const b = await processDocument(SAMPLE_WITH_IMAGE_PDF, {
         render: true,
         renderOutput: sharedOut,
         noCache: true,
+        onWarning: (m) => notes.push(m),
       });
       const bImagePath = b.pages[0].image as string;
 
-      // Different PDFs must resolve to different on-disk paths under the
-      // shared directory.
+      // Second PDF lands on the disambiguated name, not A's page-1.png.
+      expect(basename(bImagePath)).toBe('page-1-2.png');
       expect(aImagePath).not.toBe(bImagePath);
+      expect(notes.some((n) => n.includes('page-1-2.png') && n.includes('page-1.png'))).toBe(true);
       // A's PNG bytes must still match the original A render — they must
       // not have been silently replaced by B's render.
       const aBytesAfter = createHash('sha256').update(readFileSync(aImagePath)).digest('hex');
@@ -1466,65 +1463,26 @@ describe('processDocument', () => {
     }
   });
 
-  it('refuses to render when the per-PDF subdir under renderOutput is a pre-planted symlink', async () => {
-    // Hardening: the fingerprint subdir name is deterministic, so on a
-    // shared writable host another process could plant
-    // `<renderOutput>/<fingerprint>` as a symlink to elsewhere and
-    // redirect our `page-N.png` writes. Catch that before any render
-    // happens — silently following the symlink would be a security
-    // regression vs the cache hierarchy's posture.
-    //
-    // POSIX-only: Windows `symlinkSync` needs elevated privileges or
-    // a special `type: 'dir'` mode and is awkward to test there. The
-    // matching cache-side symlink tests in `tests/core/cache.test.ts`
-    // also skip Windows for the same reason.
-    if (process.platform === 'win32') return;
-    const { mkdtempSync, mkdirSync, rmSync, symlinkSync } = await import('node:fs');
+  it('does not overwrite a pre-existing page-N.png in a flat renderOutput dir', async () => {
+    // Flat renderOutput writes `page-N.png` directly into the caller's
+    // dir. A same-named file already there (e.g. planted by another
+    // process, or left by a different PDF) must be left untouched: we
+    // disambiguate onto `page-1-2.png` rather than following/clobbering
+    // whatever `page-1.png` points at.
+    const { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } = await import('node:fs');
     const { tmpdir } = await import('node:os');
-    const { join } = await import('node:path');
-    const { pdfFingerprint } = await import('../../src/core/io/cache.js');
-    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-symlink-test-'));
+    const { basename, join } = await import('node:path');
+    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-preexisting-'));
     const outDir = join(baseTmp, 'images');
-    const decoy = join(baseTmp, 'decoy');
     mkdirSync(outDir, { recursive: true });
-    mkdirSync(decoy, { recursive: true });
-    const fp = pdfFingerprint(SAMPLE_PDF);
-    symlinkSync(decoy, join(outDir, fp));
+    const planted = join(outDir, 'page-1.png');
+    writeFileSync(planted, 'not-a-real-png');
     try {
-      await expect(processDocument(SAMPLE_PDF, { render: true, renderOutput: outDir, noCache: true })).rejects.toThrow(
-        /symlink/,
-      );
-    } finally {
-      rmSync(baseTmp, { recursive: true, force: true });
-    }
-  });
-
-  it('also refuses a pre-planted symlink at the intermediate fingerprint dir when renderScale forces a nested subdir', async () => {
-    // Regression: with `--render-scale` the imagesDir becomes
-    // `<renderOutput>/<fingerprint>/s<scale>`. `mkdirSync(...,
-    // { recursive: true })` follows a symlink at the intermediate
-    // `<fingerprint>` segment to plant the scale subdir at the
-    // attacker's target — and a final lstat on the deeper path then
-    // sees a regular dir at the target and lets the render proceed.
-    // The check must also assert the fingerprint dir before going
-    // deeper, otherwise non-default scales silently bypass the
-    // hardening that already guards the default-scale path above.
-    if (process.platform === 'win32') return;
-    const { mkdtempSync, mkdirSync, rmSync, symlinkSync } = await import('node:fs');
-    const { tmpdir } = await import('node:os');
-    const { join } = await import('node:path');
-    const { pdfFingerprint } = await import('../../src/core/io/cache.js');
-    const baseTmp = mkdtempSync(join(tmpdir(), 'pdfvision-render-scale-symlink-'));
-    const outDir = join(baseTmp, 'images');
-    const decoy = join(baseTmp, 'decoy');
-    mkdirSync(outDir, { recursive: true });
-    mkdirSync(decoy, { recursive: true });
-    const fp = pdfFingerprint(SAMPLE_PDF);
-    symlinkSync(decoy, join(outDir, fp));
-    try {
-      await expect(
-        processDocument(SAMPLE_PDF, { render: true, renderOutput: outDir, renderScale: 1, noCache: true }),
-      ).rejects.toThrow(/symlink/);
+      const result = await processDocument(SAMPLE_PDF, { render: true, renderOutput: outDir, noCache: true });
+      const imagePath = result.pages[0].image as string;
+      expect(basename(imagePath)).toBe('page-1-2.png');
+      // The planted file's bytes must be intact.
+      expect(readFileSync(planted, 'utf8')).toBe('not-a-real-png');
     } finally {
       rmSync(baseTmp, { recursive: true, force: true });
     }

--- a/tests/core/processor.visualRegions.test.ts
+++ b/tests/core/processor.visualRegions.test.ts
@@ -248,4 +248,74 @@ describe('processDocument visualRegions: true', () => {
       expect(region?.associatedText).toBeUndefined();
     }
   });
+
+  it("does not reuse another PDF's same-named region crop in a shared flat renderOutput dir", async () => {
+    // Regression: renderVisualRegions crops used to go through
+    // renderPageWithStats with default reuse — in a flat --render-output
+    // dir a pre-existing `page-1_x..._y..._w..._h....png` written by a
+    // DIFFERENT PDF (same page number, identical region coordinates)
+    // was handed back as this document's crop: a stale image. The crops
+    // must route through the same collision-safe resolver as full-page
+    // renders, with disk reuse off.
+    //
+    // Two PDFs with pixel-different images at identical coordinates
+    // produce identical region bboxes → identical crop filenames.
+    const { mkdtempSync, rmSync, readFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { basename, join } = await import('node:path');
+    const { createHash } = await import('node:crypto');
+
+    async function buildImageOnlyPdf(color: string): Promise<Uint8Array> {
+      const chunks: Buffer[] = [];
+      const doc = new PDFDocument({ size: [612, 792], margin: 0 });
+      doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+      const done = new Promise<void>((resolveDone) => doc.on('end', resolveDone));
+      const canvas = createCanvas(100, 100);
+      const context = canvas.getContext('2d');
+      context.fillStyle = color;
+      context.fillRect(0, 0, 100, 100);
+      doc.image(canvas.toBuffer('image/png'), 72, 120, { width: 240, height: 180 });
+      doc.end();
+      await done;
+      return new Uint8Array(Buffer.concat(chunks));
+    }
+
+    const sharedOut = mkdtempSync(join(tmpdir(), 'pdfvision-region-collision-'));
+    try {
+      const a = await processDocument('memory://region-collision-a.pdf', {
+        sourceData: await buildImageOnlyPdf('black'),
+        renderVisualRegions: true,
+        renderOutput: sharedOut,
+        noCache: true,
+      });
+      const aImagePath = a.pages[0].visualRegions?.[0]?.image as string;
+      expect(aImagePath).toBeTypeOf('string');
+      const aBytes = createHash('sha256').update(readFileSync(aImagePath)).digest('hex');
+
+      const notes: string[] = [];
+      const b = await processDocument('memory://region-collision-b.pdf', {
+        sourceData: await buildImageOnlyPdf('navy'),
+        renderVisualRegions: true,
+        renderOutput: sharedOut,
+        noCache: true,
+        onWarning: (m) => notes.push(m),
+      });
+      const bImagePath = b.pages[0].visualRegions?.[0]?.image as string;
+      expect(bImagePath).toBeTypeOf('string');
+
+      // Identical region coordinates → identical base filename, so B must
+      // have been disambiguated onto a distinct -2 path with its own
+      // bytes, not handed A's PNG back as a cache hit.
+      expect(bImagePath).not.toBe(aImagePath);
+      expect(basename(bImagePath)).toBe(basename(aImagePath).replace(/\.png$/, '-2.png'));
+      expect(notes.some((n) => n.includes(basename(bImagePath)))).toBe(true);
+      const bBytes = createHash('sha256').update(readFileSync(bImagePath)).digest('hex');
+      expect(bBytes).not.toBe(aBytes);
+      // A's PNG bytes survive B's run untouched.
+      const aBytesAfter = createHash('sha256').update(readFileSync(aImagePath)).digest('hex');
+      expect(aBytesAfter).toBe(aBytes);
+    } finally {
+      rmSync(sharedOut, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -596,7 +596,11 @@ describe('formatMarkdown', () => {
     expect(out).toContain('### Search matches');
     expect(out).toContain('| Query | Query# | Source | Text | Context | BBox |');
     expect(out).toContain('| text\\|term | 1 | native | text\\|term | near text\\|term | 100,72,60,12 |');
-    expect(out).toContain('_No search matches found._');
+    // Page 2 matched nothing: its density line still carries `matches: 0`
+    // (search-ran-clean signal), but the noisy per-page
+    // `### Search matches / _No search matches found._` block is gone.
+    expect(out).toContain('matches: 0');
+    expect(out).not.toContain('_No search matches found._');
   });
 
   it('adds annotation counts and an annotations table when comments or markup are present', () => {

--- a/tests/output/matchesOnly.test.ts
+++ b/tests/output/matchesOnly.test.ts
@@ -1,0 +1,149 @@
+import { decode } from '@toon-format/toon';
+import { describe, expect, it } from 'vitest';
+import { formatMatchesOnly } from '../../src/output/matchesOnly.js';
+import type { DocumentResult, PageResult, SearchMatch } from '../../src/types/index.js';
+
+function makePage(overrides: Partial<PageResult> & Pick<PageResult, 'page'>): PageResult {
+  return {
+    text: '',
+    charCount: 0,
+    imageCount: 0,
+    vectorCount: 0,
+    textCoverage: 0,
+    nonPrintableRatio: 0,
+    nonPrintableCount: 0,
+    quality: { nativeTextStatus: 'empty' },
+    width: 612,
+    height: 792,
+    ...overrides,
+  };
+}
+
+function match(overrides: Partial<SearchMatch> & Pick<SearchMatch, 'page'>): SearchMatch {
+  return {
+    query: 'BLEU',
+    source: 'native',
+    text: 'BLEU',
+    bbox: { x: 340.31, y: 487.37, width: 17.86, height: 9.96 },
+    boxes: [{ x: 340.31, y: 487.37, width: 17.86, height: 9.96 }],
+    ...overrides,
+  };
+}
+
+function makeResult(pages: PageResult[], totalPages = 15): DocumentResult {
+  return {
+    file: '/tmp/attention.pdf',
+    totalPages,
+    metadata: { title: null, author: null, subject: null, creator: null },
+    pages,
+  };
+}
+
+// A single-query result with three native BLEU hits, all on page 1 —
+// mirrors the plan's markdown example.
+const THREE_HITS = makeResult([
+  makePage({
+    page: 1,
+    matches: [
+      match({ page: 1, context: 'less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-' }),
+      match({
+        page: 1,
+        bbox: { x: 231.51, y: 509.18, width: 16.69, height: 9.96 },
+        context: 'ensembles, by over 2 BLEU.',
+      }),
+      match({
+        page: 1,
+        bbox: { x: 373.35, y: 520.09, width: 15.83, height: 9.96 },
+        context: 'BLEU score of 41.8 after',
+      }),
+    ],
+  }),
+  // Page 2 matched nothing — must not appear in matches-only output.
+  makePage({ page: 2, matches: [] }),
+]);
+
+describe('formatMatchesOnly', () => {
+  it('markdown: header, summary line, and one flat table of every hit', () => {
+    const out = formatMatchesOnly(THREE_HITS, 'markdown', ['BLEU']);
+    expect(out).toMatch(/^# \/tmp\/attention\.pdf\n/);
+    expect(out).toContain('- **Pages:** 15');
+    expect(out).toContain('- **Matches:** 3 ("BLEU") on page 1');
+    expect(out).toContain('| Page | Query | Source | Text | Context | BBox |');
+    expect(out).toContain(
+      '| 1 | BLEU | native | BLEU | less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English- | 340.31,487.37,17.86,9.96 |',
+    );
+    // No per-page bodies, no Overview table, and pages with zero matches
+    // never appear.
+    expect(out).not.toContain('## Page');
+    expect(out).not.toContain('Overview');
+    // Exactly one table header.
+    expect(out.match(/\| Page \| Query \|/g)).toHaveLength(1);
+  });
+
+  it('json: flat structure with no pages[] array', () => {
+    const parsed = JSON.parse(formatMatchesOnly(THREE_HITS, 'json', ['BLEU']));
+    expect(parsed).toMatchObject({ file: '/tmp/attention.pdf', totalPages: 15, queries: ['BLEU'], totalMatches: 3 });
+    expect(parsed.pages).toBeUndefined();
+    expect(parsed.matches).toHaveLength(3);
+    expect(parsed.matches[0]).toEqual({
+      page: 1,
+      queryIndex: 0,
+      source: 'native',
+      text: 'BLEU',
+      context: 'less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-',
+      bbox: { x: 340.31, y: 487.37, width: 17.86, height: 9.96 },
+    });
+    // The query STRING is not repeated per entry — consumers key off
+    // queryIndex against the top-level queries array.
+    expect(parsed.matches[0]).not.toHaveProperty('query');
+  });
+
+  it('xml: mirrors the flat json shape', () => {
+    const out = formatMatchesOnly(THREE_HITS, 'xml', ['BLEU']);
+    expect(out).toMatch(/^<matches file="\/tmp\/attention\.pdf" totalPages="15" totalMatches="3">/);
+    expect(out).toContain('<queries>');
+    expect(out).toContain('<query>BLEU</query>');
+    expect(out).toContain(
+      '<match page="1" queryIndex="0" source="native" x="340.31" y="487.37" width="17.86" height="9.96">',
+    );
+    expect(out).toContain('<text>BLEU</text>');
+    expect(out).not.toContain('<page ');
+  });
+
+  it('toon: round-trips to the same flat data model as json', () => {
+    const toon = formatMatchesOnly(THREE_HITS, 'toon', ['BLEU']);
+    const decoded = decode(toon) as { totalMatches: number; matches: unknown[]; pages?: unknown };
+    expect(decoded.totalMatches).toBe(3);
+    expect(decoded.matches).toHaveLength(3);
+    expect(decoded.pages).toBeUndefined();
+  });
+
+  it('multi-query: keeps queryIndex per hit and lists every query', () => {
+    const result = makeResult([
+      makePage({
+        page: 3,
+        matches: [
+          match({ page: 3, query: 'GPT', queryIndex: 0, text: 'GPT' }),
+          match({ page: 3, query: 'transformer', queryIndex: 1, text: 'transformer' }),
+        ],
+      }),
+    ]);
+    const parsed = JSON.parse(formatMatchesOnly(result, 'json', ['GPT', 'transformer']));
+    expect(parsed.queries).toEqual(['GPT', 'transformer']);
+    expect(parsed.matches.map((m: { queryIndex: number }) => m.queryIndex)).toEqual([0, 1]);
+    const md = formatMatchesOnly(result, 'markdown', ['GPT', 'transformer']);
+    expect(md).toContain('- **Matches:** 2 ("GPT", "transformer") on page 3');
+  });
+
+  it('zero matches: minimal output, no table, still a valid result', () => {
+    const empty = makeResult([makePage({ page: 1, matches: [] })]);
+    const md = formatMatchesOnly(empty, 'markdown', ['BLEU']);
+    expect(md).toContain('- **Matches:** 0');
+    expect(md).not.toContain('| Page | Query |');
+
+    const json = JSON.parse(formatMatchesOnly(empty, 'json', ['BLEU']));
+    expect(json.totalMatches).toBe(0);
+    expect(json.matches).toEqual([]);
+    expect(json.queries).toEqual(['BLEU']);
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements the v0.13.0 agent-ergonomics batch: it makes the find-then-zoom flow cheap enough to be an agent's default reflex, removes three small usability thorns, and makes README/help drift structurally impossible.

### `--matches-only` — grep-like search output (96% smaller)

`--search` previously returned the full document body plus a "No search matches found" section on every non-matching page: finding 3 occurrences of a word in a 15-page paper cost ~45 KB of output. With `--matches-only`:

- One flat table (markdown) / flat `matches[]` payload (json/xml/toon) with page, query, source, text, context, and bbox per hit — pages without matches are omitted entirely.
- Measured on the *Attention Is All You Need* paper, `--search "BLEU" --matches-only`: **45,491 B → 1,735 B** for 11 matches across 3 pages.
- The bbox feeds directly into `--render-region`, so find-then-zoom stays a two-command loop.
- Requires `--search`; zero total matches still exits 0 (a zero count is a valid observation for an agent, unlike grep).
- The full `--search` output also drops the per-page "No search matches found" noise sections.

### Small fixes

- `--geometry` with markdown output now prints a stderr note instead of silently no-opping (asymmetric with `--render-scale`, which errors on misuse).
- An explicitly passed `--render-output <dir>` now writes flat `<dir>/page-N.png` paths instead of hash subdirectories; cross-PDF collisions get a `-2` suffix with a stderr note. Cache-located renders keep the hashed layout.
- Running with no arguments prints usage to stderr and exits 2 (was: help on stdout, exit 0). Explicit `--help` is unchanged.

### README/help sync CI

- New `scripts/sync-readme-usage.mjs` regenerates the README Usage block from `--help` between `<!-- usage:start/end -->` markers.
- CI now runs the script and fails on `git diff`, so the README can no longer silently fall behind the CLI (as happened with `--search` / `--strip-repeated` before 2f2d343).

## Test plan

- 1151 tests pass (58 files), including new coverage for matches-only across all four formats, multi-query, zero-match, the requires-search error, geometry note, flat render naming + collision suffix, and no-args exit code.
- Biome / oxlint / tsgo / secretlint clean; README sync verified idempotent.
- Two obsolete symlink-hardening tests tied to the removed hashed `--render-output` structure were replaced with an equivalent flat-mode no-clobber test; root-dir symlink refusal remains tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)