### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Version bump for the v0.14.0 release, covering:

- #90 — layout-rebuilt body is now the default markdown output: visual reading order, paragraph joining, and layout warnings (e.g. `reading_order_divergence`) with no flags. Structural sections (Layout tables, Overview Blocks/Tables) stay behind `--layout`. json/xml/toon schemas are untouched (byte-identical to v0.13.0).
- #91, #93 — bare-agent regression protocol in `tests/agent-regression/`, calibrated from its first live run. All five tasks passed on this code (5/5).

After merge: create the v0.14.0 GitHub release and run the npm-publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)