### PR TITLE
chore(release): bump version to 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@napi-rs/canvas": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Version bump for the v0.15.0 release, covering the adversarial-audit fixes:

- #96 — presence counts for document furniture: `formFieldCount` / `linkCount` / `annotationCount` per page and `outlineCount` per document, surfaced flagless in every format. A bare agent can no longer conclude "there are no reviewer comments" from a default run on an annotated PDF.
- #97 — output-size stderr note above 256 KiB (advisory only; stdout untouched) and the `rtl_script_text` page warning with measured RTL percentage.

The six-task bare-agent regression gate (now including the reviewer-comments task) passed 6/6 on this code.

After merge: create the v0.15.0 GitHub release and run the npm-publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)