### PR TITLE
docs(ocr): put Japanese first in Japanese examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Examples
   pdfvision encrypted.pdf --password "secret" --json                           # encrypted PDF
   printf "secret\n" | pdfvision encrypted.pdf --password-stdin --json          # avoid password in argv
   pdfvision scan.pdf --ocr --json                                              # OCR a scanned PDF
-  pdfvision scan-ja.pdf --ocr --ocr-lang eng+jpn --json                        # multi-lang OCR
+  pdfvision scan-ja.pdf --ocr --ocr-lang jpn+eng --json                        # multi-lang OCR
   pdfvision --remote https://example.com/paper.pdf --json                      # fetch + extract JSON
   pdfvision --clear-cache                                                      # wipe the on-disk cache
 

--- a/docs/src/en/guide/usage.md
+++ b/docs/src/en/guide/usage.md
@@ -107,7 +107,7 @@ This pattern is useful when an answer must be tied to auditable PDF evidence: se
 
 ```bash
 pdfvision scan.pdf --ocr --ocr-lang eng --format json
-pdfvision japanese-scan.pdf --ocr --ocr-lang eng+jpn --format json
+pdfvision japanese-scan.pdf --ocr --ocr-lang jpn+eng --format json
 ```
 
 OCR results include page text, confidence, language, and word boxes.

--- a/docs/src/ja/guide/usage.md
+++ b/docs/src/ja/guide/usage.md
@@ -107,7 +107,7 @@ pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render
 
 ```bash
 pdfvision scan.pdf --ocr --ocr-lang eng --format json
-pdfvision japanese-scan.pdf --ocr --ocr-lang eng+jpn --format json
+pdfvision japanese-scan.pdf --ocr --ocr-lang jpn+eng --format json
 ```
 
 OCR 結果にはテキスト、信頼度、言語、単語ボックスが含まれます。

--- a/docs/src/zh-cn/guide/usage.md
+++ b/docs/src/zh-cn/guide/usage.md
@@ -107,7 +107,7 @@ pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render
 
 ```bash
 pdfvision scan.pdf --ocr --ocr-lang eng --format json
-pdfvision japanese-scan.pdf --ocr --ocr-lang eng+jpn --format json
+pdfvision japanese-scan.pdf --ocr --ocr-lang jpn+eng --format json
 ```
 
 OCR 结果包含文本、置信度、语言和单词框。

--- a/docs/src/zh-tw/guide/usage.md
+++ b/docs/src/zh-tw/guide/usage.md
@@ -107,7 +107,7 @@ pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render
 
 ```bash
 pdfvision scan.pdf --ocr --ocr-lang eng --format json
-pdfvision japanese-scan.pdf --ocr --ocr-lang eng+jpn --format json
+pdfvision japanese-scan.pdf --ocr --ocr-lang jpn+eng --format json
 ```
 
 OCR 結果包含文字、信心分數、語言與單字框。

--- a/skills/pdfvision/references/ocr.md
+++ b/skills/pdfvision/references/ocr.md
@@ -130,7 +130,7 @@ This is a known limitation tracked separately from OCR. Workaround: source a dif
 
 One possibility is a `--ocr-lang` mismatch — the page contains a language not listed in the spec, or the dominant language is not first (for example, a Japanese-dominant page run with `eng+jpn` instead of `jpn+eng`). Try the alternative ordering and compare.
 
