### PR TITLE
chore(release): bump version to 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Version bump for the v0.13.0 release, covering:

- #87 — `--matches-only` compact search output (45,491 B → 1,735 B on the attention paper), flat `--render-output` paths with collision suffixes, stale-PNG reuse fix for visual-region crops, `--geometry` markdown note, no-args exit 2, and README/help sync CI.
- #88 — SKILL.md diet: 39.8 KB → 8.2 KB, warnings/flags catalogs moved to `references/`, AGENTS.md write policy.

After merge: create the v0.13.0 GitHub release and run the npm-publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)