### PR TITLE
chore(deps): migrate to pdfjs-dist 6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@napi-rs/canvas": "^1.0.0",
         "@toon-format/toon": "^2.3.0",
-        "pdfjs-dist": "^6.0.227"
+        "pdfjs-dist": "^6.1.200"
       },
       "bin": {
         "pdfvision": "dist/bin/pdfvision.mjs"
@@ -6987,9 +6987,9 @@
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
-      "version": "6.0.227",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
-      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
+      "version": "6.1.200",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.1.200.tgz",
+      "integrity": "sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@napi-rs/canvas": "^1.0.0",
     "@toon-format/toon": "^2.3.0",
-    "pdfjs-dist": "^6.0.227"
+    "pdfjs-dist": "^6.1.200"
   },
   "optionalDependencies": {
     "tesseract.js": "^7.0.0"

--- a/src/core/document/attachmentAnnotations.ts
+++ b/src/core/document/attachmentAnnotations.ts
@@ -3,6 +3,7 @@ import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
 interface PdfAnnotation {
   subtype?: unknown;
   file?: unknown;
+  fileId?: unknown;
 }
 
 interface PdfFileAttachment {
@@ -21,7 +22,12 @@ export async function collectFileAttachmentAnnotations(doc: PDFDocumentProxy): P
       const annotation = rawAnnotation as PdfAnnotation;
       if (annotation.subtype !== 'FileAttachment' || !annotation.file) continue;
       const key = fileAttachmentKey(annotation.file, pageNumber, index);
-      attachments[key] = annotation.file;
+      const content =
+        typeof annotation.fileId === 'string' ? await doc.getAttachmentContent(annotation.fileId) : undefined;
+      attachments[key] =
+        content === undefined || typeof annotation.file !== 'object'
+          ? annotation.file
+          : { ...annotation.file, content };
       index++;
     }
   }

--- a/src/core/document/attachments.ts
+++ b/src/core/document/attachments.ts
@@ -15,6 +15,24 @@ interface BuildAttachmentsOptions {
   outputDir?: string;
 }
 
