### PR TITLE
feat(output): make the layout-rebuilt body the default markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,12 @@ Options
       --geometry          Emit per-text-item bbox + font size in `pages[].spans`.
                           Only takes effect with -f json / -f xml / -f toon.
       --layout            Reconstruct `pages[].layout` (lines, blocks, vertical CJK stacks,
-                          and numeric-table hints
-                          in approximate reading order) from the same span data. Structured layout fields
-                          appear in -f json / -f xml / -f toon; Markdown uses recovered vertical text
-                          blocks, and rebuilds the page body in layout order when the native text
-                          stream diverges from the visual reading order.
-                          Also enables layout warnings: overlapping text, off-page bboxes,
-                          body crowded against repeated chrome, flattened numeric tables,
-                          or native-vs-visual reading-order divergence in `pages[].warnings`.
+                          and numeric-table hints in approximate reading order) from the
+                          same span data, and add the structured layout fields to
+                          -f json / -f xml / -f toon. In Markdown it also adds the per-page
+                          `Layout tables` sections and the Overview `Blocks` / `Tables` columns.
+                          Markdown does NOT need this flag for the reading-order body or the
+                          layout warnings — those are on by default (see below).
       --image-boxes       Emit `pages[].imageBoxes` — bounding box of every raster image
                           draw on the page. Enables large-raster warnings with --layout or
                           --geometry. Only -f json / -f xml / -f toon.
@@ -234,6 +232,9 @@ Options
 
 Output formats
   markdown (default)  Per-page sections, density Overview table, image links inline. For LLM context.
+                      The body is rebuilt in visual reading order (lines joined into paragraphs)
+                      and layout warnings surface automatically — no --layout needed. --layout adds
+                      the structural Layout tables / Blocks / Tables columns on top.
   json                Full DocumentResult schema. For programmatic parsing.
   xml                 Tag-shaped variant of json. For LLMs that parse tags more reliably than JSON.
   toon                Token-Oriented Object Notation: lossless, tabular encoding of the json schema

