### PR TITLE
docs(changelog): document unreleased user-facing changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+Notable user-facing changes to pdfvision are documented here.
+
+## [Unreleased]
+
+### Added
+
+- Added an always-on `xfa_form` warning and `xfa` structured-output field for XFA documents, plus an `attachmentCount` presence signal for embedded files. Attachment extraction already existed; XFA content itself is not extracted. ([#101](https://github.com/yamadashy/pdfvision/pull/101))
+- Added the `page_edge_text_truncated` error warning for text runs matching pdf.js's page-boundary truncation signature. The warning detects possible loss but does not recover omitted text. ([#105](https://github.com/yamadashy/pdfvision/pull/105))
+- Added tagged-table reconstruction under `--structure`, with GFM table output in Markdown and inferred row/column header metadata in JSON, XML, and TOON. ([#106](https://github.com/yamadashy/pdfvision/pull/106))
+- Added an always-computed `javascriptActionCount` presence signal, surfaced when non-zero, while keeping document-level action details behind `--viewer`. ([#107](https://github.com/yamadashy/pdfvision/pull/107))
+- Added the `invisible_text` error warning for native text drawn with PDF text rendering mode `Tr 3`, with suppression for expected raster/OCR text layers. ([#108](https://github.com/yamadashy/pdfvision/pull/108))
+- Added the conservative `text_under_opaque_fill` error warning for native text covered by later opaque dark rectangular fills. It requires positive paint-order and geometry evidence rather than claiming to detect every redaction failure. ([#109](https://github.com/yamadashy/pdfvision/pull/109))
+
+### Changed
+
+- Reduced Markdown outline size by omitting non-actionable internal destination identifiers, and corrected the large-output hint to recommend `--outline -p 1`. Structured JSON and XML outline targets remain unchanged. ([#99](https://github.com/yamadashy/pdfvision/pull/99))
+
+### Fixed
+
+- Preserved short title and author columns in right-to-left reading order on established vertical Japanese pages. ([#100](https://github.com/yamadashy/pdfvision/pull/100))
+- Preserved explicit word spaces and corrected common paired-bracket direction when reconstructing right-to-left text. ([#102](https://github.com/yamadashy/pdfvision/pull/102))
+- Reported `checked: true` only for the selected radio widget instead of every widget in its group. ([#104](https://github.com/yamadashy/pdfvision/pull/104))
+
+[Unreleased]: https://github.com/yamadashy/pdfvision/compare/v0.15.0...HEAD

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install -g pdfvision
 pdfvision document.pdf
 ```
 
-Full documentation: <https://pdfvision.dev/>
+Full documentation: <https://pdfvision.dev/> · **[Changelog](https://github.com/yamadashy/pdfvision/blob/main/CHANGELOG.md)**
 
 ## 🤖 Agent Skill
 


### PR DESCRIPTION
## Summary

- add an initial `CHANGELOG.md` with an `Unreleased` section for user-facing changes since v0.15.0
- document PRs #99–#109 with format-specific behavior and conservative trust boundaries, while excluding dependency, hosting, test-protocol, and development-only changes
- add an absolute Changelog link beside the public documentation link in the npm-visible README

## Why

User-facing trust signals and extraction fixes have accumulated since v0.15.0 without a concise release-facing history. This establishes an honest source for future release notes without cutting a release or changing the package version.

## Verification

- `npm ci` (includes build)
- `npm run lint`
- `node scripts/sync-readme-usage.mjs`
- independent claim-by-claim audit against the v0.15.0-to-main history and PRs #99–#109
- all PR links and the `Unreleased` comparison link verified

No release or version bump is included.