+export async function catalogAttachmentsToRecord(
+  attachments: ReadonlyMap<string, unknown> | null | undefined,
+  getContent: (id: string) => Promise<unknown>,
+): Promise<Record<string, unknown> | null> {
+  if (!attachments || attachments.size === 0) return null;
+
+  const record: Record<string, unknown> = {};
+  for (const [id, value] of attachments) {
+    const attachment = value as PdfAttachment;
+    const content = attachment.content === undefined ? await getContent(id) : attachment.content;
+    record[id] = {
+      ...attachment,
+      ...(content !== undefined && { content }),
+    };
+  }
+  return record;
+}
+
 export function buildAttachments(
   attachments: Record<string, unknown> | null | undefined,
   options: BuildAttachmentsOptions = {},

--- a/src/core/processor/documentFeatures.ts
+++ b/src/core/processor/documentFeatures.ts
@@ -8,7 +8,7 @@ import type {
   ProcessDocumentOptions,
 } from '../../types/index.js';
 import { collectFileAttachmentAnnotations } from '../document/attachmentAnnotations.js';
-import { buildAttachments, mergeAttachmentRecords } from '../document/attachments.js';
+import { buildAttachments, catalogAttachmentsToRecord, mergeAttachmentRecords } from '../document/attachments.js';
 import { buildLayers } from '../document/layers.js';
 import { buildOutline } from '../document/outline.js';
 import { buildViewerState } from '../document/viewer.js';
@@ -40,8 +40,12 @@ export async function extractDocumentFeatures(
     rawPageLabels === undefined
       ? undefined
       : (rawPageLabels ?? []).map((label) => (normalize ? normalize(label) : label));
+  const catalogAttachments = await doc.getAttachments();
+  const catalogAttachmentRecords = options.attachments
+    ? await catalogAttachmentsToRecord(catalogAttachments, (id) => doc.getAttachmentContent(id))
+    : undefined;
   const attachmentRecords = options.attachments
-    ? mergeAttachmentRecords(await doc.getAttachments(), await collectFileAttachmentAnnotations(doc))
+    ? mergeAttachmentRecords(catalogAttachmentRecords, await collectFileAttachmentAnnotations(doc))
     : undefined;
   const attachments: DocumentAttachment[] | undefined = options.attachments
     ? buildAttachments(attachmentRecords, {
@@ -53,7 +57,7 @@ export async function extractDocumentFeatures(
   // (one cheap worker call) so a default extraction never hides that the
   // PDF carries attachments. When the full pass ran, its merged view (which
   // also covers per-page file-attachment annotations) is the truth.
-  const attachmentCount = attachments?.length ?? Object.keys((await doc.getAttachments()) ?? {}).length;
+  const attachmentCount = attachments?.length ?? catalogAttachments?.size ?? 0;
   const rawOutline = await doc.getOutline();
   const outline: DocumentOutlineItem[] | undefined = options.outline
     ? await buildOutline(rawOutline, doc, {

--- a/src/core/renderer/crop.ts
+++ b/src/core/renderer/crop.ts
@@ -9,7 +9,7 @@ export interface ViewportCrop {
 }
 
 export interface PageViewportLike {
-  convertToViewportRectangle(rect: [number, number, number, number]): number[];
+  convertToViewportPoint(x: number, y: number): number[];
   convertToPdfPoint(x: number, y: number): number[];
 }
 
@@ -25,7 +25,9 @@ export function viewportCropForRegion(
   const rightPdf = leftPdf + region.width;
   const topPdf = viewMaxY - region.y;
   const bottomPdf = topPdf - region.height;
-  const rect = viewport.convertToViewportRectangle([leftPdf, topPdf, rightPdf, bottomPdf]);
+  const topLeft = viewport.convertToViewportPoint(leftPdf, topPdf);
+  const bottomRight = viewport.convertToViewportPoint(rightPdf, bottomPdf);
+  const rect = [topLeft[0], topLeft[1], bottomRight[0], bottomRight[1]];
   const left = Math.min(rect[0], rect[2]);
   const top = Math.min(rect[1], rect[3]);
   const right = Math.max(rect[0], rect[2]);

--- a/tests/core/attachments.unit.test.ts
+++ b/tests/core/attachments.unit.test.ts
@@ -1,8 +1,12 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
-import { describe, expect, it } from 'vitest';
-import { buildAttachments, mergeAttachmentRecords } from '../../src/core/document/attachments.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildAttachments,
+  catalogAttachmentsToRecord,
+  mergeAttachmentRecords,
+} from '../../src/core/document/attachments.js';
 
 describe('buildAttachments', () => {
   it('extracts attachment metadata without carrying content bytes', () => {
@@ -31,6 +35,17 @@ describe('buildAttachments', () => {
 
   it('returns an empty array when the PDF has no embedded file attachments', () => {
     expect(buildAttachments(null)).toEqual([]);
+  });
+
+  it('converts catalog attachment maps and loads their content lazily', async () => {
+    const getContent = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    const record = await catalogAttachmentsToRecord(
+      new Map([['attachment-id', { filename: 'report.txt', description: 'Report' }]]),
+      getContent,
+    );
+
+    expect(buildAttachments(record)).toEqual([{ name: 'report.txt', description: 'Report', size: 3 }]);
+    expect(getContent).toHaveBeenCalledWith('attachment-id');
   });
 
   it('deduplicates equivalent attachment records from multiple PDF sources', () => {

--- a/tests/core/documentFeatures.unit.test.ts
+++ b/tests/core/documentFeatures.unit.test.ts
@@ -4,7 +4,7 @@ import { extractDocumentFeatures } from '../../src/core/processor/documentFeatur
 
 interface StubDocOverrides {
   info?: Record<string, unknown>;
-  attachments?: Record<string, unknown> | null;
+  attachments?: Map<string, Record<string, unknown>> | null;
 }
 
 // Minimal PDFDocumentProxy stub for the default (flagless) feature pass:
@@ -34,7 +34,15 @@ describe('extractDocumentFeatures presence signals', () => {
   });
 
   it('counts document-level embedded files without the attachment pass', async () => {
-    const features = await extractDocumentFeatures(stubDoc({ attachments: { 'data.csv': {}, 'notes.txt': {} } }), {});
+    const features = await extractDocumentFeatures(
+      stubDoc({
+        attachments: new Map([
+          ['data.csv', {}],
+          ['notes.txt', {}],
+        ]),
+      }),
+      {},
+    );
     expect(features.attachmentCount).toBe(2);
     expect(features.attachments).toBeUndefined();
   });


### PR DESCRIPTION
## Why

Renovate's non-major bump (#95) is red on CI: pdfjs-dist 6.1 ships two breaking API changes despite the minor version. This PR does the bump together with the required source migration.

## What changed in pdf.js 6.1

1. **`PageViewport.convertToViewportRectangle` removed** (dead code upstream, mozilla/pdf.js#21426). Replaced with two `convertToViewportPoint` calls on the rectangle corners — the same transform, so crop/OCR geometry is unchanged.
2. **`getAttachments()` returns `Map<string, CatalogAttachment>`** (mozilla/pdf.js#21418) with content fetched lazily via `getAttachmentContent(id)` (part of the `/AuthEvent` on-demand decryption work, mozilla/pdf.js#21351). We convert the Map back to the previous Record shape at the pdf.js boundary and fetch content there, keeping downstream code and the public output schema unchanged. Note: `Object.keys()` on the Map silently returned 0 for `attachmentCount` — a runtime bug on 6.1, not just a type error.

## Verification

- `tsgo --noEmit`, build, full test suite (1188 tests), lint: all green
- Default markdown output **byte-identical** between 6.0.227 and 6.1.200 on RTL (Arabic), vertical-writing (tategaki), XFA, and attachment samples
- `--attachments --attachment-output`: extracted file bytes SHA-identical, `attachmentCount` correct
- `--render --render-region` crop PNG **byte-identical** (SHA match)

After this merges, #95 rebases to lint/dev-only bumps (biome, oxlint, typescript-native-preview) and should go green.

Implemented by codex (gpt-5.6-sol, reasoning xhigh); reviewed, verified, and committed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)