### PR TITLE
feat(output): slim markdown outline and fix size-note navigation hint

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -28,7 +28,7 @@ function emitOutputSizeNote(result: string): void {
   if (bytes <= OUTPUT_SIZE_NOTE_THRESHOLD_BYTES) return;
 
   process.stderr.write(
-    `pdfvision: note: output is ${formatOutputSize(bytes)} (~${formatEstimatedTokens(bytes)} tokens); consider -p <range> to page through, --search <query> --matches-only to locate content, or --outline for navigation\n`,
+    `pdfvision: note: output is ${formatOutputSize(bytes)} (~${formatEstimatedTokens(bytes)} tokens); consider -p <range> to page through, --search <query> --matches-only to locate content, or --outline -p 1 for navigation (--outline alone still emits every page)\n`,
   );
 }
 

--- a/src/output/markdown/documentSections.ts
+++ b/src/output/markdown/documentSections.ts
@@ -2,10 +2,15 @@ import type { DocumentResult } from '../../types/index.js';
 import { escapeInline, escapeTableCell, formatJavaScriptActions, formatViewerValue } from './helpers.js';
 
 function outlineLabel(item: NonNullable<DocumentResult['outline']>[number]): string {
+  // Markdown keeps only what an agent can act on: the resolved page number,
+  // external URLs, and viewer action names. Internal destination identifiers
+  // (e.g. `G6.2293078`) cost ~30% of the outline tokens on bookmark-heavy
+  // documents and feed no follow-up command; JSON/XML still carry them.
   const parts: string[] = [];
   if (item.page !== undefined) parts.push(`p. ${item.page}`);
-  if (item.type) parts.push(item.type);
-  if (item.target) parts.push(item.target);
+  if (item.type === 'url' && item.target) parts.push(item.target);
+  else if (item.type === 'action' && item.target) parts.push(`action · ${item.target}`);
+  else if (item.type === 'destination' && item.page === undefined) parts.push('destination');
   return parts.length > 0
     ? `${escapeInline(item.title)} (${escapeInline(parts.join(' · '))})`
     : escapeInline(item.title);

--- a/tests/output/markdown.test.ts
+++ b/tests/output/markdown.test.ts
@@ -702,6 +702,7 @@ describe('formatMarkdown', () => {
             items: [
               { title: 'Website', type: 'url', target: 'https://example.com' },
               { title: 'Next page', type: 'action', target: 'NextPage' },
+              { title: 'Unresolved', type: 'destination', target: 'G6.2293078' },
             ],
           },
         ],
@@ -709,9 +710,15 @@ describe('formatMarkdown', () => {
     );
 
     expect(out).toContain('## Outline');
-    expect(out).toContain('- Intro \\[draft\\] (p. 1 · destination · section.1)');
-    expect(out).toContain('  - Website (url · https://example.com)');
+    // Internal destination identifiers are dropped in Markdown once the page
+    // is resolved — they feed no follow-up command and dominate outline size
+    // on bookmark-heavy documents. JSON/XML keep the full target.
+    expect(out).toContain('- Intro \\[draft\\] (p. 1)');
+    expect(out).not.toContain('section.1');
+    expect(out).toContain('  - Website (https://example.com)');
     expect(out).toContain('  - Next page (action · NextPage)');
+    expect(out).toContain('  - Unresolved (destination)');
+    expect(out).not.toContain('G6.2293078');
   });
 
   it('surfaces an outline presence count in the header when full outline extraction was not requested', () => {


### PR DESCRIPTION
## Why

The 2026-07-11 round-2 adversarial audit walked the bare-agent journey on the 756-page ISO 32000 sample and found two token-economy leaks in the giant-document navigation path:

1. **Outline destination-ID noise.** Every markdown outline line carried ` · destination · G6.2293078`-style internal identifiers an agent cannot act on. On the ISO 32000 sample (828 bookmark entries) they cost ~30% of the outline: 63.4 KB → **40.8 KB** after this change.
2. **The size note recommended a trap.** The >256 KiB stderr note suggested `--outline for navigation`, but `--outline` is additive — it still emits every page (2.3 MB on the same sample). The note now suggests `--outline -p 1` and explains why.

## What

- Markdown `outlineLabel` keeps only actionable parts: resolved page number, external URLs, viewer action names, and a bare `destination` marker for unresolved internal jumps. JSON/XML output is unchanged and still carries full targets.
- Size-note wording updated.
- Tests updated for the new markdown contract (incl. an unresolved-destination case).

## Verification

- `npm run lint` / `npm run test` (1172 passed) / `npm run build` all green
- ISO 32000: `--outline -p 1` output 63,397 → 40,780 bytes; entries render as `- 2.1 General (p. 9)`
- EU AI Act flagless: stderr note now reads `... or --outline -p 1 for navigation (--outline alone still emits every page)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)