### PR TITLE
fix(remote): time out stalled response bodies

### DIFF
--- a/src/core/io/remote.ts
+++ b/src/core/io/remote.ts
@@ -34,7 +34,7 @@ export interface DownloadRemoteOptions {
   noCache?: boolean;
   /** Max bytes to accept. Defaults to 100 MB. */
   maxBytes?: number;
-  /** Network timeout in milliseconds. Defaults to 60_000. */
+  /** Download deadline covering response headers and body transfer. Defaults to 60_000 ms. */
   timeoutMs?: number;
   /**
    * Override the global `fetch` for tests. Production callers leave this
@@ -107,55 +107,74 @@ async function fetchRemotePdfBytes(rawUrl: string, options: DownloadRemoteOption
   try {
     response = await fetchImpl(rawUrl, { signal: controller.signal, redirect: 'follow' });
   } catch (error) {
+    clearTimeout(timeoutHandle);
     if ((error as Error).name === 'AbortError') {
       throw new Error(`Timed out after ${timeoutMs}ms downloading ${rawUrl}`);
     }
     throw new Error(`Network error downloading ${rawUrl}: ${(error as Error).message}`);
+  }
+
+  try {
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText} for ${rawUrl}`);
+    }
+
+    // Some servers send Content-Length up front; a 200 with a too-large
+    // declared length is rejected before we read a single byte. Servers
+    // that omit Content-Length still get capped during the streaming read
+    // below, so this is a fast-path optimisation rather than the only check.
+    const declaredLength = Number(response.headers.get('content-length') ?? '');
+    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+      throw new Error(`Remote PDF declares ${declaredLength} bytes, exceeds limit of ${maxBytes}`);
+    }
+
+    if (response.body === null) {
+      throw new Error(`Remote response has no body: ${rawUrl}`);
+    }
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    try {
+      while (true) {
+        let result: ReadableStreamReadResult<Uint8Array>;
+        try {
+          result = await reader.read();
+        } catch (error) {
+          if (controller.signal.aborted) {
+            throw new Error(`Timed out after ${timeoutMs}ms downloading ${rawUrl}`);
+          }
+          throw error;
+        }
+
+        if (result.done) break;
+        total += result.value.length;
+        if (total > maxBytes) {
+          try {
+            await reader.cancel();
+          } catch {
+            // Cancellation is cleanup. Its failure must not replace the
+            // deterministic size-limit error that triggered it.
+          }
+          throw new Error(`Remote PDF exceeds ${maxBytes} bytes`);
+        }
+        chunks.push(result.value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const data = Buffer.concat(chunks);
+    if (!hasPdfHeader(data)) {
+      const contentType = response.headers.get('content-type')?.trim() || 'unknown';
+      throw new Error(
+        `Remote URL did not return a PDF (content-type: ${contentType}, bytes: ${data.length}): ${rawUrl}`,
+      );
+    }
+    return data;
   } finally {
     clearTimeout(timeoutHandle);
   }
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} ${response.statusText} for ${rawUrl}`);
-  }
-
-  // Some servers send Content-Length up front; a 200 with a too-large
-  // declared length is rejected before we read a single byte. Servers
-  // that omit Content-Length still get capped during the streaming read
-  // below, so this is a fast-path optimisation rather than the only check.
-  const declaredLength = Number(response.headers.get('content-length') ?? '');
-  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
-    throw new Error(`Remote PDF declares ${declaredLength} bytes, exceeds limit of ${maxBytes}`);
-  }
-
-  if (response.body === null) {
-    throw new Error(`Remote response has no body: ${rawUrl}`);
-  }
-
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  try {
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      total += value.length;
-      if (total > maxBytes) {
-        await reader.cancel();
-        throw new Error(`Remote PDF exceeds ${maxBytes} bytes`);
-      }
-      chunks.push(value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  const data = Buffer.concat(chunks);
-  if (!hasPdfHeader(data)) {
-    const contentType = response.headers.get('content-type')?.trim() || 'unknown';
-    throw new Error(`Remote URL did not return a PDF (content-type: ${contentType}, bytes: ${data.length}): ${rawUrl}`);
-  }
-  return data;
 }
 
 export async function downloadRemoteData(rawUrl: string, options: DownloadRemoteOptions = {}): Promise<Uint8Array> {

--- a/tests/core/remote.test.ts
+++ b/tests/core/remote.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { createServer, type Server } from 'node:http';
+import { createServer, type Server, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -197,11 +197,61 @@ describe('downloadRemote', () => {
     );
   });
 
+  it('preserves the size-limit error when cancelling an oversized body outlasts the timeout', async () => {
+    let cancelCalled = false;
+    const fetchState: { signal: AbortSignal | null } = { signal: null };
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(2));
+      },
+      cancel() {
+        cancelCalled = true;
+        return new Promise<void>((_resolve, reject) => {
+          const rejectOnAbort = () => reject(new DOMException('cancelled by timeout', 'AbortError'));
+          if (fetchState.signal?.aborted) {
+            rejectOnAbort();
+            return;
+          }
+          fetchState.signal?.addEventListener('abort', rejectOnAbort, { once: true });
+        });
+      },
+    });
+    const fetchImpl: typeof fetch = async (_input, init): Promise<Response> => {
+      fetchState.signal = init?.signal ?? null;
+      return new Response(body, { status: 200 });
+    };
+
+    await expect(
+      downloadRemoteData('https://example.com/oversized.pdf', { fetchImpl, maxBytes: 1, timeoutMs: 5 }),
+    ).rejects.toThrow('Remote PDF exceeds 1 bytes');
+    expect(cancelCalled).toBe(true);
+    expect(fetchState.signal?.aborted).toBe(true);
+  });
+
   it('honours the timeout when the server hangs', async () => {
     setHandler((_req, _res) => {
       // Never respond — the test expects a timeout error.
     });
     await expect(downloadRemote(`http://127.0.0.1:${port}/hang.pdf`, { timeoutMs: 100 })).rejects.toThrow(/Timed out/);
+  });
+
+  it('honours the timeout while reading a body that stalls after the headers', async () => {
+    let stalledResponse: ServerResponse | undefined;
+    setHandler((_req, res) => {
+      stalledResponse = res;
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/pdf');
+      res.flushHeaders();
+      res.write('%PDF-');
+    });
+
+    const url = `http://127.0.0.1:${port}/stalled-body.pdf`;
+    try {
+      await expect(downloadRemote(url, { timeoutMs: 100 })).rejects.toThrow(`Timed out after 100ms downloading ${url}`);
+      expect(stalledResponse?.headersSent).toBe(true);
+    } finally {
+      stalledResponse?.destroy();
+    }
   });
 
   it('falls back to a generic basename when the URL has no path segment', async () => {


### PR DESCRIPTION
## Summary

- keep the remote-download timeout active until the response body is fully consumed
- preserve the deterministic streaming size-limit error even if cancellation fails as the timeout fires
- document `timeoutMs` as a deadline covering response headers and body transfer
- add a regression for a server that sends headers and a partial PDF body, then stalls

## Evidence

The timer previously cleared as soon as `fetch()` returned response headers. A server could therefore send headers, leave the body stream open, and hold the CLI indefinitely despite `timeoutMs`.

The regression flushes a successful PDF response, writes a partial `%PDF-` prefix, and intentionally leaves the body open. The transfer now aborts at the configured deadline and releases the test server response.

A second regression drives the production download helper with a signal-aware stream whose cancellation rejects when the same deadline aborts. Cancellation remains cleanup and cannot replace the already-detected size-limit error.

## Validation

- `npx vitest run tests/core/remote.test.ts` — 18/18
- 20 consecutive focused-suite runs — 360/360, no flake
- `npm run lint`
- `npm run test` — 66 files, 1,287 tests
- `npm run build`
- independent adversarial re-audit — no blocker

No release is included.