-Another possibility is low resolution. pdfvision renders at 2× by default. For genuinely fine print, render to PNG manually at higher scale and feed through tesseract.js directly via the library API (the CLI doesn't currently expose a scale flag for OCR).
+Another possibility is low resolution. pdfvision renders OCR at 2× by default. For genuinely fine print, try `--ocr --render-scale 3` first (supported range `(0, 4]`). If that is still insufficient, render a higher-resolution PNG separately and pass it to tesseract.js directly.
 
 ### "OCR is slow — N pages × M seconds is unbearable"
 

--- a/skills/pdfvision/references/ocr.md
+++ b/skills/pdfvision/references/ocr.md
@@ -25,7 +25,7 @@ npx pdfvision doc.pdf --ocr --ocr-lang chi_sim     # Simplified Chinese
 npx pdfvision doc.pdf --ocr --ocr-lang eng+chi_sim+chi_tra
 ```
 
-**Order matters.** Tesseract treats the first language as the primary recogniser; later languages act as additional candidate dictionaries. `eng+jpn` favours English glyph recognition and falls back to Japanese; `jpn+eng` does the opposite. Empirically:
+**Order matters.** [Tesseract documents](https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html#order-of-multiple-languages) the first language as primary and notes that language order can change OCR output and runtime. Put the dominant language first:
 
 - For mostly-Japanese slides with English headers / labels: `jpn+eng`
 - For English documentation with sparse Japanese terms: `eng+jpn`
@@ -128,9 +128,9 @@ This is a known limitation tracked separately from OCR. Workaround: source a dif
 
 ### "Confidence is moderate but text has obvious garbage"
 
-Most often a `--ocr-lang` mismatch — the page contains a language not listed in the spec, or the order is wrong (Japanese-dominant page run with `eng+jpn` instead of `jpn+eng`). Try the alternative ordering and compare.
+One possibility is a `--ocr-lang` mismatch — the page contains a language not listed in the spec, or the dominant language is not first (for example, a Japanese-dominant page run with `eng+jpn` instead of `jpn+eng`). Try the alternative ordering and compare.
 
-Second most common: low resolution. pdfvision renders at 2× by default. For genuinely fine print, render to PNG manually at higher scale and feed through tesseract.js directly via the library API (the CLI doesn't currently expose a scale flag for OCR).
+Another possibility is low resolution. pdfvision renders at 2× by default. For genuinely fine print, render to PNG manually at higher scale and feed through tesseract.js directly via the library API (the CLI doesn't currently expose a scale flag for OCR).
 
 ### "OCR is slow — N pages × M seconds is unbearable"
 
@@ -151,7 +151,7 @@ Keeping both signals available means a sanity check (compare native vs OCR for a
 ## Examples
 
 ```bash
-# Japanese slide deck, eng-dominant titles
+# Japanese-dominant slide deck with English titles
 npx pdfvision slides.pdf --ocr --ocr-lang jpn+eng -f json
 
 # English paper with embedded Chinese citations

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -187,7 +187,7 @@ Examples
   pdfvision encrypted.pdf --password "secret" --json                           # encrypted PDF
   printf "secret\\n" | pdfvision encrypted.pdf --password-stdin --json          # avoid password in argv
   pdfvision scan.pdf --ocr --json                                              # OCR a scanned PDF
-  pdfvision scan-ja.pdf --ocr --ocr-lang eng+jpn --json                        # multi-lang OCR
+  pdfvision scan-ja.pdf --ocr --ocr-lang jpn+eng --json                        # multi-lang OCR
   pdfvision --remote https://example.com/paper.pdf --json                      # fetch + extract JSON
   pdfvision --clear-cache                                                      # wipe the on-disk cache
 


### PR DESCRIPTION
## Summary

- put `jpn` first in examples that explicitly process Japanese-dominant scans
- regenerate the README usage block from the built CLI help
- align the usage example across all four documentation locales
- keep the bundled OCR reference within Tesseract's documented language-order contract
- direct fine-print troubleshooting to the CLI's supported `--ocr --render-scale 3` path before manual preprocessing

## Why

[Tesseract documents](https://tesseract-ocr.github.io/tessdoc/Command-Line-Usage.html#order-of-multiple-languages) the first listed language as primary and notes that language order can change OCR output and runtime. The previous `eng+jpn` examples explicitly described Japanese scans but put English first, contradicting the existing dominant-language-first guidance.

Generic language-code examples and English-dominant examples remain unchanged. The bundled reference also drops unsupported claims about dictionary fallback, directional glyph preference, and troubleshooting-frequency rankings.

The low-resolution troubleshooting path now reflects the existing implementation: `--render-scale` is accepted with `--ocr` and passed to OCR rasterization. Direct tesseract.js processing remains an escape hatch only when the supported `(0, 4]` CLI range is insufficient.

## Validation

- `npm run build`
- `node scripts/sync-readme-usage.mjs`
- `npm run lint`
- `npm run test` — 66 files, 1,291 tests
- `npm run docs:build`
- six-example scope audit: only `scan-ja.pdf` and `japanese-scan.pdf` examples change to `jpn+eng`
- bundled skill size: 8,158 bytes
- independent claim/scope audit — no blocker after tightening unsupported wording
- post-rebase integration gates on merge `6e60ec9` — no blocker
- review-fix validation: `npx vitest run tests/core/ocr.test.ts -t effectiveOcrRenderScale`, full 66 files / 1,291 tests, `npm run lint`, `npm run docs:build`, and `git diff --check`

No release is included.