--- a/skills/pdfvision/SKILL.md
+++ b/skills/pdfvision/SKILL.md
@@ -69,7 +69,7 @@ Each page/overview row carries a derived `quality` field (observation only; the 
 
 `quality.visualStatus` (only with `--render` / `--ocr`): `ok` = clearly populated; `sparse` = faint marks only (text/annotation-only included), not blank — inspect `--render-region` / `--visual-regions`; `blank` = blank against its own dominant background (render failure or genuinely blank).
 
-`pages[].warnings[]` flags page anomalies with a self-explanatory `message` (geometry ones need `--layout`). Read `references/warnings.md` only when a code needs more than its message.
+`pages[].warnings[]` flags page anomalies with a self-explanatory `message` (all surface in default markdown). Read `references/warnings.md` only when a code needs more than its message.
 
 ## Caching
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -56,14 +56,12 @@ Options
       --geometry          Emit per-text-item bbox + font size in \`pages[].spans\`.
                           Only takes effect with -f json / -f xml / -f toon.
       --layout            Reconstruct \`pages[].layout\` (lines, blocks, vertical CJK stacks,
-                          and numeric-table hints
-                          in approximate reading order) from the same span data. Structured layout fields
-                          appear in -f json / -f xml / -f toon; Markdown uses recovered vertical text
-                          blocks, and rebuilds the page body in layout order when the native text
-                          stream diverges from the visual reading order.
-                          Also enables layout warnings: overlapping text, off-page bboxes,
-                          body crowded against repeated chrome, flattened numeric tables,
-                          or native-vs-visual reading-order divergence in \`pages[].warnings\`.
+                          and numeric-table hints in approximate reading order) from the
+                          same span data, and add the structured layout fields to
+                          -f json / -f xml / -f toon. In Markdown it also adds the per-page
+                          \`Layout tables\` sections and the Overview \`Blocks\` / \`Tables\` columns.
+                          Markdown does NOT need this flag for the reading-order body or the
+                          layout warnings — those are on by default (see below).
       --image-boxes       Emit \`pages[].imageBoxes\` — bounding box of every raster image
                           draw on the page. Enables large-raster warnings with --layout or
                           --geometry. Only -f json / -f xml / -f toon.
@@ -161,6 +159,9 @@ Options
 
 Output formats
   markdown (default)  Per-page sections, density Overview table, image links inline. For LLM context.
+                      The body is rebuilt in visual reading order (lines joined into paragraphs)
+                      and layout warnings surface automatically — no --layout needed. --layout adds
+                      the structural Layout tables / Blocks / Tables columns on top.
   json                Full DocumentResult schema. For programmatic parsing.
   xml                 Tag-shaped variant of json. For LLMs that parse tags more reliably than JSON.
   toon                Token-Oriented Object Notation: lossless, tabular encoding of the json schema

--- a/src/core/processor/processFileOptions.ts
+++ b/src/core/processor/processFileOptions.ts
@@ -41,7 +41,13 @@ export function buildProcessDocumentOptions(options: ProcessOptions): ProcessDoc
     searchCaseSensitive: options.searchCaseSensitive,
     normalize: options.normalize,
     geometry: options.geometry,
-    layout: options.layout,
+    // Markdown output always computes layout internally: the default body
+    // is the layout-rebuilt reading-order text and the per-page / overview
+    // warnings include the layout-derived ones (reading_order_divergence,
+    // text_overlap, ...). The structured `pages[].layout` sections stay
+    // gated behind the user's explicit --layout (see formatMarkdown), and
+    // json/xml/toon keep the original opt-in so their schema is unchanged.
+    layout: options.layout || options.format === 'markdown',
     imageBoxes: options.imageBoxes,
     vectorBoxes: options.vectorBoxes,
     visualRegions: options.visualRegions,

--- a/src/core/processor/renderResult.ts
+++ b/src/core/processor/renderResult.ts
@@ -28,6 +28,10 @@ export function renderResult(result: DocumentResult, options: ProcessOptions): s
     case 'toon':
       return formatToon(result);
     default:
-      return formatMarkdown(result, { stripRepeated: options.stripRepeated });
+      // `layout` here is the user's explicit --layout choice, NOT the
+      // internal force-on used for the body/warnings. It gates the
+      // structural Markdown sections (Layout tables, Overview
+      // Blocks/Tables columns) so the default stays body + warnings only.
+      return formatMarkdown(result, { stripRepeated: options.stripRepeated, layout: options.layout });
   }
 }

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -22,6 +22,12 @@ export interface MarkdownOptions {
    *  to have been extracted with `layout: true`; throws otherwise so
    *  silent no-ops don't mask a misconfigured call. */
   stripRepeated?: boolean;
+  /** The user's explicit `--layout` choice. Markdown always computes
+   *  layout internally (so the default body is reading-order text and
+   *  layout warnings surface), but the *structural* sections — the
+   *  per-page `### Layout tables` blocks and the Overview `Blocks` /
+   *  `Tables` columns — stay gated behind this flag. Defaults to false. */
+  layout?: boolean;
 }
 
 function layoutBody(page: PageResult, filterRepeated: boolean): string {
@@ -31,35 +37,32 @@ function layoutBody(page: PageResult, filterRepeated: boolean): string {
     .join('\n\n');
 }
 
-/** Body text for a page: either the pdf.js-derived `page.text` (default),
- *  or a layout-driven rebuild when repeated chrome must be stripped or
- *  when vertical CJK stacks are present. The latter avoids Markdown
- *  showing `縦\n書\nき` even though the layout pass has already recovered
- *  the human-readable `縦書き` block. */
+/** Body text for a page. Markdown always runs the layout pass, so the
+ *  default body is the layout-rebuilt reading-order text: blocks in
+ *  visual reading order, lines within a block joined into paragraphs
+ *  instead of the old blank-line-per-physical-line rendering. This also
+ *  fixes native stream order that diverges from the visual order
+ *  (magazine frames, out-of-stream titles) and vertical CJK stacks —
+ *  `page.text` would show `縦\n書\nき` while the block already recovered
+ *  the human-readable `縦書き`.
+ *
+ *  Falls back to `page.text` only when there is no usable layout (e.g. a
+ *  scanned page with no native text layer), so nothing is ever lost. */
 function pageBody(page: PageResult, options: MarkdownOptions): string {
-  if (!options.stripRepeated) {
-    if (page.layout?.blocks.some((b) => b.writingMode === 'vertical')) return layoutBody(page, false);
-    // When the warning pass established that the native stream order
-    // diverges from the visual reading order (magazine-style frames
-    // emitted out of order), the layout rebuild is the human-faithful
-    // body — raw page.text would bury the page title mid-stream.
-    if (page.layout && page.warnings?.some((w) => w.code === 'reading_order_divergence')) {
-      return layoutBody(page, false);
+  if (options.stripRepeated) {
+    if (!page.layout) {
+      // Caller asked to strip repeated chrome but the document carries no
+      // layout — `repeated: true` is only set during the cross-page
+      // layout pass, so there is no way to filter without it. Fail loud
+      // rather than silently emitting the unfiltered text.
+      throw new Error('stripRepeated requires layout extraction (pass layout: true to processDocument)');
     }
-    return page.text;
+    // Rebuild from non-repeated blocks. Double-newline separators keep
+    // consecutive paragraphs / heading + body from running together.
+    return layoutBody(page, true);
   }
-  if (!page.layout) {
-    // Caller asked to strip repeated chrome but the document carries no
-    // layout — `repeated: true` is only set during the cross-page
-    // layout pass, so there is no way to filter without it. Fail loud
-    // rather than silently emitting the unfiltered text.
-    throw new Error('stripRepeated requires layout extraction (pass layout: true to processDocument)');
-  }
-  // Rebuild the body from non-repeated blocks. Use double-newline
-  // separators so consecutive paragraphs / heading + body don't run
-  // together when their original spacing came from layout gaps rather
-  // than literal newlines.
-  return layoutBody(page, true);
+  if (page.layout && page.layout.blocks.length > 0) return layoutBody(page, false);
+  return page.text;
 }
 
 /**
@@ -125,7 +128,7 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
     }
   }
 
-  appendOverview(lines, result);
+  appendOverview(lines, result, { layout: options.layout ?? false });
 
   for (const page of result.pages) {
     const coveragePct = Math.round(page.textCoverage * 100);
@@ -152,8 +155,11 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
     const rotationFragment = page.rotation !== undefined ? ` · rotation: ${page.rotation}°` : '';
     const vectorsFragment = page.vectorCount > 0 ? ` · vectors: ${page.vectorCount}` : '';
     const vectorBoxesFragment = page.vectorBoxes !== undefined ? ` · vectorBoxes: ${page.vectorBoxes.length}` : '';
+    // Layout tables are structural output: only surfaced when the user
+    // explicitly asked for --layout, even though layout is always
+    // computed for the default body / warnings.
     const layoutTablesFragment =
-      (page.layout?.tables?.length ?? 0) > 0 ? ` · tables: ${page.layout?.tables?.length}` : '';
+      options.layout && (page.layout?.tables?.length ?? 0) > 0 ? ` · tables: ${page.layout?.tables?.length}` : '';
     const visualRegionsFragment =
       page.visualRegions !== undefined ? ` · visualRegions: ${page.visualRegions.length}` : '';
     const formFieldsFragment = page.formFields !== undefined ? ` · formFields: ${page.formFields.length}` : '';
@@ -192,7 +198,7 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
       lines.push('');
       lines.push(body);
     }
-    if (page.layout?.tables && page.layout.tables.length > 0) {
+    if (options.layout && page.layout?.tables && page.layout.tables.length > 0) {
       appendLayoutTables(lines, page.layout.tables);
     }
     // Only render the match table for pages that actually matched. A

--- a/src/output/markdown/overview.ts
+++ b/src/output/markdown/overview.ts
@@ -8,16 +8,23 @@ export function formatSize(page: PageResult): string {
   return `${trim(page.width)}×${trim(page.height)}`;
 }
 
-export function appendOverview(lines: string[], result: DocumentResult): void {
+interface AppendOverviewOptions {
+  /** The user's explicit --layout choice. Markdown always computes
+   *  layout internally, so the Blocks / Tables columns (structural
+   *  output) are only shown when the user actually asked for --layout. */
+  layout: boolean;
+}
+
+export function appendOverview(lines: string[], result: DocumentResult, options: AppendOverviewOptions): void {
   if (result.pages.length <= 1) return;
 
-  const showBlocks = result.pages.some((p) => p.layout !== undefined);
+  const showBlocks = options.layout && result.pages.some((p) => p.layout !== undefined);
   const showNonPrint = result.pages.some((p) => p.nonPrintableCount > 0);
   const showRender = result.pages.some((p) => p.renderContentRatio !== undefined);
   const showRotation = result.pages.some((p) => p.rotation !== undefined);
   const showVectors = result.pages.some((p) => p.vectorCount > 0);
   const showVectorBoxes = result.pages.some((p) => p.vectorBoxes !== undefined);
-  const showLayoutTables = result.pages.some((p) => (p.layout?.tables?.length ?? 0) > 0);
+  const showLayoutTables = options.layout && result.pages.some((p) => (p.layout?.tables?.length ?? 0) > 0);
   const showFormFields = result.pages.some((p) => p.formFields !== undefined);
   const showLinks = result.pages.some((p) => p.links !== undefined);
   const showAnnotations = result.pages.some((p) => p.annotations !== undefined);

--- a/tests/core/processor.test.ts
+++ b/tests/core/processor.test.ts
@@ -30,6 +30,25 @@ describe('processFile', () => {
     expect(result).toContain('Hello pdfvision');
   });
 
+  it('keeps layout out of the structured JSON when --layout is not requested', async () => {
+    // Markdown computes layout internally (for the reading-order body and
+    // layout warnings), but that must NOT leak into json/xml/toon: the
+    // structured schema stays layout-opt-in and unchanged.
+    const result = await processFile(SAMPLE_PDF, { format: 'json', noCache: true });
+    const parsed = JSON.parse(result);
+    expect(parsed.pages[0].layout).toBeUndefined();
+  });
+
+  it('gates the structural layout sections in default markdown (no --layout)', async () => {
+    // Even though markdown always runs the layout pass, the structural
+    // `### Layout tables` section and the Overview Tables/Blocks columns
+    // only appear when the user explicitly passes --layout.
+    const md = await processFile(SAMPLE_PDF, { format: 'markdown', noCache: true });
+    expect(md).not.toContain('### Layout tables');
+    expect(md).not.toMatch(/ Blocks \|/);
+    expect(md).not.toMatch(/ Tables \|/);
+  });
+
   it('extracts text as TOON', async () => {
     // Guard the format='toon' wiring through processFile so a typo in the
     // dispatch switch can't silently fall through to markdown.

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -272,6 +272,10 @@ describe('formatMarkdown', () => {
           makePage({ page: 2, text: 'plain', charCount: 5 }),
         ],
       }),
+      // Layout tables + the Overview Tables/Blocks columns are structural
+      // output, gated behind the user's explicit --layout even though
+      // markdown always computes layout for the body / warnings.
+      { layout: true },
     );
 
     expect(out).toMatch(/\| Page \| Chars \| Images \| Coverage \| Size \(pt\) \| Tables \| Blocks \|/);
@@ -1000,6 +1004,9 @@ describe('formatMarkdown', () => {
           }),
         ],
       }),
