### PR TITLE
fix(text): preserve explicit RTL word spaces and mirror reversed brackets

### DIFF
--- a/src/core/layout/lineText.ts
+++ b/src/core/layout/lineText.ts
@@ -1,7 +1,8 @@
 import type { TextSpan } from '../../types/index.js';
-import { CJK_TIGHT_GAP_RATIO, isCjkLeading } from '../text/cjkJoin.js';
+import { CJK_TIGHT_GAP_RATIO, isCjkLeading, mirrorReversedRtlCharacter } from '../text/cjkJoin.js';
 import { shouldInsertSemanticSpace } from '../text/spacing.js';
 import { isRtlDominantPositionedText, textOrder } from '../text/textDirection.js';
+import { hasExplicitSpaceBefore } from './spanMetadata.js';
 
 /** Gap fraction for non-CJK pairs — pdf.js typically packs inter-word
  *  spaces around 0.22 × fontSize. Preserves the pre-fix behavior for
@@ -33,7 +34,7 @@ export function joinLineSpans(spans: TextSpan[]): string {
   if (spans.length === 0) return '';
   const rtl = isRtlDominantPositionedText(spans);
   const ordered = textOrder(spans);
-  let out = ordered[0].text;
+  let out = rtl ? mirrorReversedRtlCharacter(ordered[0].text) : ordered[0].text;
   for (let i = 1; i < ordered.length; i++) {
     const prev = ordered[i - 1];
     const cur = ordered[i];
@@ -45,7 +46,12 @@ export function joinLineSpans(spans: TextSpan[]): string {
     // into a synthesized space.
     const fontSize = cur.fontSize || prev.fontSize || FONT_SIZE_FALLBACK_PT;
     const threshold = fontSize * (bothCjk ? CJK_TIGHT_GAP_RATIO : DEFAULT_SPACE_GAP_RATIO);
-    out += gap > threshold || shouldInsertSemanticSpace(prev.text, cur.text, gap, fontSize) ? ` ${cur.text}` : cur.text;
+    const insertSpace =
+      (rtl && hasExplicitSpaceBefore(prev)) ||
+      gap > threshold ||
+      shouldInsertSemanticSpace(prev.text, cur.text, gap, fontSize);
+    const text = rtl ? mirrorReversedRtlCharacter(cur.text) : cur.text;
+    out += insertSpace ? ` ${text}` : text;
   }
   return out;
 }

--- a/src/core/layout/lines.ts
+++ b/src/core/layout/lines.ts
@@ -20,6 +20,7 @@ import {
   textWithHorizontalRuby,
 } from './horizontalRuby.js';
 import { joinLineSpans } from './lineText.js';
+import { copySpanMetadata } from './spanMetadata.js';
 import { hasVerticalTextShape } from './verticalText.js';
 
 /** Fallback fontSize when both prev and cur report 0 (rare — usually
@@ -279,7 +280,7 @@ function spansWithHorizontalRuby(
   return spans.map((span) => {
     const spanAttachments = attachments.get(span);
     return spanAttachments && spanAttachments.length > 0
-      ? { ...span, text: textWithHorizontalRuby(span.text, spanAttachments) }
+      ? copySpanMetadata(span, { ...span, text: textWithHorizontalRuby(span.text, spanAttachments) })
       : span;
   });
 }

--- a/src/core/layout/spanMetadata.ts
+++ b/src/core/layout/spanMetadata.ts
@@ -1,0 +1,21 @@
+import type { TextSpan } from '../../types/index.js';
+
+const spansWithExplicitSpaceBefore = new WeakSet<TextSpan>();
+
+/** Record that pdf.js emitted an explicit whitespace item immediately
+ * before this span in visual order. Kept outside TextSpan so geometry and
+ * layout serializers cannot expose internal reconstruction metadata. */
+export function markExplicitSpaceBefore(span: TextSpan): void {
+  spansWithExplicitSpaceBefore.add(span);
+}
+
+export function hasExplicitSpaceBefore(span: TextSpan): boolean {
+  return spansWithExplicitSpaceBefore.has(span);
+}
+
+/** Preserve internal reconstruction metadata when a layout pass has to
+ * clone a span, such as when horizontal ruby text is attached. */
+export function copySpanMetadata(source: TextSpan, target: TextSpan): TextSpan {
+  if (hasExplicitSpaceBefore(source)) markExplicitSpaceBefore(target);
+  return target;
+}

