### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Version bump for the v0.14.0 release, covering:

- #90 — the layout-rebuilt body becomes the default markdown output: visual reading order, lines joined into paragraphs, and layout warnings surfaced without `--layout`. Structural sections stay gated; json/xml/toon unchanged.
- #91 — bare-agent regression protocol added as the release gate (`tests/agent-regression/README.md`).

After merge: create the v0.14.0 GitHub release and run the npm-publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)