### PR TITLE
fix(layout): cluster short vertical CJK columns on tategaki pages

### DIFF
--- a/src/core/layout/vertical/bodyRuns.ts
+++ b/src/core/layout/vertical/bodyRuns.ts
@@ -31,6 +31,11 @@ const BODY_VERTICAL_CJK_MAX_COLUMN_GAP_RATIO = 3;
 const BODY_VERTICAL_CJK_MAX_COLUMN_GAP_PT = 36;
 const BODY_VERTICAL_CJK_COLUMN_OVERLAP_RATIO = 0.05;
 const SHORT_BODY_VERTICAL_CJK_MIN_RUN_SPANS = 3;
+/** A lone long vertical label can be a chart axis on an otherwise horizontal
+ *  page. Multiple body columns are the page-level tategaki signal; short
+ *  columns beyond their right edge are title/author-shaped front matter. */
+const PAGE_CONTEXT_SHORT_VERTICAL_CJK_MIN_RUN_SPANS = 2;
+const PAGE_CONTEXT_VERTICAL_CJK_MIN_BODY_RUNS = 2;
 const SHORT_BODY_VERTICAL_CJK_MIN_FONT_RATIO = 0.75;
 const SHORT_BODY_VERTICAL_CJK_MAX_FONT_RATIO = 1.25;
 const BODY_VERTICAL_INLINE_GLYPH_RE = /^[A-Za-z()]$/u;