--- a/src/core/processor/pageText.ts
+++ b/src/core/processor/pageText.ts
@@ -5,6 +5,7 @@ import {
   horizontalRubyReadingText,
 } from '../layout/horizontalRuby.js';
 import { mergeSameOffsetRubyTextAttachments } from '../layout/rubyMerge.js';
+import { markExplicitSpaceBefore } from '../layout/spanMetadata.js';
 import {
   extractBodyVerticalCjkRunAnalysis,
   extractTallVerticalRuns,
@@ -138,6 +139,8 @@ function collectPageTextItems({
   const verticalJoinSpanIndices = new Map<TextSpan, number>();
   const seenTextItems = new Map<string, number>();
   const pageFontAliases = new Map<string, string>();
+  let previousSpanOnLine: TextSpan | undefined;
+  let pendingExplicitSpace = false;
   for (const item of content.items) {
     if (!isTextItem(item)) continue;
     if (isLikelyPrepressProductionText(item.str)) continue;
@@ -155,6 +158,10 @@ function collectPageTextItems({
       // sometimes differing only in pdf.js' hard-EOL flag. Keep one text
       // run, but preserve the line-break signal if any duplicate carries it.
       if (item.hasEOL) joinItems[seenIndex].hasEOL = true;
+      if (item.hasEOL) {
+        previousSpanOnLine = undefined;
+        pendingExplicitSpace = false;
+      }
       continue;
     }
     textArea += Math.abs(w * h);
@@ -192,16 +199,30 @@ function collectPageTextItems({
     // Skip whitespace-only items in spans output — pdf.js emits a span
     // for every positioned space, which can double the array length and
     // sometimes carries a synthetic width that exceeds the page width.
-    // The aggregate `text` already preserves the spaces, so layout
-    // analysis loses nothing; downstream agents get a cleaner signal.
+    // Preserve real word boundaries as private adjacency metadata so the
+    // layout text joiner can still reconstruct RTL lines without changing
+    // the public TextSpan schema.
     const spanText = flags.normalize ? normalizeText(item.str) : item.str;
+    const explicitWhitespace = item.str.length > 0 && item.str.trim().length === 0;
     if (wantSpans && spanText.trim().length > 0 && geometry) {
-      const span = {
+      const span: TextSpan = {
         text: spanText,
         ...geometry,
         ...(typeof item.fontName === 'string' && { fontName: stablePageFontName(item.fontName, pageFontAliases) }),
       };
+      if (pendingExplicitSpace && previousSpanOnLine) markExplicitSpaceBefore(span);
       spans.push(span);
+      previousSpanOnLine = span;
+      pendingExplicitSpace = false;
+    } else if (wantSpans && explicitWhitespace) {
+      if (previousSpanOnLine && !item.hasEOL) pendingExplicitSpace = true;
+    } else if (wantSpans && item.str.length > 0) {
+      previousSpanOnLine = undefined;
+      pendingExplicitSpace = false;
+    }
+    if (item.hasEOL) {
+      previousSpanOnLine = undefined;
+      pendingExplicitSpace = false;
     }
     if (item.str.trim().length > 0 && geometry) {
       const span = {

--- a/src/core/text/cjkJoin.ts
+++ b/src/core/text/cjkJoin.ts
@@ -77,6 +77,18 @@ export interface JoinPageTextOptions {
 export const CJK_TIGHT_GAP_RATIO = 0.3;
 const SYNTHETIC_LINE_BREAK_GAP_RATIO = 1.5;
 const RTL_WORD_SPACE_MIN_GAP_RATIO = 0.12;
+export const RTL_MIRRORED_CHARACTERS: ReadonlyMap<string, string> = new Map([
+  ['(', ')'],
+  [')', '('],
+  ['[', ']'],
+  [']', '['],
+  ['{', '}'],
+  ['}', '{'],
+  ['<', '>'],
+  ['>', '<'],
+  ['«', '»'],
+  ['»', '«'],
+]);
 const LATIN_TIGHT_ARTIFACT_SPACE_RATIO = 0.12;
 const LATIN_WORD_FRAGMENT_END_RE = /[\p{Script=Latin}\p{M}\p{N}]$/u;
 const LATIN_WORD_FRAGMENT_START_RE = /^[\p{Script=Latin}\p{M}\p{N}]/u;
@@ -275,29 +287,47 @@ function isRtlLine(items: readonly JoinItem[]): boolean {
 }
 
 function joinRtlLineItems(items: readonly JoinItem[]): string {
-  const words = textOrder(
-    items.filter((item) => item.str.trim().length > 0).map((item) => ({ ...item, text: item.str })),
-  );
+  const visualItems = [...items].sort((a, b) => a.x - b.x);
+  const textItems: (JoinItem & { text: string; explicitSpaceAfter: boolean })[] = [];
+  let pendingExplicitSpace = false;
+  for (const item of visualItems) {
+    if (isWhitespaceOnly(item.str)) {
+      if (textItems.length > 0) pendingExplicitSpace = true;
+      continue;
+    }
+    if (item.str.length === 0) continue;
+
+    textItems.push({
+      ...item,
+      text: item.str,
+      // Reversal turns the space before this visual item into a space after it.
+      explicitSpaceAfter: pendingExplicitSpace && textItems.length > 0,
+    });
+    pendingExplicitSpace = false;
+  }
+
+  const words = textOrder(textItems);
   if (words.length === 0) return '';
 
-  let out = words[0].str;
+  let out = mirrorReversedRtlCharacter(words[0].str);
   for (let i = 1; i < words.length; i++) {
     const prev = words[i - 1];
     const cur = words[i];
     const gap = prev.x - (cur.x + cur.width);
     const fontSize = cur.fontSize || prev.fontSize || 12;
-    if (
-      gap > fontSize * RTL_WORD_SPACE_MIN_GAP_RATIO &&
-      isRtlDominantText(prev.str) &&
-      isRtlDominantText(cur.str) &&
-      !/\s$/.test(out) &&
-      !/^\s/.test(cur.str)
-    ) {
+    const hasFallbackSpace =
+      gap > fontSize * RTL_WORD_SPACE_MIN_GAP_RATIO && isRtlDominantText(prev.str) && isRtlDominantText(cur.str);
+    if ((prev.explicitSpaceAfter || hasFallbackSpace) && !/\s$/.test(out) && !/^\s/.test(cur.str)) {
       out += ' ';
     }
-    out += cur.str;
+    out += mirrorReversedRtlCharacter(cur.str);
   }
   return out;
+}
+
+export function mirrorReversedRtlCharacter(text: string): string {
+  if (Array.from(text).length !== 1) return text;
+  return RTL_MIRRORED_CHARACTERS.get(text) ?? text;
 }
 
 function joinLtrLineItems(items: readonly JoinItem[]): string {

--- a/tests/core/cjkJoin.test.ts
+++ b/tests/core/cjkJoin.test.ts
@@ -225,4 +225,72 @@ describe('joinPageText (CJK-aware whitespace handling)', () => {
 
     expect(joinPageText(items).normalize('NFKC')).toBe('انواع اخلطوط العربية\nانواع العربية');
   });
+
+  it('preserves explicit spaces in glyph-per-item visual-order RTL text', () => {
+    const visualGlyphs = [' ', 'ل', 'ي', 'م', 'ج', ' ', '\t', 'ر', 'ص', 'م', '  '];
+    const visualX = [-10, 0, 10, 20, 30, 39.8, 39.85, 39.9, 49.9, 59.9, 70];
+    const items: JoinItem[] = visualGlyphs.map((str, index) => ({
+      str,
+      x: visualX[index],
+      width: str.trim().length === 0 ? 1.6 : 10,
+      fontSize: 10,
+      hasEOL: false,
+      dir: str.trim().length === 0 ? 'ltr' : 'rtl',
+    }));
+
+    expect(joinPageText(items)).toBe('مصر جميل');
+  });
+
+  it('keeps the geometric-gap fallback for RTL producers without space items', () => {
+    const visualGlyphs = Array.from('ليمجرصم');
+    const items: JoinItem[] = visualGlyphs.map((str, index) => ({
+      str,
+      x: index < 4 ? index * 10 : 44 + (index - 4) * 10,
+      width: 10,
+      fontSize: 10,
+      hasEOL: false,
+      dir: 'rtl',
+    }));
+
+    expect(joinPageText(items)).toBe('مصر جميل');
+  });
+
+  it('mirrors single-character paired punctuation after reversing RTL visual order', () => {
+    const logicalText = '(توضيح) [1] {س} <ص> «ع»';
+    const mirroredCharacters: Record<string, string> = {
+      '(': ')',
+      ')': '(',
+      '[': ']',
+      ']': '[',
+      '{': '}',
+      '}': '{',
+      '<': '>',
+      '>': '<',
+      '«': '»',
+      '»': '«',
+    };
+    const visualGlyphs = Array.from(logicalText)
+      .reverse()
+      .map((str) => mirroredCharacters[str] ?? str);
+    const items: JoinItem[] = visualGlyphs.map((str, index) => ({
+      str,
+      x: index * 10,
+      width: str === ' ' ? 2 : 10,
+      fontSize: 10,
+      hasEOL: false,
+      dir: str === ' ' ? 'ltr' : 'rtl',
+    }));
+
+    expect(joinPageText(items)).toBe(logicalText);
+  });
+
+  it('leaves LTR lines and paired punctuation inside logical-order RTL items unchanged', () => {
+    const ltrItems: JoinItem[] = [{ str: '(hello) [1]', x: 0, width: 70, fontSize: 10, hasEOL: false, dir: 'ltr' }];
+    const logicalRtlItems: JoinItem[] = [
+      { str: 'مرحبا (توضيح) [1] {س} <ص> «ع»', x: 0, width: 180, fontSize: 10, hasEOL: false, dir: 'rtl' },
+    ];
+
+    expect(joinPageText(ltrItems)).toBe('(hello) [1]');
+    expect(joinPageText(logicalRtlItems)).toBe('مرحبا (توضيح) [1] {س} <ص> «ع»');
+  });
 });

--- a/tests/core/layout.unit.test.ts
+++ b/tests/core/layout.unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildLayout, markRepeatedBlocks } from '../../src/core/layout/index.js';
+import { markExplicitSpaceBefore } from '../../src/core/layout/spanMetadata.js';
 import { detectPageWarnings } from '../../src/core/warnings/index.js';
 import type { LayoutBlock, PageResult, TextSpan } from '../../src/types/index.js';
 
@@ -1607,6 +1608,49 @@ describe('buildLayout — multi-column reading order', () => {
     const layout = buildLayout(spans);
 
     expect(layout.blocks[0].lines[0].text).toBe('انواع اخلطوط العربية');
+  });
+
+  it('uses explicit-space metadata when RTL glyph geometry cannot recover the word boundary', () => {
+    const visualGlyphs = Array.from('ليمجرصم');
+    const spans = visualGlyphs.map((glyph, index) =>
+      span(glyph, index < 4 ? index * 10 : 39.9 + (index - 4) * 10, 184, 10, 10),
+    );
+    // The source whitespace appeared immediately before ر in visual order.
+    markExplicitSpaceBefore(spans[4]);
+
+    const layout = buildLayout(spans);
+
+    expect(layout.blocks[0].lines[0].text).toBe('مصر جميل');
+  });
+
+  it('mirrors paired punctuation after reversing RTL layout glyphs', () => {
+    const logicalText = '(توضيح) [1]';
+    const visualGlyphs = Array.from('[1] (حيضوت)');
+    const spans: TextSpan[] = [];
+    let pendingSpace = false;
+    for (const glyph of visualGlyphs) {
+      if (glyph === ' ') {
+        pendingSpace = spans.length > 0;
+        continue;
+      }
+      const current = span(glyph, spans.length * 10, 184, 10, 10);
+      if (pendingSpace) markExplicitSpaceBefore(current);
+      pendingSpace = false;
+      spans.push(current);
+    }
+
+    const layout = buildLayout(spans);
+
+    expect(layout.blocks[0].lines[0].text).toBe(logicalText);
+  });
+
+  it('ignores RTL explicit-space metadata on LTR layout lines', () => {
+    const spans = [span('hello', 0, 184, 10, 25), span('world', 25, 184, 10, 25)];
+    markExplicitSpaceBefore(spans[1]);
+
+    const layout = buildLayout(spans);
+
+    expect(layout.blocks[0].lines[0].text).toBe('helloworld');
   });
 
   it('does not split Type3-style wide word spacing rows into columns', () => {

--- a/tests/core/pageText.unit.test.ts
+++ b/tests/core/pageText.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { buildLayout } from '../../src/core/layout/index.js';
 import type { PageFlags } from '../../src/core/processor/pageData.js';
 import { extractPageText } from '../../src/core/processor/pageText.js';
 
@@ -80,6 +81,28 @@ function verticalGlyphItems(text: string, x: number, y: number, fontSize: number
 }
 
 describe('extractPageText', () => {
+  it('threads dropped RTL spaces into layout without changing serialized spans', () => {
+    const visualGlyphs = ['ل', 'ي', 'م', 'ج', ' ', 'ر', 'ص', 'م'];
+    const items = visualGlyphs.map((glyph, index) => ({
+      ...positionedTextItem(glyph, index < 4 ? index * 10 : 39.9 + (index - 4) * 10, 100, 10, glyph === ' ' ? 1.6 : 10),
+      dir: glyph === ' ' ? 'ltr' : 'rtl',
+      hasEOL: index === visualGlyphs.length - 1,
+    }));
+
+    const result = extractPageText({
+      content: { items },
+      flags: BASE_FLAGS,
+      pageHeight: 800,
+      viewMinX: 0,
+      viewMinY: 0,
+    });
+    const layout = buildLayout(result.spans);
+
+    expect(result.text).toBe('مصر جميل');
+    expect(layout.blocks[0].lines[0].text).toBe('مصر جميل');
+    expect(JSON.parse(JSON.stringify(result.spans))).toEqual(result.spans);
+  });
+
   it('filters prepress production marks from text and spans', () => {
     const result = extractPageText({
       content: {


### PR DESCRIPTION
## Why

Round-2 audit finding F1. On real Arabic PDFs from the Chromium PDF-export producer (Wikipedia REST export and friends: one item per glyph, **visual order**, Arabic presentation forms, **explicit space glyphs** whose geometric gaps are ~0), pdfvision output was nearly unusable:

- Word spaces vanished: `لمعلوماتعنمعا ٍنأخرى،طالعمصر` — the join layer dropped the real space items and its gap heuristic (>0.12×fontSize) never fires on this producer.
- Paired brackets mirrored: `)توضيح(`, `]1[` — visual→logical reversal without the Unicode Bidi_Mirrored swap.

poppler's `pdftotext` gets both right on the same file; this was the only audited axis where pdfvision lost to a mainstream extractor.

## What

Two paths, same two fixes (the default Markdown body is built by the **layout** path, not `joinPageText` — the first iteration missed that and was caught in review):

1. `joinRtlLineItems` (cjkJoin.ts): explicit whitespace items become word separators (visual space-before maps to logical space-after on reversal); gap heuristic kept as fallback; Bidi_Mirrored single-char swap `() [] {} <> «»`.
2. Layout path: dropped whitespace items are recorded on the neighboring span via a **WeakSet side channel** (`spanMetadata.ts`) — public TextSpan schema unchanged, serializers can't leak it; the horizontal-ruby clone path copies the mark; `joinLineSpans` honors the marks and applies the shared mirror helper on RTL lines only.

## Verification

- lint / test (1180 passed) / build green
- Default markdown body on the Arabic sample (`--no-cache`): `لمعلومات عن معا ٍن أخرى، طالع مصر (توضيح).`, `جبل كاترين (2,629 متر)[1]`, `[2][3]` — spaces and bracket direction correct; embedded-LTR lines like `[5](2019) 53429404` untouched (no double-mirroring)
- Byte-identical before/after on: udhr-hebrew, vertical-japanese, soumu whitepaper, PLoS, attention

Implemented by codex `gpt-5.6-sol` (reasoning xhigh) in an isolated worktree over two iterations; reviewed, independently verified, and committed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)