### PR TITLE
fix(form-fields): report checked only for the selected radio widget

### DIFF
--- a/src/core/formFields/index.ts
+++ b/src/core/formFields/index.ts
@@ -70,11 +70,11 @@ export function buildFormFields(
     const maxY = Math.max(y1, y2);
     const type = formFieldType(ann);
     const value = fieldValue(ann.fieldValue);
-    const checked = type === 'checkbox' || type === 'radio' ? value !== undefined && value !== 'Off' : undefined;
+    const exportValue = fieldExportValue(ann, type);
+    const checked = fieldChecked(type, value, exportValue);
     const flags = annotationFlagNames(ann.annotationFlags);
     const actions = normalizeJavaScriptActions(ann.actions);
     const resetForm = formResetAction(ann.resetForm);
-    const exportValue = fieldExportValue(ann, type);
     const caption = fieldCaption(ann, type, options);
     const choiceMetadata = choiceFieldMetadata(ann);
     const displayValue =
@@ -195,6 +195,17 @@ function fieldExportValue(annotation: PdfAnnotation, type: FormFieldType): strin
   if (type === 'checkbox') return fieldValue(annotation.exportValue);
   if (type === 'radio') return fieldValue(annotation.buttonValue ?? annotation.exportValue);
   return undefined;
+}
+
+function fieldChecked(
+  type: FormFieldType,
+  value: string | undefined,
+  exportValue: string | undefined,
+): boolean | undefined {
+  if (type !== 'checkbox' && type !== 'radio') return undefined;
+  const selected = value !== undefined && value !== 'Off';
+  if (type === 'checkbox' || !selected) return selected;
+  return exportValue === undefined ? selected : value === exportValue;
 }
 
 function fieldArrayValue(value: unknown): string {

--- a/tests/core/formFields.unit.test.ts
+++ b/tests/core/formFields.unit.test.ts
@@ -184,6 +184,112 @@ describe('buildFormFields', () => {
     });
   });
 
+  it('checks only the radio widget whose button value matches the group value', () => {
+    const fields = buildFormFields(
+      [
+        {
+          subtype: 'Widget',
+          fieldName: 'fruit',
+          fieldType: 'Btn',
+          radioButton: true,
+          rect: [10, 10, 20, 20],
+          fieldValue: '1',
+          buttonValue: '0',
+        },
+        {
+          subtype: 'Widget',
+          fieldName: 'fruit',
+          fieldType: 'Btn',
+          radioButton: true,
+          rect: [30, 10, 40, 20],
+          fieldValue: '1',
+          buttonValue: '1',
+        },
+        {
+          subtype: 'Widget',
+          fieldName: 'fruit',
+          fieldType: 'Btn',
+          radioButton: true,
+          rect: [50, 10, 60, 20],
+          fieldValue: '1',
+          buttonValue: '2',
+        },
+      ],
+      100,
+    );
+
+    expect(fields.map((field) => ({ exportValue: field.exportValue, checked: field.checked }))).toEqual([
+      { exportValue: '0', checked: false },
+      { exportValue: '1', checked: true },
+      { exportValue: '2', checked: false },
+    ]);
+  });
+
+  it('leaves every radio widget unchecked when the group value is Off', () => {
+    const fields = buildFormFields(
+      [
+        {
+          subtype: 'Widget',
+          fieldName: 'shared',
+          fieldType: 'Btn',
+          radioButton: true,
+          rect: [10, 10, 20, 20],
+          fieldValue: 'Off',
+          buttonValue: '0',
+        },
+        {
+          subtype: 'Widget',
+          fieldName: 'shared',
+          fieldType: 'Btn',
+          radioButton: true,
+          rect: [30, 10, 40, 20],
+          fieldValue: 'Off',
+          buttonValue: '1',
+        },
+      ],
+      100,
+    );
+
+    expect(fields.map((field) => field.checked)).toEqual([false, false]);
+  });
+
+  it('keeps checkbox checked state based on non-Off field values', () => {
+    const fields = buildFormFields(
+      [
+        {
+          subtype: 'Widget',
+          fieldName: 'agree',
+          fieldType: 'Btn',
+          checkBox: true,
+          rect: [10, 10, 20, 20],
+          fieldValue: 'Yes',
+          exportValue: 'Yes',
+        },
+      ],
+      100,
+    );
+
+    expect(fields[0]).toMatchObject({ type: 'checkbox', value: 'Yes', exportValue: 'Yes', checked: true });
+  });
+
+  it('falls back to the selected group value when a radio widget has no on-state', () => {
+    const fields = buildFormFields(
+      [
+        {
+          subtype: 'Widget',
+          fieldName: 'legacy',
+          fieldType: 'Btn',
+          radioButton: true,
+          rect: [10, 10, 20, 20],
+          fieldValue: 'Selected',
+        },
+      ],
+      100,
+    );
+
+    expect(fields[0]).toMatchObject({ type: 'radio', value: 'Selected', checked: true });
+  });
+
   it('extracts non-JavaScript reset form actions from button widgets', () => {
     const fields = buildFormFields(
       [


### PR DESCRIPTION
## Why

A radio group's `fieldValue` is shared by every widget in the group. The checked computation used a simple non-`'Off'` test, so once any option was selected, **every** radio button in the group reported `checked: true`. An agent reading `--form-fields` output would conclude all options are selected at once — a first-command misread on real-world forms with radio groups.

Found while verifying pdf.js 6.1's /Opt export-value resolution (mozilla/pdf.js#21428) against its `opt_demo.pdf` test file: three radio groups, all widgets reported checked.

## What

A radio widget is now checked only when the group value matches its own on-state (`buttonValue`, falling back to `exportValue`), with the previous behavior kept when no on-state is exposed. Checkbox semantics are unchanged. No output-schema change (markdown/JSON/XML/TOON all carry the same corrected `checked`).

## Verification

- 4 new unit tests (3-option group → exactly one checked; `Off` group → none; checkbox regression; missing-on-state fallback); full suite 1192 green, typecheck/build/lint green
- `opt_demo.pdf` CLI: `fruit` → only `Banane` checked, `veg` → only `Potato` checked, `shared`/`agree` unchecked
- Real-form regression: IRS W-9 and F-1040 `--form-fields` output **byte-identical** before/after

Implemented by codex (gpt-5.6-sol, reasoning xhigh); reviewed, verified, and committed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)