@@ -259,6 +264,35 @@ export function collectShortBodyVerticalCjkRuns(
   bodyRuns: readonly VerticalCjkRun[],
   excludedSpans: ReadonlySet<TextSpan>,
 ): VerticalCjkRun[] {
+  return collectShortVerticalCjkRuns(spans, bodyRuns, excludedSpans, SHORT_BODY_VERTICAL_CJK_MIN_RUN_SPANS, (run) =>
+    isContextualShortBodyVerticalRun(run, bodyRuns),
+  );
+}
+
+export function collectPageContextShortVerticalCjkRuns(
+  spans: readonly TextSpan[],
+  bodyRuns: readonly VerticalCjkRun[],
+  excludedSpans: ReadonlySet<TextSpan>,
+): VerticalCjkRun[] {
+  if (bodyRuns.length < PAGE_CONTEXT_VERTICAL_CJK_MIN_BODY_RUNS) return [];
+
+  const rightmostBodyX = Math.max(...bodyRuns.map((run) => run.centerX));
+  return collectShortVerticalCjkRuns(
+    spans,
+    bodyRuns,
+    excludedSpans,
+    PAGE_CONTEXT_SHORT_VERTICAL_CJK_MIN_RUN_SPANS,
+    (run) => run.centerX > rightmostBodyX && run.spans.some((span) => containsCjkScript(span.text)),
+  );
+}
+
+function collectShortVerticalCjkRuns(
+  spans: readonly TextSpan[],
+  bodyRuns: readonly VerticalCjkRun[],
+  excludedSpans: ReadonlySet<TextSpan>,
+  minRunSpans: number,
+  acceptRun: (run: VerticalCjkRun) => boolean,
+): VerticalCjkRun[] {
   if (bodyRuns.length === 0) return [];
 
   const bodySpanSet = new Set<TextSpan>();
@@ -270,7 +304,7 @@ export function collectShortBodyVerticalCjkRuns(
     .filter((span) => !bodySpanSet.has(span) && !excludedSpans.has(span))
     .filter(isShortBodyVerticalCjkGlyph)
     .sort((a, b) => centerX(b) - centerX(a) || a.y - b.y);
-  if (candidates.length < SHORT_BODY_VERTICAL_CJK_MIN_RUN_SPANS) return [];
+  if (candidates.length < minRunSpans) return [];
 
   const columns: TextSpan[][] = [];
   for (const candidate of candidates) {
@@ -294,8 +328,8 @@ export function collectShortBodyVerticalCjkRuns(
     const sortedColumn = [...column].sort((a, b) => a.y - b.y || a.x - b.x);
     let run: TextSpan[] = [];
     const flush = () => {
-      const verticalRun = toVerticalGlyphRun(run, SHORT_BODY_VERTICAL_CJK_MIN_RUN_SPANS);
-      if (verticalRun && isContextualShortBodyVerticalRun(verticalRun, bodyRuns)) runs.push(verticalRun);
+      const verticalRun = toVerticalGlyphRun(run, minRunSpans);
+      if (verticalRun && acceptRun(verticalRun)) runs.push(verticalRun);
       run = [];
     };
     for (const span of sortedColumn) {

--- a/src/core/layout/vertical/ruby.ts
+++ b/src/core/layout/vertical/ruby.ts
@@ -4,6 +4,7 @@ import { mergeConsecutiveRubyAssociations } from '../rubyMerge.js';
 import {
   BODY_VERTICAL_CJK_MIN_RUN_SPANS,
   collectBodyVerticalCjkRuns,
+  collectPageContextShortVerticalCjkRuns,
   collectShortBodyVerticalCjkRuns,
   collectTallBodyVerticalCjkRuns,
   groupBodyVerticalRunsIntoBlocks,
@@ -163,7 +164,12 @@ export function extractBodyVerticalCjkRunAnalysis(spans: readonly TextSpan[]): B
     rubyRuns.some((ruby) => isRubyAdjacentToBodyColumn(ruby, run)),
   );
   const shortBodyRuns = collectShortBodyVerticalCjkRuns(spans, nonRubyBodyRuns, rubySpanSet);
-  const bodyColumns = [...nonRubyBodyRuns, ...tallBodyRunsWithRubyContext, ...shortBodyRuns];
+  const pageContextExcludedSpans = new Set<TextSpan>(rubySpanSet);
+  for (const run of shortBodyRuns) {
+    for (const span of run.spans) pageContextExcludedSpans.add(span);
+  }
+  const pageContextShortRuns = collectPageContextShortVerticalCjkRuns(spans, nonRubyBodyRuns, pageContextExcludedSpans);
+  const bodyColumns = [...nonRubyBodyRuns, ...tallBodyRunsWithRubyContext, ...shortBodyRuns, ...pageContextShortRuns];
   const gutterAnnotationRuns = collectGutterAnnotationRuns(spans, bodyColumns, rubySpanSet);
   const gutterAnnotationSpans = gutterAnnotationRuns
     .flatMap((run) => run.spans)

--- a/tests/core/vertical/bodyRuns.test.ts
+++ b/tests/core/vertical/bodyRuns.test.ts
@@ -43,6 +43,45 @@ describe('vertical body runs', () => {
     expect(verticalBlocks[0].lines.every((line) => line.writingMode === 'vertical')).toBe(true);
   });
 
+  it('clusters short vertical CJK columns in right-to-left order when body runs establish vertical context', () => {
+    const title = verticalGlyphs('こころ', 506, 47, 15.5);
+    const author = verticalGlyphs('夏目漱石', 450, 59, 11.6);
+    const rightBody = verticalGlyphs('本文甲乙丙丁戊己庚辛', 392, 47, 11.6);
+    const leftBody = verticalGlyphs('続篇甲乙丙丁戊己庚辛', 369, 47, 11.6);
+    const spans = [...leftBody, ...rightBody, ...author, ...title];
+
+    const analysis = extractBodyVerticalCjkRunAnalysis(spans);
+    expect(
+      analysis.blocks.map((block) => block.columns.map((column) => column.spans.map((item) => item.text).join(''))),
+    ).toEqual([['こころ'], ['夏目漱石'], ['本文甲乙丙丁戊己庚辛', '続篇甲乙丙丁戊己庚辛']]);
+
+    const layout = buildLayout(spans, 595);
+    expect(layout.blocks.map((block) => block.text)).toEqual([
+      'こころ',
+      '夏目漱石',
+      '本文甲乙丙丁戊己庚辛\n続篇甲乙丙丁戊己庚辛',
+    ]);
+    expect(layout.blocks.every((block) => block.writingMode === 'vertical')).toBe(true);
+  });
+
+  it('keeps identical short CJK spans horizontal without vertical body context', () => {
+    const title = verticalGlyphs('こころ', 506, 47, 15.5);
+    const author = verticalGlyphs('夏目漱石', 450, 59, 11.6);
+
+    const analysis = extractBodyVerticalCjkRunAnalysis([...author, ...title]);
+    expect(analysis.blocks).toEqual([]);
+
+    const layout = buildLayout([...author, ...title], 595);
+    expect(layout.blocks.some((block) => block.writingMode === 'vertical')).toBe(false);
+    expect(layout.blocks.flatMap((block) => block.lines.map((line) => line.text))).toEqual([
+      'こ',
+      '夏 こ',
+      '目',
+      '漱 ろ',
+      '石',
+    ]);
+  });
+
   it('excludes short larger-than-ruby right-gutter annotations from body columns', () => {
     const body = verticalGlyphs('本文甲乙丙丁戊己庚辛', 300, 100, 10);
     const annotation = verticalGlyphTexts(['(', '注', '%', ')'], 310, 124, 8);


### PR DESCRIPTION
## Why

The 2026-07-11 round-2 audit tested a **real-producer tategaki PDF** (Chrome headless `writing-mode: vertical-rl`, embedded Hiragino subset — the same class as browser/ebook-generated vertical Japanese PDFs in the wild). Body columns and ruby (furigana → `先生《せんせい》`) reconstruct perfectly, but the short title/author columns fell through to horizontal clustering and came out interleaved with no warning:

```
夏 こ
目
漱 ろ
石
```

Root cause: the vertical display-title path requires ≥20pt (`VERTICAL_CJK_MIN_FONT_SIZE_PT`), the body-run detector requires long columns — sub-20pt short columns had no vertical route.

## What

New `collectPageContextShortVerticalCjkRuns` pass, gated twice for safety:

1. Page must already have **2+ vertical CJK body runs** (strong page-level tategaki evidence — a lone chart axis label never qualifies).
2. Candidate short columns (2+ CJK chars, any font size) must lie **to the right of the rightmost body column** — the tategaki title/author front-matter position.

Accepted columns merge into the right-to-left column order, so the page now reads: こころ → 夏目漱石 → body.

Known limitation (accepted): short columns to the *left* of the body (trailing attributions) are not covered yet; being conservative beats false positives on chart labels.

## Verification

- `npm run lint` / `npm run test` (1174 passed) / `npm run build` green
- `tategaki-chrome.pdf` flagless: title and author intact, before the body; artifact gone (verified with `--no-cache`)
- Byte-identical before/after on: tategaki-ruby, vertical-japanese (synthetic), soumu whitepaper, PLoS, cyberagent speakerdeck deck

Implemented by codex `gpt-5.6-sol` (reasoning xhigh) in an isolated worktree; reviewed, independently verified, and committed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)