+      // The Blocks column is structural output, only shown when the user
+      // asked for --layout (markdown computes layout unconditionally).
+      { layout: true },
     );
     expect(out).toMatch(/Blocks \|/);
     expect(out).toMatch(/\| 1 \| 1 \| 0 \| 0% \| 612×792 \| 1 \|/);
@@ -1299,9 +1306,10 @@ describe('formatMarkdown', () => {
     expect(out).not.toContain('© COLOPL, Inc.');
   });
 
-  it('leaves the body untouched when stripRepeated is off (default)', async () => {
-    // Sanity: opting out of strip means the existing `page.text` flow
-    // is preserved verbatim, including the repeated chrome.
+  it('keeps repeated chrome in the body when stripRepeated is off (default)', async () => {
+    // The default markdown body is the layout rebuild (reading order,
+    // joined paragraphs), but WITHOUT stripRepeated it keeps the repeated
+    // chrome — only --strip-repeated drops it. Distinguishes the two modes.
     const out = formatMarkdown(
       makeResult({
         pages: [
@@ -1365,6 +1373,103 @@ describe('formatMarkdown', () => {
 
     expect(out).toMatch(/\n縦書き$/);
     expect(out).not.toContain('縦\n書\nき');
+  });
+
+  it('rebuilds the default body from layout blocks: reading order + joined paragraphs', () => {
+    // The v0.14.0 default: markdown always uses the layout rebuild for the
+    // body. Lines within a block join into a paragraph (single newlines),
+    // blocks are separated by blank lines, and blocks emit in visual
+    // reading order — even when `page.text` (native stream order) diverges.
+    const out = formatMarkdown(
+      makeResult({
+        pages: [
+          makePage({
+            page: 1,
+            // Native stream order buries the title after the body — the
+            // out-of-order case the layout rebuild fixes.
+            text: 'Body first line\nbody second line\nDocument Title',
+            charCount: 45,
+            layout: {
+              blocks: [
+                {
+                  text: 'Document Title',
+                  x: 0,
+                  y: 0,
+                  width: 200,
+                  height: 20,
+                  lines: [{ text: 'Document Title', x: 0, y: 0, width: 200, height: 20, fontSize: 18 }],
+                },
+                {
+                  text: 'Body first line\nbody second line',
+                  x: 0,
+                  y: 40,
+                  width: 200,
+                  height: 24,
+                  lines: [
+                    { text: 'Body first line', x: 0, y: 40, width: 200, height: 12, fontSize: 10 },
+                    { text: 'body second line', x: 0, y: 54, width: 200, height: 12, fontSize: 10 },
+                  ],
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+    );
+    // Title comes first (reading order), then the two body lines joined
+    // into one paragraph with a single newline (no blank line between).
+    expect(out).toContain('Document Title\n\nBody first line\nbody second line');
+    // No blank-line-per-physical-line: the two body lines are not split by
+    // a blank line the way the old `page.text` default rendered them.
+    expect(out).not.toContain('Body first line\n\nbody second line');
+  });
+
+  it('surfaces layout warnings in the default body without --layout, but gates the tables section', () => {
+    // Layout warnings (reading_order_divergence, etc.) reach the default
+    // markdown even though `--layout` was not requested; the structural
+    // `### Layout tables` section stays gated behind the explicit flag.
+    const result = makeResult({
+      pages: [
+        makePage({
+          page: 1,
+          text: 'title mid-stream',
+          charCount: 16,
+          layout: {
+            blocks: [{ text: 'title', x: 0, y: 0, width: 100, height: 12, lines: [] }],
+            tables: [
+              {
+                x: 0,
+                y: 20,
+                width: 100,
+                height: 24,
+                rowCount: 1,
+                columnCount: 1,
+                rows: [{ y: 20, height: 12, cells: [{ text: 'cell', x: 0, y: 20, width: 100, height: 12 }] }],
+              },
+            ],
+          },
+          warnings: [
+            {
+              code: 'reading_order_divergence',
+              severity: 'warning',
+              message: 'native text order diverges from what a human reads',
+              blockIndex: 0,
+            },
+          ],
+        }),
+      ],
+    });
+    // Default (no --layout): warning present, tables section absent.
+    const dflt = formatMarkdown(result);
+    expect(dflt).toContain('### Warnings');
+    expect(dflt).toContain('(reading_order_divergence)');
+    expect(dflt).not.toContain('### Layout tables');
+    expect(dflt).not.toContain('· tables:');
+    // With --layout: the structural tables section appears too.
+    const withLayout = formatMarkdown(result, { layout: true });
+    expect(withLayout).toContain('### Warnings');
+    expect(withLayout).toContain('### Layout tables');
+    expect(withLayout).toContain('· tables: 1');
   });
 
   it('throws when stripRepeated is requested but the page carries no layout', async () => {


### PR DESCRIPTION
## Summary

v0.14.0: markdown output now always runs the layout pass internally, and the default (no `--layout`) body becomes the layout rebuild — blocks in visual reading order, lines joined into paragraphs instead of the old blank-line-per-physical-line rendering. Layout-derived warnings (`reading_order_divergence`, `text_overlap`, `off_page`, …) surface in default markdown too.

Still gated behind explicit `--layout` (markdown only): the per-page `Layout tables` sections and the Overview `Blocks` / `Tables` columns. **json/xml/toon are completely unchanged** — `pages[].layout` and layout warnings remain `--layout` opt-in there, so the structured schema and defaults are untouched.

Why: layout computation is free (benchmarked within noise even on a 34 MB report), while the old default could silently present native stream order — burying a page title 63% into the body with zero warnings (PLoS p1). The best body should not require a flag agents have to know about.

Implementation: `buildProcessDocumentOptions` forces `layout: true` when `format === 'markdown'`; the markdown formatter separately receives the user's actual `--layout` choice to gate the structural sections. Structured formatters never see the forced flag. Pages with no usable layout (e.g. scanned pages) fall back to `page.text`, so nothing is lost.

## Verification (measured on the built CLI)

- **PLoS p1, no flags**: "Why Most Published Research Findings Are False" now leads the page body, with a `reading_order_divergence` warning — previously buried mid-stream with `warnings: 0`.
- **Structured output regression**: `-f json` and `--layout -f json` output is **byte-identical to the published pdfvision@0.13.0** on the attention paper and a Japanese government whitepaper, plus before/after-build identity on 5 samples (arxiv / speakerdeck / ja-gov / forms / scanned).
- **CJK**: the Japanese whitepaper renders in natural block order, no lost characters.
- **Size note**: the attention paper's default markdown grows 43,487 → 45,890 bytes (+5.5%). The body itself is flat-to-smaller (blank lines 714 → 531); the growth is 17 newly surfaced layout warnings, byte-identical to what `--layout` already emitted. That surfacing is the point of the change — the original plan predicted a net decrease, so recording the deviation here.
- **Cache semantics**: default markdown now shares a cache slot with `--layout` runs instead of plain `-f json`; `page.text` is identical across slots, so no extraction differences — the only shift is one extra cache miss for `markdown` → `-f json` sequences (layout is cheap). Detailed in the commit body.

## Test plan

- 1159 tests pass (4 new: default-body rebuild, warning surfacing, structural gating, no-layout fallback; 3 updated).
- Biome / oxlint / tsgo / secretlint clean; `--help` updated and README re-synced via `scripts/sync-readme-usage.mjs` (idempotent); SKILL.md stays within the 8 KB budget (8,191 bytes) with a 1-line factual correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)