### PR TITLE
fix(geometry): honor non-default page UserUnit

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,15 @@ Options
                           same dir is written with a `-2` suffix and a note on stderr.
                           Without this, PNGs land under the cache (or OS tmp with --no-cache).
       --render-scale <n>  Rasterisation multiplier for --render / --render-visual-regions / --ocr.
-                          Default 2 (≈144 DPI on a letter page). Smaller values shrink the PNG
+                          Default 2 (≈144 DPI). Smaller values shrink the PNG
                           (and vision-model payload); OCR keeps at least scale 2 for recognition
                           quality; larger values capture more detail.
                           Accepts decimals; bounds (0, 4].
       --render-region <x,y,width,height>
-                          Render a sub-rectangle in unrotated page-view user-space units (typically
-                          points with default /UserUnit; top-left origin, y grows downward).
-                          With default /UserUnit, a 400×300 region at scale 3 yields a 1200×900px
-                          PNG. Single-page only: --pages must resolve to exactly one
+                          Render a sub-rectangle in raw unrotated page-view units (top-left origin,
+                          y grows downward). Physical points = raw value × pages[].userUnit (or 1
+                          when omitted); pixels = raw region × UserUnit × render scale. Single-page
+                          only: --pages must resolve to exactly one
                           page (errors otherwise). Region must fit within the page bounds.
                           Typical use: --layout to find a suspect block, then re-run with that
                           block's bbox here to zoom in.
@@ -225,7 +225,8 @@ Options
                           Match case exactly (default: insensitive).
       --matches-only      Emit a focused search report: the file, total page/match counts, and
                           a flat list of emitted matches with page, query reference, source,
-                          text, optional context, and bbox. Requires --search. The full pages/body
+                          text, optional context, and bbox. Non-default page UserUnits are retained
+                          in compact pageUserUnits metadata. Requires --search. The full pages/body
                           payload is omitted; zero matches still exits 0 with a zero-match report.
                           Works in every format. Size grows with emitted matches and context.
       --remote <url>      Download an http(s) PDF, validate the PDF header, and run extraction
@@ -257,7 +258,7 @@ Examples
   pdfvision document.pdf -p 1-3 --json                                         # specific pages, JSON
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
   pdfvision slides.pdf -r --render-scale 1                                     # 1× raster (smaller PNGs)
-  pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150pt box on page 3
+  pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150 page-view-unit box on page 3
   pdfvision report.pdf --search "revenue" --json                               # find emitted "revenue" matches with bboxes; pipe to --render-region
   pdfvision paper.pdf --search "GPT" --search "transformer" --json             # multi-query (each match keeps its source query)
   pdfvision paper.pdf --search "BLEU" --matches-only                           # report metadata + flat match list, without page bodies
@@ -326,7 +327,7 @@ printf "secret\n" | pdfvision encrypted.pdf --password-stdin --json
 pdfvision scan.pdf --ocr --ocr-lang eng+jpn --json
 ```
 
-Coordinates use the unrotated pdf.js `page.view` visible box in PDF user-space units, with a **top-down origin** (0,0 at the view box's top-left, y grows downward). The view box is CropBox ∩ MediaBox when a distinct valid CropBox applies, otherwise MediaBox. With default `/UserUnit`, units are typically points, not PNG pixels. `pages[].width` / `height`, bboxes, and `--render-region` bounds are relative to this box, and bboxes pass unchanged to `--render-region`. For full-page PNG overlays, unrotated pages scale by image/page dimensions; rotated pages require the rotated pdf.js viewport transform because the PNG follows the human-visible orientation.
+Coordinates use raw units from the unrotated pdf.js `page.view` visible box, with a **top-down origin** (0,0 at the view box's top-left, y grows downward). The view box is CropBox ∩ MediaBox when a distinct valid CropBox applies, otherwise MediaBox. Non-default PDF `/UserUnit` values appear as `pages[].userUnit` and `overview[].userUnit`; the fields are omitted when the value is 1. Physical points = raw page-view value × UserUnit, while rendered pixels = raw region × UserUnit × render scale before rotation swaps axes. `pages[].width` / `height`, bboxes, and `--render-region` bounds stay raw, and bboxes pass unchanged to `--render-region`.
 
 Each `pages[].spans[]` entry is one retained positioned pdf.js text item, which may contain a character, word, or longer string. Adjacent items stay separate; the rounded bbox is the item's aggregate axis-aligned envelope, not glyph outlines. Layout and search may reconstruct lines or slice match boxes without changing public span granularity.
 

--- a/docs/src/en/guide/command-line-options.md
+++ b/docs/src/en/guide/command-line-options.md
@@ -39,9 +39,9 @@ JSON-style paths below are exact for JSON, decoded TOON, and `processDocument()`
 | `-r, --render` | Render each selected page as a PNG and attach the image path to the page result. |
 | `--render-output <dir>` | Write rendered page PNGs or visual-region PNGs into a directory. Requires `--render` or `--render-visual-regions`. |
 | `--render-scale <n>` | Set rasterization scale for `--render`, `--render-visual-regions`, or `--ocr`. Default: `2`; accepts decimals in `(0, 4]`. OCR uses at least scale 2 for recognition quality. |
-| `--render-region <x,y,width,height>` | Render one page sub-rectangle in unrotated page-view user-space units. Requires `--render` or `--ocr`, and exactly one selected page. |
+| `--render-region <x,y,width,height>` | Render one page sub-rectangle in raw unrotated page-view units. Requires `--render` or `--ocr`, and exactly one selected page. |
 
-Coordinates use a top-left origin: `x` grows right, `y` grows downward. The same coordinate system is used by layout blocks, image boxes, vector boxes, search matches, and visual regions.
+Coordinates use a top-left origin: `x` grows right, `y` grows downward. The same raw page-view units are used by layout blocks, image boxes, vector boxes, search matches, and visual regions. Physical points = raw value × `pages[].userUnit` (or 1 when omitted); pixels = raw region × UserUnit × render scale.
 
 ## Layout and Visual Structure
 

--- a/docs/src/en/guide/faq.md
+++ b/docs/src/en/guide/faq.md
@@ -41,7 +41,7 @@ Yes. `--search` emits `pages[].matches[]` with page, source, matched text, conte
 
 ## What coordinate system does pdfvision use?
 
-Boxes use the unrotated pdf.js page-view visible box in PDF user-space units, with a top-left origin. This is CropBox ∩ MediaBox when applicable, otherwise MediaBox. `x` grows right and `y` grows downward. With default `/UserUnit`, units are typically points, not PNG pixels. Bboxes pass unchanged to `--render-region`; full-page PNG overlays scale unrotated pages by image/page dimensions and use the rotated pdf.js viewport transform on rotated pages.
+Boxes use raw unrotated pdf.js page-view units, with a top-left origin. The visible box is CropBox ∩ MediaBox when applicable, otherwise MediaBox. `x` grows right and `y` grows downward. Physical points = raw value × `pages[].userUnit` (or 1 when omitted); pixels = raw region × UserUnit × render scale. Bboxes pass unchanged to `--render-region`; rotated pages use the rotated pdf.js viewport transform.
 
 ## Where does the cache live?
 

--- a/docs/src/en/guide/rendering-and-ocr.md
+++ b/docs/src/en/guide/rendering-and-ocr.md
@@ -21,7 +21,7 @@ You do not have to render everything. Start with the overview, then render the p
 pdfvision document.pdf --render --render-output ./images --format json
 ```
 
-Each selected page receives an image path. Layout boxes use unrotated pdf.js page-view coordinates, not PNG pixels. Scale by image/page dimensions for unrotated full-page PNGs; use the rotated pdf.js viewport transform for rotated pages.
+Each selected page receives an image path. Layout boxes use raw unrotated pdf.js page-view units, not PNG pixels. Physical points = raw value × `pages[].userUnit` (or 1 when omitted); pixels = raw value × UserUnit × render scale. Use the rotated pdf.js viewport transform for rotated pages.
 
 Use `--render-scale` to control detail:
 
@@ -46,7 +46,7 @@ The rendered image path is returned in `pages[].image`, so an agent can pass it 
 pdfvision document.pdf --pages 2 --render --render-region 120,180,360,240 --render-output ./regions
 ```
 
-`--render-region` uses unrotated page-view user-space units (typically points with default `/UserUnit`) with a top-left origin. A layout, image, or visual-region bbox passes unchanged.
+`--render-region` uses raw unrotated page-view units with a top-left origin. A layout, image, or visual-region bbox passes unchanged; the renderer applies UserUnit and render scale when producing pixels.
 
 The same crop flow works after `--search`, because search matches can carry bounding boxes. See [Search and Region Zoom](./search-and-region-zoom.md).
 

--- a/docs/src/en/guide/search-and-region-zoom.md
+++ b/docs/src/en/guide/search-and-region-zoom.md
@@ -19,6 +19,8 @@ Matches are emitted in `pages[].matches[]`. Each match includes the page number,
 
 Markdown output also shows a per-page `Search matches` table when `--search` is used. Use JSON, XML, or TOON when a downstream tool needs to consume the coordinates directly.
 
+Add `--matches-only` for a compact flat report without page bodies. If any selected page has a non-default PDF `/UserUnit`, the report preserves it as `pageUserUnits: [{ page, userUnit }]` in JSON/TOON, equivalent `<pageUserUnits>` entries in XML, and a `Page UserUnits` summary in Markdown. The metadata is omitted when every selected page uses UserUnit 1.
+
 Repeat `--search` to run multiple queries in one pass:
 
 ```bash
@@ -72,7 +74,7 @@ Take a match bbox and pass it to `--render-region`:
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` requires exactly one selected page. The region uses unrotated page-view user-space units (typically points with default `/UserUnit`) with a top-left origin, and it must stay within the page bounds.
+`--render-region` requires exactly one selected page. The region uses raw unrotated page-view units with a top-left origin, and it must stay within the page bounds. Physical points = raw value × `pages[].userUnit` (or 1 when omitted); pixels = raw region × UserUnit × render scale.
 
 Use `--render-scale` when the crop contains small labels, superscripts, dense table cells, or chart legends:
 

--- a/docs/src/en/guide/structured-output.md
+++ b/docs/src/en/guide/structured-output.md
@@ -65,7 +65,7 @@ The overview is especially useful for long documents because it lets the agent c
 Each `pages[]` entry includes:
 
 - `text` and optional `rawText`.
-- page dimensions in unrotated page-view user-space units.
+- page dimensions in raw unrotated page-view units, plus optional `userUnit` when it is not 1.
 - optional page rotation in degrees when the PDF page is rotated.
 - density fields mirrored from the overview.
 - optional `formFieldCount`, `linkCount`, and `annotationCount` presence signals, omitted when zero.
@@ -107,9 +107,11 @@ Practical interpretation:
 
 ## Coordinates
 
-All boxes use the unrotated pdf.js `page.view` visible box in PDF user-space units, with a top-left origin. The box is CropBox ∩ MediaBox when a distinct valid CropBox applies, otherwise MediaBox. `pages[].width` / `height`, zero-based coordinates, and `renderRegion` bounds are relative to it. With default `/UserUnit`, units are typically points, not PNG pixels.
+All boxes use raw unrotated pdf.js `page.view` units, with a top-left origin. The visible box is CropBox ∩ MediaBox when a distinct valid CropBox applies, otherwise MediaBox. `pages[].width` / `height`, zero-based coordinates, and `renderRegion` bounds are relative to it. `pages[].userUnit` and `overview[].userUnit` expose a non-default PDF `/UserUnit` and are omitted when it is 1. Physical points equal a raw page-view value × `userUnit` (or 1 when omitted); rendered pixels equal a raw region × UserUnit × render scale before rotation swaps axes.
 
-Pass bboxes unchanged to `--render-region`. For full-page PNG overlays, scale unrotated pages by image/page dimensions; on rotated pages, use `pages[].rotation` and the rotated pdf.js viewport transform because the PNG follows the human-visible orientation.
+Pass raw bboxes unchanged to `--render-region`. For full-page PNG overlays, scale unrotated pages by image/page dimensions; on rotated pages, use `pages[].rotation` and the rotated pdf.js viewport transform because the PNG follows the human-visible orientation.
+
+Warning-detector thresholds and `pt` / `pt²` messages use a private physical-point view of already extracted geometry. This does not make all extraction physically invariant: layout grouping, form-label reconstruction, vector-box shaping, and visual-region generation still include raw-unit heuristics and can produce different upstream signals for physically equivalent PDFs.
 
 Coordinate-bearing fields include spans, layout blocks and lines, image boxes, vector boxes, visual regions, form fields, links, annotations, structure references, OCR words, and search matches. This means an agent can move from structured extraction to a visual crop without inventing a new coordinate system.
 

--- a/docs/src/ja/guide/command-line-options.md
+++ b/docs/src/ja/guide/command-line-options.md
@@ -39,9 +39,9 @@ description: PDF 入力、出力形式、レンダリング、OCR、検索、レ
 | `-r, --render` | 選択ページを PNG としてレンダリングし、ページ結果に画像パスを付けます。 |
 | `--render-output <dir>` | ページ PNG または視覚領域 PNG の出力先を指定します。`--render` または `--render-visual-regions` が必要です。 |
 | `--render-scale <n>` | `--render`, `--render-visual-regions`, `--ocr` のラスタライズ倍率を指定します。既定は `2`、範囲は `(0, 4]` です。 |
-| `--render-region <x,y,width,height>` | 回転前の page view box の user-space units で 1 ページの矩形をレンダリングします。`--render` または `--ocr` が必要で、`--pages` はちょうど 1 ページに解決される必要があります。 |
+| `--render-region <x,y,width,height>` | 回転前の生の page-view units で、1 ページ内の矩形をレンダリングします。`--render` または `--ocr` が必要で、`--pages` はちょうど 1 ページに解決される必要があります。 |
 
-座標は左上原点で、`x` は右、`y` は下に増えます。既定の `/UserUnit` では通常ポイントですが、PNG のピクセルではありません。layout block、image box、vector box、search match、visual region と同じ座標系です。
+座標は左上原点で、`x` は右、`y` は下に増えます。layout block、image box、vector box、search match、visual region も同じ生の page-view units を使います。物理サイズのポイント数は「生の値 × `pages[].userUnit`（省略時は 1）」、ピクセル数は「生の領域 × UserUnit × render scale」です。
 
 ## レイアウトと視覚構造
 

--- a/docs/src/ja/guide/faq.md
+++ b/docs/src/ja/guide/faq.md
@@ -41,7 +41,7 @@ visual regions は、図、グラフ、表、フォームセクション、注�
 
 ## 座標系はどうなっていますか？
 
-bbox は回転前の pdf.js page view 表示ボックスの PDF user-space units で、左上が原点です。これは適用可能な場合は CropBox ∩ MediaBox、それ以外は MediaBox です。`x` は右、`y` は下に増えます。既定の `/UserUnit` では通常ポイントですが、PNG のピクセル座標ではありません。bbox は変更せず `--render-region` に渡せます。ページ全体の PNG に重ねる場合、回転なしでは画像とページの寸法比で拡大し、回転ありでは pdf.js の回転 viewport transform を使います。
+bbox は、回転前の pdf.js page view 表示ボックスを基準とする生の page-view units で、左上が原点です。表示ボックスは、適用可能な場合は CropBox ∩ MediaBox、それ以外は MediaBox です。`x` は右、`y` は下に増えます。物理サイズのポイント数は「生の値 × `pages[].userUnit`（省略時は 1）」、ピクセル数は「生の領域 × UserUnit × render scale」です。bbox は変更せず `--render-region` に渡せます。回転ページでは、pdf.js の回転 viewport transform を使います。
 
 ## キャッシュはどこにありますか？
 

--- a/docs/src/ja/guide/rendering-and-ocr.md
+++ b/docs/src/ja/guide/rendering-and-ocr.md
@@ -21,7 +21,7 @@ pdfvision はレンダリングを最後の手段ではなく、根拠の一種�
 pdfvision document.pdf --render --render-output ./images --format json
 ```
 
-選択ページに画像パスが付きます。レイアウト bbox は回転前の pdf.js page view box 座標で、PNG のピクセル座標ではありません。回転なしのページ全体 PNG では画像とページの寸法比で拡大し、回転ありでは pdf.js の回転 viewport transform を使います。
+選択ページに画像パスが付きます。レイアウト bbox は、回転前の pdf.js page view box を基準とする生の page-view units で、PNG のピクセル座標ではありません。物理サイズのポイント数は「生の値 × `pages[].userUnit`（省略時は 1）」、ピクセル数は「生の値 × UserUnit × render scale」です。回転ページでは、pdf.js の回転 viewport transform を使います。
 
 ```bash
 pdfvision document.pdf --render --render-scale 3
@@ -44,7 +44,7 @@ pdfvision document.pdf --render --render-scale 3
 pdfvision document.pdf --pages 2 --render --render-region 120,180,360,240 --render-output ./regions
 ```
 
-`--render-region` は回転前の page view box の user-space units（既定の `/UserUnit` では通常ポイント）で矩形を指定します。レイアウトブロックや視覚領域の bbox は変更せず渡せます。
+`--render-region` は、回転前の生の page-view units で矩形を指定します。レイアウトブロックや視覚領域の bbox は変更せず渡せます。ピクセル化するときは、レンダラーが UserUnit と render scale を適用します。
 
 検索結果の bbox からも同じ流れでクロップできます。詳しくは [検索と領域ズーム](./search-and-region-zoom.md) を参照してください。
 

--- a/docs/src/ja/guide/search-and-region-zoom.md
+++ b/docs/src/ja/guide/search-and-region-zoom.md
@@ -17,6 +17,8 @@ pdfvision report.pdf --search "revenue" --json
 
 一致結果は `pages[].matches[]` に出ます。各 match にはページ番号、query、source、テキスト断片、位置を特定できた場合の bbox が含まれます。
 
+ページ本文を除いた小さなフラット形式が必要なら、`--matches-only` を追加します。選択ページに既定値以外の PDF `/UserUnit` があれば、JSON/TOON では `pageUserUnits: [{ page, userUnit }]`、XML では同等の `<pageUserUnits>`、Markdown では `Page UserUnits` の要約として保持します。すべての選択ページが UserUnit 1 の場合、このメタデータは省略されます。
+
 複数の query は `--search` を繰り返します。
 
 ```bash
@@ -70,7 +72,7 @@ match の bbox を `--render-region` に渡します。
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` は選択ページがちょうど 1 ページである必要があります。領域は回転前の page view box の user-space units（既定の `/UserUnit` では通常ポイント）と左上原点を使い、ページ境界内に収まる必要があります。
+`--render-region` は、選択ページがちょうど 1 ページである必要があります。領域は回転前の生の page-view units と左上原点を使い、ページ境界内に収めます。物理サイズのポイント数は「生の値 × `pages[].userUnit`（省略時は 1）」、ピクセル数は「生の領域 × UserUnit × render scale」です。
 
 小さいラベル、上付き文字、密な表セル、チャート凡例では `--render-scale` を上げます。
 

--- a/docs/src/ja/guide/structured-output.md
+++ b/docs/src/ja/guide/structured-output.md
@@ -59,7 +59,7 @@ interface DocumentResult {
 
 ## Page Result
 
-各 `pages[]` には、`text`, `rawText`, ページ寸法、密度フィールド、必要に応じて `spans`, `layout`, `imageBoxes`, `vectorBoxes`, `visualRegions`, `formFields`, `links`, `annotations`, `structure`, `ocr`, `warnings`, `matches` が入ります。
+各 `pages[]` には、`text`、`rawText`、生の page-view units で表したページ寸法、既定値以外の場合の `userUnit`、密度フィールド、必要に応じて `spans`、`layout`、`imageBoxes`、`vectorBoxes`、`visualRegions`、`formFields`、`links`、`annotations`、`structure`、`ocr`、`warnings`、`matches` が入ります。
 
 OCR はネイティブテキストを上書きしません。利用側が `page.text` と `page.ocr?.text` を比較して選びます。
 
@@ -96,7 +96,9 @@ OCR はネイティブテキストを上書きしません。利用側が `page.
 
 ## 座標系
 
-すべての bbox は回転前の pdf.js `page.view` 表示ボックスの PDF user-space units で、左上原点です。このボックスは、有効な CropBox が適用される場合は CropBox ∩ MediaBox、それ以外は MediaBox です。`pages[].width` / `height`、ゼロ基準座標、`renderRegion` の境界はこのボックス基準です。既定の `/UserUnit` では通常ポイントですが、PNG のピクセル座標ではありません。bbox は変更せず `--render-region` に渡せます。ページ全体の PNG に重ねる場合、回転なしの場合は画像とページの寸法比で拡大し、回転ありの場合は pdf.js の回転 viewport transform を使います。
+すべての bbox は、回転前の pdf.js `page.view` を基準とする生の page-view units で表し、左上を原点とします。表示ボックスは、有効な CropBox が適用される場合は CropBox ∩ MediaBox、それ以外は MediaBox です。`pages[].width` / `height`、ゼロ基準座標、`renderRegion` の境界も、このボックスを基準にします。`pages[].userUnit` と `overview[].userUnit` は、既定値 1 以外の PDF `/UserUnit` を示し、1 の場合は省略されます。物理サイズのポイント数は「生の page-view 値 × userUnit（省略時は 1）」、レンダリング後のピクセル数は「生の領域 × UserUnit × render scale」です。bbox は変更せず `--render-region` に渡せます。ページ全体の PNG に重ねる場合、回転なしでは画像とページの寸法比で拡大し、回転ありでは pdf.js の回転 viewport transform を使います。
+
+警告検出のしきい値と `pt` / `pt²` を含むメッセージには、抽出済みジオメトリを物理ポイントへ換算した非公開ビューを使います。ただし、抽出処理のすべてが物理サイズに対して不変になるわけではありません。レイアウトのグループ化、フォームラベルの再構築、vector box の整形、visual region の生成には、生の単位に基づくヒューリスティックが残っているため、物理的に同等な PDF でも上流の抽出結果が異なる場合があります。
 
 座標を持つフィールドには、spans、layout blocks/lines、image boxes、vector boxes、visual regions、form fields、links、annotations、structure references、OCR words、search matches が含まれます。これにより、エージェントは新しい座標系を発明せずに、構造化抽出から視覚クロップへ移れます。
 

--- a/docs/src/ja/guide/structured-output.md
+++ b/docs/src/ja/guide/structured-output.md
@@ -96,7 +96,7 @@ OCR はネイティブテキストを上書きしません。利用側が `page.
 
 ## 座標系
 
-すべての bbox は、回転前の pdf.js `page.view` を基準とする生の page-view units で表し、左上を原点とします。表示ボックスは、有効な CropBox が適用される場合は CropBox ∩ MediaBox、それ以外は MediaBox です。`pages[].width` / `height`、ゼロ基準座標、`renderRegion` の境界も、このボックスを基準にします。`pages[].userUnit` と `overview[].userUnit` は、既定値 1 以外の PDF `/UserUnit` を示し、1 の場合は省略されます。物理サイズのポイント数は「生の page-view 値 × userUnit（省略時は 1）」、レンダリング後のピクセル数は「生の領域 × UserUnit × render scale」です。bbox は変更せず `--render-region` に渡せます。ページ全体の PNG に重ねる場合、回転なしでは画像とページの寸法比で拡大し、回転ありでは pdf.js の回転 viewport transform を使います。
+すべての bbox は、回転前の pdf.js `page.view` を基準とする生の page-view units で表し、左上を原点とします。表示ボックスは、有効な CropBox が適用される場合は CropBox ∩ MediaBox、それ以外は MediaBox です。`pages[].width` / `height`、ゼロ基準座標、`renderRegion` の境界も、このボックスを基準にします。`pages[].userUnit` と `overview[].userUnit` は、既定値 1 以外の PDF `/UserUnit` を示し、1 の場合は省略されます。物理サイズのポイント数は「生の page-view 値 × userUnit（省略時は 1）」、レンダリング後のピクセル数は「生の領域 × UserUnit × render scale」です。bbox は変更せず `--render-region` に渡せます。ページ全体の PNG に重ねる場合、回転なしの場合は画像とページの寸法比で拡大し、回転ありの場合は pdf.js の回転 viewport transform を使います。
 
 警告検出のしきい値と `pt` / `pt²` を含むメッセージには、抽出済みジオメトリを物理ポイントへ換算した非公開ビューを使います。ただし、抽出処理のすべてが物理サイズに対して不変になるわけではありません。レイアウトのグループ化、フォームラベルの再構築、vector box の整形、visual region の生成には、生の単位に基づくヒューリスティックが残っているため、物理的に同等な PDF でも上流の抽出結果が異なる場合があります。
 

--- a/docs/src/zh-cn/guide/command-line-options.md
+++ b/docs/src/zh-cn/guide/command-line-options.md
@@ -39,9 +39,9 @@ description: pdfvision CLI 选项参考，涵盖 PDF 输入、输出格式、渲
 | `-r, --render` | 将每个选中页面渲染为 PNG，并在页面结果中附加图像路径。 |
 | `--render-output <dir>` | 指定页面 PNG 或视觉区域 PNG 的输出目录。需要 `--render` 或 `--render-visual-regions`。 |
 | `--render-scale <n>` | 设置 `--render`、`--render-visual-regions` 或 `--ocr` 的栅格化倍率。默认 `2`，范围 `(0, 4]`。 |
-| `--render-region <x,y,width,height>` | 以未旋转的 page view box user-space units 渲染一页中的矩形。需要 `--render` 或 `--ocr`，且 `--pages` 必须恰好解析为一个页面。 |
+| `--render-region <x,y,width,height>` | 以未旋转的原始 page-view units 渲染一页中的矩形。需要 `--render` 或 `--ocr`，且 `--pages` 必须恰好解析为一个页面。 |
 
-坐标使用左上原点：`x` 向右增加，`y` 向下增加。默认 `/UserUnit` 下通常是点，而不是 PNG 像素。layout block、image box、vector box、search match 和 visual region 使用同一坐标系。
+坐标使用左上原点：`x` 向右增加，`y` 向下增加。layout block、image box、vector box、search match 和 visual region 使用相同的原始 page-view units。物理点数 = 原始值 × `pages[].userUnit`（省略时按 1）；像素数 = 原始区域 × UserUnit × render scale。
 
 ## 布局与视觉结构
 

--- a/docs/src/zh-cn/guide/faq.md
+++ b/docs/src/zh-cn/guide/faq.md
@@ -41,7 +41,7 @@ Visual regions 是可裁剪的页面区域，可能包含有意义的图形、�
 
 ## pdfvision 使用什么坐标系？
 
-bbox 使用未旋转的 pdf.js page view 可见框 PDF user-space units，并以左上角为原点。适用时该框是 CropBox ∩ MediaBox，否则是 MediaBox。`x` 向右增加，`y` 向下增加。默认 `/UserUnit` 下通常是点，而不是 PNG 像素。bbox 可原样传给 `--render-region`；整页 PNG 叠加在未旋转页按图像/页面尺寸缩放，在旋转页使用 pdf.js 的旋转 viewport transform。
+bbox 使用未旋转的 pdf.js page view 可见框原始 page-view units，并以左上角为原点。适用时该框是 CropBox ∩ MediaBox，否则是 MediaBox。`x` 向右增加，`y` 向下增加。物理点数 = 原始值 × `pages[].userUnit`（省略时按 1）；像素数 = 原始区域 × UserUnit × render scale。bbox 可原样传给 `--render-region`；旋转页使用 pdf.js 的旋转 viewport transform。
 
 ## 缓存在哪里？
 

--- a/docs/src/zh-cn/guide/rendering-and-ocr.md
+++ b/docs/src/zh-cn/guide/rendering-and-ocr.md
@@ -21,7 +21,7 @@ pdfvision 把渲染当作证据，而不是最后手段。智能体可以先读�
 pdfvision document.pdf --render --render-output ./images --format json
 ```
 
-每个选中页面都会得到一个图像路径。布局 bbox 使用未旋转的 pdf.js page view box 页面坐标，而不是 PNG 像素。未旋转整页按图像/页面尺寸缩放；旋转页使用 pdf.js 的旋转 viewport transform。
+每个选中页面都会得到一个图像路径。布局 bbox 使用未旋转的 pdf.js page view box 原始 page-view units，而不是 PNG 像素。物理点数 = 原始值 × `pages[].userUnit`（省略时按 1）；像素数 = 原始值 × UserUnit × render scale。旋转页使用 pdf.js 的旋转 viewport transform。
 
 ```bash
 pdfvision document.pdf --render --render-scale 3
@@ -44,7 +44,7 @@ pdfvision document.pdf --render --render-scale 3
 pdfvision document.pdf --pages 2 --render --render-region 120,180,360,240 --render-output ./regions
 ```
 
-`--render-region` 使用未旋转的 page view box user-space units（默认 `/UserUnit` 下通常是点）和左上角原点。布局、图像或视觉区域 bbox 可原样传入。
+`--render-region` 使用未旋转的原始 page-view units 和左上角原点。布局、图像或视觉区域 bbox 可原样传入；渲染器在生成像素时应用 UserUnit 与 render scale。
 
 搜索结果的 bbox 也可以使用同一裁剪流程。参见 [搜索与区域放大](./search-and-region-zoom.md)。
 

--- a/docs/src/zh-cn/guide/search-and-region-zoom.md
+++ b/docs/src/zh-cn/guide/search-and-region-zoom.md
@@ -17,6 +17,8 @@ pdfvision report.pdf --search "revenue" --json
 
 匹配结果会输出到 `pages[].matches[]`。每个 match 包含页码、query、source、文本片段，以及能够定位可见区域时的 bbox。
 
+如需省略页面正文的紧凑扁平报告，可添加 `--matches-only`。如果任一选中页面使用非默认 PDF `/UserUnit`，JSON/TOON 会保留 `pageUserUnits: [{ page, userUnit }]`，XML 会输出等价的 `<pageUserUnits>`，Markdown 会输出 `Page UserUnits` 摘要。所有选中页面均使用 UserUnit 1 时，该元数据会被省略。
+
 重复 `--search` 可以一次运行多个查询：
 
 ```bash
@@ -70,7 +72,7 @@ match 的 `source` 帮助智能体判断它应该被多大程度信任：
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` 要求选中的页恰好为一页。区域使用未旋转的 page view box user-space units（默认 `/UserUnit` 下通常是点）和左上角原点，并且必须在页面边界内。
+`--render-region` 要求选中的页恰好为一页。区域使用未旋转的原始 page-view units 和左上角原点，并且必须在页面边界内。物理点数 = 原始值 × `pages[].userUnit`（省略时按 1）；像素数 = 原始区域 × UserUnit × render scale。
 
 如果裁剪图包含小标签、上标、密集表格单元格或图表图例，可以提高 `--render-scale`：
 

--- a/docs/src/zh-cn/guide/structured-output.md
+++ b/docs/src/zh-cn/guide/structured-output.md
@@ -59,7 +59,7 @@ interface DocumentResult {
 
 ## Page Result
 
-每个 `pages[]` 条目包含 `text`、`rawText`、页面尺寸、密度字段，以及按需出现的 `spans`、`layout`、`imageBoxes`、`vectorBoxes`、`visualRegions`、`formFields`、`links`、`annotations`、`structure`、`ocr`、`warnings` 和 `matches`。
+每个 `pages[]` 条目包含 `text`、`rawText`、以原始 page-view units 表示的页面尺寸、非默认时出现的 `userUnit`、密度字段，以及按需出现的 `spans`、`layout`、`imageBoxes`、`vectorBoxes`、`visualRegions`、`formFields`、`links`、`annotations`、`structure`、`ocr`、`warnings` 和 `matches`。
 
 OCR 不会覆盖原生文本。使用方应比较 `page.text` 与 `page.ocr?.text` 后再选择。
 
@@ -96,7 +96,9 @@ OCR 不会覆盖原生文本。使用方应比较 `page.text` 与 `page.ocr?.tex
 
 ## 坐标
 
-所有 bbox 使用未旋转的 pdf.js `page.view` 可见框 PDF user-space units，并以左上角为原点。存在有效 CropBox 时，该框是 CropBox ∩ MediaBox，否则是 MediaBox。`pages[].width` / `height`、零基准坐标和 `renderRegion` 边界均相对于此框。默认 `/UserUnit` 下通常是点，而不是 PNG 像素。bbox 可原样传给 `--render-region`；整页 PNG 叠加在未旋转页按图像/页面尺寸缩放，在旋转页使用 pdf.js 的旋转 viewport transform。
+所有 bbox 均使用未旋转的 pdf.js `page.view` 原始 page-view units，并以左上角为原点。存在有效 CropBox 时，可见框是 CropBox ∩ MediaBox，否则是 MediaBox。`pages[].width` / `height`、零基准坐标和 `renderRegion` 边界均相对于此框。`pages[].userUnit` 与 `overview[].userUnit` 只在 PDF `/UserUnit` 不为默认值 1 时出现。物理点数 = 原始 page-view 值 × `userUnit`（省略时按 1）；渲染像素数 = 原始区域 × UserUnit × render scale，旋转可能交换两个轴。bbox 可原样传给 `--render-region`；旋转页使用 pdf.js 的旋转 viewport transform。
+
+警告检测阈值以及包含 `pt` / `pt²` 的消息使用已提取几何的私有物理点视图。但这并不保证整个提取流程在物理尺寸上保持不变：布局分组、表单标签重建、vector box 整形和 visual region 生成仍包含基于原始单位的启发式规则，因此物理上等价的 PDF 仍可能产生不同的上游信号。
 
 带坐标的字段包括 spans、layout blocks/lines、image boxes、vector boxes、visual regions、form fields、links、annotations、structure references、OCR words 和 search matches。智能体可以从结构化提取直接跳到视觉裁剪，而不需要发明新的坐标系。
 

--- a/docs/src/zh-tw/guide/command-line-options.md
+++ b/docs/src/zh-tw/guide/command-line-options.md
@@ -39,9 +39,9 @@ description: pdfvision CLI 選項參考，涵蓋 PDF 輸入、輸出格式、渲
 | `-r, --render` | 將每個選中頁面渲染為 PNG，並在頁面結果中附加影像路徑。 |
 | `--render-output <dir>` | 指定頁面 PNG 或視覺區域 PNG 的輸出目錄。需要 `--render` 或 `--render-visual-regions`。 |
 | `--render-scale <n>` | 設定 `--render`、`--render-visual-regions` 或 `--ocr` 的 rasterization 倍率。預設 `2`，範圍 `(0, 4]`。 |
-| `--render-region <x,y,width,height>` | 以未旋轉的 page view box user-space units 渲染一頁中的矩形。需要 `--render` 或 `--ocr`，且 `--pages` 必須剛好解析為一個頁面。 |
+| `--render-region <x,y,width,height>` | 以未旋轉的原始 page-view units 渲染一頁中的矩形。需要 `--render` 或 `--ocr`，且 `--pages` 必須剛好解析為一個頁面。 |
 
-座標使用左上原點：`x` 向右增加，`y` 向下增加。預設 `/UserUnit` 下通常是點，而不是 PNG 像素。layout block、image box、vector box、search match 和 visual region 使用同一座標系。
+座標使用左上原點：`x` 向右增加，`y` 向下增加。layout block、image box、vector box、search match 和 visual region 使用相同的原始 page-view units。物理點數 = 原始值 × `pages[].userUnit`（省略時按 1）；像素數 = 原始區域 × UserUnit × render scale。
 
 ## 版面與視覺結構
 

--- a/docs/src/zh-tw/guide/faq.md
+++ b/docs/src/zh-tw/guide/faq.md
@@ -41,7 +41,7 @@ Visual regions 是可裁切的頁面區域，可能包含有意義的圖形、�
 
 ## pdfvision 使用什麼座標系？
 
-bbox 使用未旋轉的 pdf.js page view 可見框 PDF user-space units，並以左上角為原點。適用時該框是 CropBox ∩ MediaBox，否則是 MediaBox。`x` 向右增加，`y` 向下增加。預設 `/UserUnit` 下通常是點，而不是 PNG 像素。bbox 可原樣傳給 `--render-region`；整頁 PNG 疊加在未旋轉頁按影像/頁面尺寸縮放，在旋轉頁使用 pdf.js 的旋轉 viewport transform。
+bbox 使用未旋轉的 pdf.js page view 可見框原始 page-view units，並以左上角為原點。適用時該框是 CropBox ∩ MediaBox，否則是 MediaBox。`x` 向右增加，`y` 向下增加。物理點數 = 原始值 × `pages[].userUnit`（省略時按 1）；像素數 = 原始區域 × UserUnit × render scale。bbox 可原樣傳給 `--render-region`；旋轉頁使用 pdf.js 的旋轉 viewport transform。
 
 ## 快取在哪裡？
 

--- a/docs/src/zh-tw/guide/rendering-and-ocr.md
+++ b/docs/src/zh-tw/guide/rendering-and-ocr.md
@@ -21,7 +21,7 @@ pdfvision 把渲染當作證據，而不是最後手段。代理可以先讀取�
 pdfvision document.pdf --render --render-output ./images --format json
 ```
 
-每個選中頁面都會得到一個影像路徑。版面 bbox 使用未旋轉的 pdf.js page view box 頁面座標，而不是 PNG 像素。未旋轉整頁按影像/頁面尺寸縮放；旋轉頁使用 pdf.js 的旋轉 viewport transform。
+每個選中頁面都會得到一個影像路徑。版面 bbox 使用未旋轉的 pdf.js page view box 原始 page-view units，而不是 PNG 像素。物理點數 = 原始值 × `pages[].userUnit`（省略時按 1）；像素數 = 原始值 × UserUnit × render scale。旋轉頁使用 pdf.js 的旋轉 viewport transform。
 
 ```bash
 pdfvision document.pdf --render --render-scale 3
@@ -44,7 +44,7 @@ pdfvision document.pdf --render --render-scale 3
 pdfvision document.pdf --pages 2 --render --render-region 120,180,360,240 --render-output ./regions
 ```
 
-`--render-region` 使用未旋轉的 page view box user-space units（預設 `/UserUnit` 下通常是點）和左上角原點。版面、影像或視覺區域 bbox 可原樣傳入。
+`--render-region` 使用未旋轉的原始 page-view units 和左上角原點。版面、影像或視覺區域 bbox 可原樣傳入；渲染器在產生像素時套用 UserUnit 與 render scale。
 
 搜尋結果的 bbox 也可以使用同一裁切流程。參見 [搜尋與區域放大](./search-and-region-zoom.md)。
 

--- a/docs/src/zh-tw/guide/search-and-region-zoom.md
+++ b/docs/src/zh-tw/guide/search-and-region-zoom.md
@@ -17,6 +17,8 @@ pdfvision report.pdf --search "revenue" --json
 
 匹配結果會輸出到 `pages[].matches[]`。每個 match 包含頁碼、query、source、文字片段，以及能夠定位可見區域時的 bbox。
 
+如需省略頁面本文的精簡扁平報告，可加入 `--matches-only`。如果任一選中頁面使用非預設 PDF `/UserUnit`，JSON/TOON 會保留 `pageUserUnits: [{ page, userUnit }]`，XML 會輸出對等的 `<pageUserUnits>`，Markdown 會輸出 `Page UserUnits` 摘要。所有選中頁面均使用 UserUnit 1 時，此中繼資料會省略。
+
 重複 `--search` 可以一次執行多個查詢：
 
 ```bash
@@ -70,7 +72,7 @@ match 的 `source` 幫助代理判斷它應該被多大程度信任：
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` 要求選中的頁剛好為一頁。區域使用未旋轉的 page view box user-space units（預設 `/UserUnit` 下通常是點）和左上角原點，並且必須在頁面邊界內。
+`--render-region` 要求選中的頁剛好為一頁。區域使用未旋轉的原始 page-view units 和左上角原點，並且必須在頁面邊界內。物理點數 = 原始值 × `pages[].userUnit`（省略時按 1）；像素數 = 原始區域 × UserUnit × render scale。
 
 如果裁切圖包含小標籤、上標、密集表格儲存格或圖表圖例，可以提高 `--render-scale`：
 

--- a/docs/src/zh-tw/guide/structured-output.md
+++ b/docs/src/zh-tw/guide/structured-output.md
@@ -59,7 +59,7 @@ interface DocumentResult {
 
 ## Page Result
 
-每個 `pages[]` 項目包含 `text`、`rawText`、頁面尺寸、密度欄位，以及按需出現的 `spans`、`layout`、`imageBoxes`、`vectorBoxes`、`visualRegions`、`formFields`、`links`、`annotations`、`structure`、`ocr`、`warnings` 和 `matches`。
+每個 `pages[]` 項目包含 `text`、`rawText`、以原始 page-view units 表示的頁面尺寸、非預設時出現的 `userUnit`、密度欄位，以及按需出現的 `spans`、`layout`、`imageBoxes`、`vectorBoxes`、`visualRegions`、`formFields`、`links`、`annotations`、`structure`、`ocr`、`warnings` 和 `matches`。
 
 OCR 不會覆蓋原生文字。使用方應比較 `page.text` 與 `page.ocr?.text` 後再選擇。
 
@@ -96,7 +96,9 @@ OCR 不會覆蓋原生文字。使用方應比較 `page.text` 與 `page.ocr?.tex
 
 ## 座標
 
-所有 bbox 使用未旋轉的 pdf.js `page.view` 可見框 PDF user-space units，並以左上角為原點。存在有效 CropBox 時，該框是 CropBox ∩ MediaBox，否則是 MediaBox。`pages[].width` / `height`、零基準座標和 `renderRegion` 邊界均相對於此框。預設 `/UserUnit` 下通常是點，而不是 PNG 像素。bbox 可原樣傳給 `--render-region`；整頁 PNG 疊加在未旋轉頁按影像/頁面尺寸縮放，在旋轉頁使用 pdf.js 的旋轉 viewport transform。
+所有 bbox 均使用未旋轉的 pdf.js `page.view` 原始 page-view units，並以左上角為原點。存在有效 CropBox 時，可見框是 CropBox ∩ MediaBox，否則是 MediaBox。`pages[].width` / `height`、零基準座標和 `renderRegion` 邊界均相對於此框。`pages[].userUnit` 與 `overview[].userUnit` 只在 PDF `/UserUnit` 不為預設值 1 時出現。物理點數 = 原始 page-view 值 × `userUnit`（省略時按 1）；渲染像素數 = 原始區域 × UserUnit × render scale，旋轉可能交換兩個軸。bbox 可原樣傳給 `--render-region`；旋轉頁使用 pdf.js 的旋轉 viewport transform。
+
+警告偵測閾值以及包含 `pt` / `pt²` 的訊息，會使用已擷取幾何的私有物理點視圖。但這並不保證整個擷取流程在物理尺寸上保持不變：版面分組、表單標籤重建、vector box 整形和 visual region 產生仍包含以原始單位為基礎的啟發式規則，因此物理上等價的 PDF 仍可能產生不同的上游訊號。
 
 帶座標的欄位包括 spans、layout blocks/lines、image boxes、vector boxes、visual regions、form fields、links、annotations、structure references、OCR words 和 search matches。代理可以從結構化擷取直接跳到視覺裁切，而不需要發明新的座標系。
 

--- a/skills/pdfvision/SKILL.md
+++ b/skills/pdfvision/SKILL.md
@@ -24,7 +24,7 @@ npx pdfvision doc.pdf -p 1-5                    # page subset (also -p 1,3,5)
 npx pdfvision doc.pdf -f json                  # structured; also -f xml, -f toon
 npx pdfvision scan.pdf --ocr -f json           # OCR an image/scanned page
 npx pdfvision scan.pdf --render --render-output ./img               # PNG for a vision LLM
-npx pdfvision doc.pdf -p 3 --render --render-region 100,200,300,150 # zoom in page coordinates
+npx pdfvision doc.pdf -p 3 --render --render-region 100,200,300,150 # raw page-view units
 npx pdfvision report.pdf --search "revenue" --matches-only          # report + bboxes
 ```
 
@@ -45,7 +45,7 @@ Use opt-ins only when default native-text extraction is insufficient. Caveats: `
 | `--password` / `--password-stdin` | Encrypted PDFs; password never guessed or emitted |
 | `--geometry` | Per-text-item bbox + fontSize (heading detection); JSON/XML/TOON only |
 | `--ocr` + `--ocr-lang` | `coverage: 0%` / `nonPrintableRatio >= 0.05`; primary lang first (`jpn+eng`) — see `references/ocr.md` |
-| `--render` (+ `--render-output` / `--render-scale` / `--render-region`) | Rasterise for vision; scale 1 = half-size, 3×+ = detail (default 2); `--render-region <x,y,w,h>` zooms one block (single-page) |
+| `--render` (+`--render-output` / `--render-scale` / `--render-region`) | Rasterise; scale 1 = half-size, 3×+ = detail (default 2); region uses raw units (single-page) |
 | `--search <query>` | "Where does X appear?" `pages[N].matches[*]` with bbox; `--matches-only`, `--search-regex`, `--search-case-sensitive` |
 | `--no-cache` | Force re-extraction |
 

--- a/skills/pdfvision/references/flags.md
+++ b/skills/pdfvision/references/flags.md
@@ -125,7 +125,7 @@ Multimodal flows, typically after the density Overview already flagged the page 
 
 ## `--render-region <x,y,w,h>` — zoom into a sub-rectangle of one page
 
-Use when the agent already saw a suspect block via `--layout` / `warnings[]` and only wants visual confirmation of that bbox, not the whole page. Coordinates use unrotated page-view user-space units (typically points with default `/UserUnit`), top-left origin; single-page only. The bbox passes unchanged. On rotated pages, pdfvision maps it through the rotated viewport, so the cropped PNG's visible width/height may be swapped.
+Use when the agent already saw a suspect block via `--layout` / `warnings[]` and only wants visual confirmation of that bbox, not the whole page. Coordinates use raw unrotated page-view units with a top-left origin; single-page only. Physical points = raw value × `pages[].userUnit` (or 1 when omitted), while pixels = raw region × UserUnit × render scale. The bbox passes unchanged. On rotated pages, pdfvision maps it through the rotated viewport, so the cropped PNG's visible width/height may be swapped.
 
 ## `--search <query>` — find occurrences with bbox
 

--- a/skills/pdfvision/references/structured-output.md
+++ b/skills/pdfvision/references/structured-output.md
@@ -50,6 +50,7 @@ interface PageOverview {
   nonPrintableCount: number;      // raw count — stays discriminable when the 3dp ratio rounds to 0
   renderContentRatio?: number;    // 0..1, fraction of pixels differing from the page's dominant background (present iff --render or --ocr)
   rotation?: number;               // clockwise page rotation in degrees; present only for rotated pages
+  userUnit?: number;               // PDF /UserUnit; omitted when 1; physical points = raw page-view value * userUnit
   quality: PageQuality;           // derived classification — see below
   warningCount?: number;          // mirror of pages[N].warnings.length, omitted when no rule fired
   matchCount?: number;            // mirror of pages[N].matches.length; present-with-0 means "search ran, no hit"
@@ -59,7 +60,7 @@ interface PageOverview {
   linkCount?: number;             // furniture presence count; automatic when non-zero, present-with-0 when the matching flag ran
   annotationCount?: number;       // furniture presence count; automatic when non-zero, present-with-0 when the matching flag ran
   structureNodeCount?: number;    // count of tagged-PDF structure nodes; present iff --structure
-  width: number;                  // unrotated page-view user-space units
+  width: number;                  // raw unrotated page-view units
   height: number;
 }
 ```
@@ -94,6 +95,7 @@ interface PageResult {
   renderContentRatio?: number;   // pixel fraction differing from the page's dominant background (present iff --render or --ocr)
   quality: PageQuality;          // derived per-page classification — agent-side dispatch lives on this field
   rotation?: number;              // clockwise page rotation in degrees; present only for rotated pages
+  userUnit?: number;              // PDF /UserUnit; omitted when 1; mirrored in overview[]
   width: number;
   height: number;
   image?: string;                // absolute PNG path — present iff --render
@@ -452,7 +454,7 @@ interface VectorBox {
 }
 ```
 
-One entry per painted vector path where pdf.js reports a path bbox, plus shading fills when pdf.js exposes the active clipping bbox, excluding page-sized white background fills. This is useful for maps, symbol tables, charts, diagrams, gradient panels, table rules, form boxes, and slide shapes: content a human sees, but that is neither native text nor a raster image. Horizontal/vertical strokes are expanded to at least 0.5pt in the degenerate dimension so their boxes can feed `--render-region`. `vectorCount` remains the broad density signal for meaningful vector drawing operations; `vectorBoxes[]` is the opt-in location signal and can be shorter than `vectorCount` when a low-level op has no bbox.
+One entry per painted vector path where pdf.js reports a path bbox, plus shading fills when pdf.js exposes the active clipping bbox, excluding page-sized white background fills. This is useful for maps, symbol tables, charts, diagrams, gradient panels, table rules, form boxes, and slide shapes: content a human sees, but that is neither native text nor a raster image. Horizontal/vertical strokes are expanded to at least 0.5 raw page-view unit in the degenerate dimension so their boxes can feed `--render-region`. `vectorCount` remains the broad density signal for meaningful vector drawing operations; `vectorBoxes[]` is the opt-in location signal and can be shorter than `vectorCount` when a low-level op has no bbox.
 
 ## Visual regions (`--visual-regions`)
 
@@ -524,7 +526,9 @@ interface OcrWord {
 
 ## Coordinate system
 
-All coordinates (spans, layout blocks, image boxes, vector boxes, visual regions, form fields, `renderRegion`) use the unrotated pdf.js `page.view` visible box in PDF user-space units, with `(0, 0)` at its top-left and `y` growing downward. This box is CropBox ∩ MediaBox when a distinct valid CropBox applies, otherwise MediaBox. With default `/UserUnit`, units are typically points, not PNG pixels. `pages[].width` / `height` and `renderRegion` bounds are relative to this box, and the same bbox passes unchanged to `--render-region`. Unrotated full-page PNG overlays scale by image/page dimensions; rotated pages require the rotated pdf.js viewport transform. JSON, decoded TOON, and the library retain clockwise rotation in `pages[].rotation` and `overview[].rotation`; XML keeps page-result rotation on `<pages><page rotation="...">` but currently omits overview rotation.
+All coordinates (spans, layout blocks, image boxes, vector boxes, visual regions, form fields, `renderRegion`) use raw units from the unrotated pdf.js `page.view` visible box, with `(0, 0)` at its top-left and `y` growing downward. This box is CropBox ∩ MediaBox when a distinct valid CropBox applies, otherwise MediaBox. `pages[].userUnit` and `overview[].userUnit` expose a non-default PDF `/UserUnit` and are omitted when it is 1. Physical points = raw page-view value × UserUnit; rendered pixels = raw region × UserUnit × render scale before rotation swaps axes. `pages[].width` / `height` and `renderRegion` bounds are raw values relative to the visible box, and the same bbox passes unchanged to `--render-region`. JSON, decoded TOON, and the library retain clockwise rotation in `pages[].rotation` and `overview[].rotation`; XML keeps page-result rotation on `<pages><page rotation="...">` but currently omits overview rotation.
+
+Warning-detector thresholds and `pt` / `pt²` messages use a private physical-point view of the geometry already extracted, while public bboxes stay raw. This does not make the full extraction pipeline physically invariant: layout grouping, form-label reconstruction, vector-box shaping, and visual-region generation still include raw-unit heuristics and can produce different upstream signals for physically equivalent non-default-UserUnit PDFs.
 
 To map unrotated page coordinates onto an unrotated full-page PNG:
 
@@ -540,8 +544,8 @@ This direct scale is valid for unrotated pages. For rotated pages, use `pages[].
 
 Both flags only have effect when `--render` (or `--ocr`, which internally rasterises) is on.
 
-- **`--render-scale <n>`**: rasterisation scale multiplier. Default `2` (≈144 DPI with default `/UserUnit`). Bounds `(0, 4]`. Smaller values shrink the vision-model payload; larger values capture finer detail.
-- **`--render-region <x,y,w,h>`**: render one page sub-rectangle in the same unrotated page-view top-left system as `imageBoxes` / `layout.blocks`; the bbox passes unchanged. With default `/UserUnit`, a 400×300 unrotated region at scale 3 produces a 1200×900px PNG. Rotated pages can swap output pixel width/height because the crop is mapped through the human-visible viewport. It is single-page only and rejects out-of-bounds regions. The tuple is in the cache key and filename, and is echoed in `PageResult.renderRegion`.
+- **`--render-scale <n>`**: rasterisation scale multiplier. Default `2` (≈144 DPI). Bounds `(0, 4]`. Smaller values shrink the vision-model payload; larger values capture finer detail.
+- **`--render-region <x,y,w,h>`**: render one page sub-rectangle in the same raw unrotated page-view top-left system as `imageBoxes` / `layout.blocks`; the bbox passes unchanged. Pixel dimensions equal raw region × UserUnit × render scale. Rotated pages can swap output pixel width/height because the crop is mapped through the human-visible viewport. It is single-page only and rejects out-of-bounds regions. The tuple is in the cache key and filename, and is echoed in `PageResult.renderRegion`.
 - **`--render-visual-regions`**: render every `visualRegions[]` crop and attach `image` / `renderContentRatio` on each region. When the rendered crop contains measurable non-background pixels, `renderedContentBox` gives the tighter rendered-pixel bbox in page coordinates while leaving the source-geometry region unchanged. Region boxes include associated captions/form labels, nearby panel titles, short table lead-ins, short image labels, and nearby headings when detected, so the crop is usually closer to what a human would select before asking a vision model to read it. This uses the same output directory, `--render-scale`, cache image validation, and safe per-PDF subdirectory rules as full-page `--render`, but leaves `pages[].image` absent unless `--render` was also requested.
 
 Typical agent flow: extract with `--layout`, find a suspect block in `layout.blocks[i]` (or get its index out of `warnings[i].blockIndex`), then re-run with `--pages <N> --render --render-region <x,y,w,h>` using `blocks[i]`'s bbox to zoom in.
@@ -649,6 +653,8 @@ pdfvision doc.pdf --search "revenue" --json
 pdfvision doc.pdf -p <m.page> --render --render-region <m.bbox.x>,<m.bbox.y>,<m.bbox.width>,<m.bbox.height>
 ```
 
+`--matches-only` keeps the flat report compact but preserves non-default physical scaling as optional `pageUserUnits: [{ page, userUnit }]` metadata in JSON/TOON, equivalent `<pageUserUnits>` entries in XML, and a `Page UserUnits` summary in Markdown. The field is omitted when every selected page uses UserUnit 1. Match bboxes remain raw page-view values and pass unchanged to `--render-region`.
+
 **Semantics**:
 
 - **literal substring** by default (regex chars in the query are escaped). Pass `--search-regex` to opt into JavaScript regular expressions.
@@ -663,7 +669,7 @@ pdfvision doc.pdf -p <m.page> --render --render-region <m.bbox.x>,<m.bbox.y>,<m.
 - **Text/choice form field values are searched too**. Form-field matches come back with `source: 'formField'` and use the widget bbox, even when `--form-fields` was not requested for output; comb text widgets narrow matches to the matching cells when pdf.js exposes `maxLen`/comb appearance metadata. Choice fields search the selected option's visible display value when it differs from the exported value. Internal values that are not visible text, such as unchecked checkbox `Off` or hidden/noView widget values, are not searched.
 - **Link targets are searched too**. Link matches come back with `source: 'link'` and use the clickable link bbox, even when `--links` was not requested for output. This lets URL / destination / attachment-target searches succeed even when the visible link text is glyph-garbled.
 - **Visible FreeText annotation contents are searched too**. Annotation matches come back with `source: 'annotation'` and use the annotation bbox, even when `--annotations` was not requested for output. Sticky-note popup contents and other normally closed annotation comments are not searched.
-- **OCR text is searched too when `--ocr` is on**. OCR-derived matches come back with `source: 'ocr'`; when `ocr.words[]` is present, `bbox`/`boxes[]` use OCR word geometry in the same page-point coordinate system as native spans. If word-level reconstruction misses one or more occurrences, pdfvision supplements from full `ocr.text` with a page-level bbox so no-space scripts and OCR line-boundary differences still remain searchable. If native text, a form-field value, or visible annotation text already produced the same query/text hit on that page, the duplicate OCR hit is suppressed so the precise non-OCR bbox wins; OCR-only extra hits are still emitted.
+- **OCR text is searched too when `--ocr` is on**. OCR-derived matches come back with `source: 'ocr'`; when `ocr.words[]` is present, `bbox`/`boxes[]` use OCR word geometry in the same raw page-view coordinate system as native spans. If word-level reconstruction misses one or more occurrences, pdfvision supplements from full `ocr.text` with a page-level bbox so no-space scripts and OCR line-boundary differences still remain searchable. If native text, a form-field value, or visible annotation text already produced the same query/text hit on that page, the duplicate OCR hit is suppressed so the precise non-OCR bbox wins; OCR-only extra hits are still emitted.
 
 `pages[].matches` is **present-with-`[]`** when `--search` ran but the page had no hits — distinct from the field being absent entirely (search wasn't requested). The same posture extends to the overview, which gains a `matchCount` mirror field with the same present-with-`0` semantics.
 
@@ -678,11 +684,11 @@ pdfvision doc.pdf -p <m.page> --render --render-region <m.bbox.x>,<m.bbox.y>,<m.
     <author>...</author>
   </metadata>
   <overview>
-    <page no="1" label="i" charCount="..." imageCount="..." vectorCount="..." textCoverage="..." nonPrintableRatio="..." nonPrintableCount="..." nativeTextStatus="..." visualStatus="..." width="..." height="..."/>
+    <page no="1" label="i" charCount="..." imageCount="..." vectorCount="..." textCoverage="..." nonPrintableRatio="..." nonPrintableCount="..." nativeTextStatus="..." visualStatus="..." userUnit="2" width="..." height="..."/>
     ...
   </overview>
   <pages>
-    <page no="1" label="i" charCount="..." imageCount="..." vectorCount="..." textCoverage="..." nonPrintableRatio="..." nonPrintableCount="..." formFieldCount="..." linkCount="..." annotationCount="..." nativeTextStatus="..." visualStatus="..." rotation="90" width="..." height="..." image="...">
+    <page no="1" label="i" charCount="..." imageCount="..." vectorCount="..." textCoverage="..." nonPrintableRatio="..." nonPrintableCount="..." formFieldCount="..." linkCount="..." annotationCount="..." nativeTextStatus="..." visualStatus="..." rotation="90" userUnit="2" width="..." height="..." image="...">
       <spans>
         <span text="..." x="..." y="..." width="..." height="..." fontSize="..." fontName="..."/>
         ...

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -33,15 +33,15 @@ Options
                           same dir is written with a \`-2\` suffix and a note on stderr.
                           Without this, PNGs land under the cache (or OS tmp with --no-cache).
       --render-scale <n>  Rasterisation multiplier for --render / --render-visual-regions / --ocr.
-                          Default 2 (≈144 DPI on a letter page). Smaller values shrink the PNG
+                          Default 2 (≈144 DPI). Smaller values shrink the PNG
                           (and vision-model payload); OCR keeps at least scale 2 for recognition
                           quality; larger values capture more detail.
                           Accepts decimals; bounds (0, 4].
       --render-region <x,y,width,height>
-                          Render a sub-rectangle in unrotated page-view user-space units (typically
-                          points with default /UserUnit; top-left origin, y grows downward).
-                          With default /UserUnit, a 400×300 region at scale 3 yields a 1200×900px
-                          PNG. Single-page only: --pages must resolve to exactly one
+                          Render a sub-rectangle in raw unrotated page-view units (top-left origin,
+                          y grows downward). Physical points = raw value × pages[].userUnit (or 1
+                          when omitted); pixels = raw region × UserUnit × render scale. Single-page
+                          only: --pages must resolve to exactly one
                           page (errors otherwise). Region must fit within the page bounds.
                           Typical use: --layout to find a suspect block, then re-run with that
                           block's bbox here to zoom in.
@@ -150,7 +150,8 @@ Options
                           Match case exactly (default: insensitive).
       --matches-only      Emit a focused search report: the file, total page/match counts, and
                           a flat list of emitted matches with page, query reference, source,
-                          text, optional context, and bbox. Requires --search. The full pages/body
+                          text, optional context, and bbox. Non-default page UserUnits are retained
+                          in compact pageUserUnits metadata. Requires --search. The full pages/body
                           payload is omitted; zero matches still exits 0 with a zero-match report.
                           Works in every format. Size grows with emitted matches and context.
       --remote <url>      Download an http(s) PDF, validate the PDF header, and run extraction
@@ -182,7 +183,7 @@ Examples
   pdfvision document.pdf -p 1-3 --json                                         # specific pages, JSON
   pdfvision document.pdf -r --render-output ./images                           # render PNGs to ./images
   pdfvision slides.pdf -r --render-scale 1                                     # 1× raster (smaller PNGs)
-  pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150pt box on page 3
+  pdfvision report.pdf -p 3 -r --render-region 100,200,300,150                 # zoom into a 300×150 page-view-unit box on page 3
   pdfvision report.pdf --search "revenue" --json                               # find emitted "revenue" matches with bboxes; pipe to --render-region
   pdfvision paper.pdf --search "GPT" --search "transformer" --json             # multi-query (each match keeps its source query)
   pdfvision paper.pdf --search "BLEU" --matches-only                           # report metadata + flat match list, without page bodies

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -309,7 +309,7 @@ export async function processDocument(filePath: string, options: ProcessDocument
     const pagesWithLayout = pages.filter((p) => p.layout && p.layout.blocks.length > 0).length;
     const chromeDetectionReliable = pagesWithLayout >= 2;
     for (const p of pages) {
-      const warnings = detectPageWarnings(p, {
+      const warningContext = {
         chromeDetectionReliable,
         rasterBackedTextLayer: rasterBackedTextLayerByPage.get(p.page),
         optionalContentText: optionalContentTextByPage.get(p.page),
@@ -321,7 +321,8 @@ export async function processDocument(filePath: string, options: ProcessDocument
         invisibleText: invisibleTextByPage.get(p.page),
         opaqueFillText: opaqueFillTextByPage.get(p.page),
         pdfJsWarnings,
-      });
+      };
+      const warnings = detectPageWarnings(p, warningContext);
       if (warnings.length > 0) p.warnings = warnings;
       else delete p.warnings;
     }

--- a/src/core/processor/cacheKey.ts
+++ b/src/core/processor/cacheKey.ts
@@ -49,7 +49,7 @@ export function buildCacheKey(input: CacheKeyInput): string {
     pages: input.pages ?? 'all',
     // Bump when DocumentResult shape or extraction semantics change so older
     // entries are not handed out as fresh results.
-    format: 'structured-v137',
+    format: 'structured-v138',
     passwordHash:
       input.password !== undefined ? createHash('sha256').update(input.password).digest('hex').slice(0, 16) : null,
     render: !!input.render,

--- a/src/core/processor/overview.ts
+++ b/src/core/processor/overview.ts
@@ -22,6 +22,7 @@ export function buildOverview(
     // produced a raster.
     ...(page.renderContentRatio !== undefined && { renderContentRatio: page.renderContentRatio }),
     ...(page.rotation !== undefined && { rotation: page.rotation }),
+    ...(page.userUnit !== undefined && { userUnit: page.userUnit }),
     quality: page.quality,
     // Mirror the warnings count from each page so the top-level
     // table flags problem pages at a glance. Omitted when no

--- a/src/core/processor/pageData.ts
+++ b/src/core/processor/pageData.ts
@@ -25,6 +25,8 @@ export interface PageData {
   nonPrintableRatio: number;
   nonPrintableCount: number;
   rotation?: number;
+  /** PDF page dictionary /UserUnit. Omitted for the default value (1). */
+  userUnit?: number;
   width: number;
   height: number;
   spans?: TextSpan[];

--- a/src/core/processor/pageExtraction.ts
+++ b/src/core/processor/pageExtraction.ts
@@ -55,6 +55,7 @@ export async function extractPageData(
   const xMin = Math.min(view[0], view[2]);
   const yMin = Math.min(view[1], view[3]);
   const rotation = normalizePageRotation(page.rotate);
+  const userUnit = normalizePageUserUnit(page.userUnit);
 
   const {
     text,
@@ -250,8 +251,9 @@ export async function extractPageData(
     nonPrintableRatio: npStats.ratio,
     nonPrintableCount: npStats.count,
     ...(rotation !== undefined && { rotation }),
-    // Round to 2dp; PDF dimensions are nominally integers (Letter 612×792,
-    // A4 595×842) but encrypted/cropped PDFs can carry sub-point fractions.
+    ...(userUnit !== undefined && { userUnit }),
+    // Round to 2dp; raw page-view dimensions are commonly integers (Letter
+    // 612×792 at UserUnit 1) but encrypted/cropped PDFs can carry fractions.
     width: round2(width),
     height: round2(height),
     // Spans are only exposed publicly when --geometry is on; layout /
@@ -298,4 +300,9 @@ function normalizePageRotation(rotation: number | undefined): number | undefined
   if (typeof rotation !== 'number' || !Number.isFinite(rotation)) return undefined;
   const normalized = ((Math.round(rotation) % 360) + 360) % 360;
   return normalized === 0 ? undefined : normalized;
+}
+
+function normalizePageUserUnit(userUnit: number | undefined): number | undefined {
+  if (typeof userUnit !== 'number' || !Number.isFinite(userUnit) || userUnit <= 0 || userUnit === 1) return undefined;
+  return userUnit;
 }

--- a/src/core/processor/pageResult.ts
+++ b/src/core/processor/pageResult.ts
@@ -41,6 +41,7 @@ export function buildPageResult({
     nonPrintableCount: data.nonPrintableCount,
     ...(renderRatio !== undefined && { renderContentRatio: renderRatio }),
     ...(data.rotation !== undefined && { rotation: data.rotation }),
+    ...(data.userUnit !== undefined && { userUnit: data.userUnit }),
     width: data.width,
     height: data.height,
     ...(data.spans !== undefined && { spans: data.spans }),

--- a/src/core/processor/pageSelection.ts
+++ b/src/core/processor/pageSelection.ts
@@ -60,7 +60,7 @@ export async function resolvePageNumbers({ doc, options, renderRegion }: Resolve
     const bottom = renderRegion.y + renderRegion.height;
     if (right > pageW + RENDER_REGION_BOUNDS_EPSILON_PT || bottom > pageH + RENDER_REGION_BOUNDS_EPSILON_PT) {
       throw new Error(
-        `renderRegion ${right}×${bottom} (right×bottom) falls outside page ${pageNumbers[0]} bounds ${pageW}×${pageH} (width×height, page units)`,
+        `renderRegion ${right}×${bottom} (right×bottom) falls outside page ${pageNumbers[0]} bounds ${pageW}×${pageH} (width×height, raw page-view units)`,
       );
     }
   }

--- a/src/core/renderer/index.ts
+++ b/src/core/renderer/index.ts
@@ -68,8 +68,8 @@ export async function renderPageToBuffer(
   // With a region, the canvas captures only the sub-rectangle; without
   // it, we render the full viewport. `Math.round` matches the rounding
   // pdf.js uses on the full viewport so cropped + full pixel grids
-  // align at integer pt × integer scale. `Math.max(1, ...)` keeps
-  // sub-pixel regions (e.g. 0.4pt × scale 1 → 0.4px) from collapsing
+  // align at integer viewport pixels. `Math.max(1, ...)` keeps
+  // sub-pixel regions from collapsing
   // the canvas to a 0-dim allocation that @napi-rs/canvas refuses with
   // an opaque error.
   const canvasW = Math.max(1, Math.round(crop ? crop.width : viewport.width));

--- a/src/core/text/cjkJoin.ts
+++ b/src/core/text/cjkJoin.ts
@@ -28,7 +28,7 @@ export interface JoinItem {
   x: number;
   /** Top of the aggregate item bbox in top-down page coordinates, when geometry is available. */
   y?: number;
-  /** Text-item advance width in PDF user-space units (may be 0 on broken PDFs). */
+  /** Text-item advance width in raw page-view units (may be 0 on broken PDFs). */
   width: number;
   /** Text-matrix scale, with the item's reported or derived height as a fallback. */
   fontSize: number;

--- a/src/core/warnings/edge/offPage.ts
+++ b/src/core/warnings/edge/offPage.ts
@@ -27,8 +27,8 @@ const TRAILING_CLOSING_PUNCT = /[）」』】〕〉》｝］〙〗。、，．)\
 const CONTAINS_CJK = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}！-｠]/u;
 
 export function detectOffPage(blocks: LayoutBlock[], pageWidth: number, pageHeight: number, out: PageWarning[]): void {
-  // pageWidth / pageHeight come from the visible pdf.js page.view box,
-  // matching the zero-based coordinates used by the public geometry.
+  // pageWidth / pageHeight and blocks use the same zero-based visible coordinate
+  // space. The main warning pipeline supplies its private physical-point view.
   const tolerance = offPageTolerance(pageWidth, pageHeight);
   for (let i = 0; i < blocks.length; i++) {
     const b = blocks[i];

--- a/src/core/warnings/index.ts
+++ b/src/core/warnings/index.ts
@@ -19,6 +19,7 @@ import {
   hasUnreliableGlyphGeometry,
 } from './glyphText.js';
 import { detectInvisibleText } from './invisibleText.js';
+import { warningInputsInPhysicalPoints } from './physicalGeometry.js';
 import { detectFormLabelReadingOrderDivergence, detectReadingOrderDivergence } from './readingOrder.js';
 import { detectTextUnderOpaqueFill } from './redactionBypass.js';
 import { detectRtlScriptText } from './rtlScript.js';
@@ -96,6 +97,11 @@ export interface PageWarningContext {
  * omitting the field from the public output when the array is empty.
  */
 export function detectPageWarnings(page: PageResult, context: PageWarningContext = {}): PageWarning[] {
+  const physical = warningInputsInPhysicalPoints(page, context);
+  return detectPageWarningsInPhysicalPoints(physical.page, physical.context);
+}
+
+function detectPageWarningsInPhysicalPoints(page: PageResult, context: PageWarningContext): PageWarning[] {
   const warnings: PageWarning[] = [];
 
   detectGlyphGarbageText(page, warnings);

--- a/src/core/warnings/physicalGeometry.ts
+++ b/src/core/warnings/physicalGeometry.ts
@@ -1,0 +1,83 @@
+import type { FormField, LayoutBlock, PageResult, TextSpan } from '../../types/index.js';
+import type { OpaqueFillTextEvidence } from '../graphics/opaqueFillText.js';
+import type { PageWarningContext } from './index.js';
+
+/**
+ * Warning thresholds and pt/pt² messages operate on physical PostScript
+ * points. pdf.js deliberately leaves extracted geometry in raw `page.view`
+ * units, so a non-default PDF /UserUnit needs a private scaled view before
+ * every warning detector runs. The public result is never mutated: its raw
+ * bboxes must remain directly reusable as renderRegion input.
+ *
+ * Keep this clone deliberately bounded to geometry that warning detectors
+ * actually read. Large nested payloads such as structure trees, matches, OCR
+ * words, annotations, and visual-region provenance stay shared by reference;
+ * current detectors read only their text/flags/confidence or do not read them.
+ */
+export function warningInputsInPhysicalPoints(
+  page: PageResult,
+  context: PageWarningContext,
+): { page: PageResult; context: PageWarningContext } {
+  const userUnit = page.userUnit;
+  if (userUnit === undefined || userUnit === 1) return { page, context };
+
+  return {
+    page: {
+      ...page,
+      width: page.width * userUnit,
+      height: page.height * userUnit,
+      ...(page.spans && { spans: page.spans.map((span) => scaleSpan(span, userUnit)) }),
+      ...(page.layout && {
+        layout: {
+          ...page.layout,
+          blocks: page.layout.blocks.map((block) => scaleBlock(block, userUnit)),
+        },
+      }),
+      ...(page.imageBoxes && { imageBoxes: page.imageBoxes.map((box) => scaleBox(box, userUnit)) }),
+      ...(page.vectorBoxes && { vectorBoxes: page.vectorBoxes.map((box) => scaleBox(box, userUnit)) }),
+      ...(page.formFields && { formFields: page.formFields.map((field) => scaleFormField(field, userUnit)) }),
+    },
+    context: {
+      ...context,
+      ...(context.spans && { spans: context.spans.map((span) => scaleSpan(span, userUnit)) }),
+      ...(context.imageBoxes && { imageBoxes: context.imageBoxes.map((box) => scaleBox(box, userUnit)) }),
+      ...(context.vectorBoxes && { vectorBoxes: context.vectorBoxes.map((box) => scaleBox(box, userUnit)) }),
+      ...(context.opaqueFillText && { opaqueFillText: scaleOpaqueFillText(context.opaqueFillText, userUnit) }),
+    },
+  };
+}
+
+function scaleBox<T extends { x: number; y: number; width: number; height: number }>(box: T, factor: number): T {
+  return {
+    ...box,
+    x: box.x * factor,
+    y: box.y * factor,
+    width: box.width * factor,
+    height: box.height * factor,
+  };
+}
+
+function scaleSpan(span: TextSpan, factor: number): TextSpan {
+  return { ...scaleBox(span, factor), fontSize: span.fontSize * factor };
+}
+
+function scaleBlock(block: LayoutBlock, factor: number): LayoutBlock {
+  return {
+    ...scaleBox(block, factor),
+    lines: block.lines.map((line) => ({ ...scaleBox(line, factor), fontSize: line.fontSize * factor })),
+  };
+}
+
+function scaleFormField(field: FormField, factor: number): FormField {
+  return {
+    ...scaleBox(field, factor),
+    ...(field.label && { label: scaleBox(field.label, factor) }),
+  };
+}
+
+function scaleOpaqueFillText(evidence: OpaqueFillTextEvidence, factor: number): OpaqueFillTextEvidence {
+  return {
+    ...evidence,
+    fills: evidence.fills.map((fill) => scaleBox(fill, factor)),
+  };
+}

--- a/src/output/markdown.ts
+++ b/src/output/markdown.ts
@@ -5,7 +5,7 @@ import { appendFormFields } from './markdown/formFields.js';
 import { escapeInline, escapeTableCell, jsActionCount } from './markdown/helpers.js';
 import { appendLayoutTables } from './markdown/layoutTables.js';
 import { appendLinks } from './markdown/links.js';
-import { appendOverview, formatSize } from './markdown/overview.js';
+import { appendOverview, formatPhysicalSize } from './markdown/overview.js';
 import { appendJavaScriptActions, appendOcr, appendPageImage, appendWarnings } from './markdown/pageArtifacts.js';
 import { appendSearchMatches } from './markdown/pageSections.js';
 import { appendStructureItem, appendStructureTables, structureNodeCount } from './markdown/structure.js';
@@ -211,7 +211,7 @@ export function formatMarkdown(result: DocumentResult, options: MarkdownOptions 
     // because no search ran. Mirrors the overview Matches column.
     const matchesFragment = page.matches !== undefined ? ` · matches: ${page.matches.length}` : '';
     lines.push(
-      `_chars: ${page.charCount} · images: ${page.imageCount} · coverage: ${coveragePct}%${pageLabelFragment}${nonPrintFragment}${renderFragment}${rotationFragment}${vectorsFragment}${vectorBoxesFragment}${layoutTablesFragment}${visualRegionsFragment}${formFieldsFragment}${linksFragment}${annotationsFragment}${structureFragment}${jsActionsFragment}${nativeFragment}${visualFragment}${warningsFragment}${matchesFragment} · size: ${formatSize(page)}pt_`,
+      `_chars: ${page.charCount} · images: ${page.imageCount} · coverage: ${coveragePct}%${pageLabelFragment}${nonPrintFragment}${renderFragment}${rotationFragment}${vectorsFragment}${vectorBoxesFragment}${layoutTablesFragment}${visualRegionsFragment}${formFieldsFragment}${linksFragment}${annotationsFragment}${structureFragment}${jsActionsFragment}${nativeFragment}${visualFragment}${warningsFragment}${matchesFragment} · size: ${formatPhysicalSize(page)}_`,
     );
     const body = pageBody(page, options);
     if (body) {

--- a/src/output/markdown/overview.ts
+++ b/src/output/markdown/overview.ts
@@ -8,6 +8,13 @@ export function formatSize(page: PageResult): string {
   return `${trim(page.width)}×${trim(page.height)}`;
 }
 
+/** Compact physical size for ordinary pages; explicit raw/physical sizes when /UserUnit is non-default. */
+export function formatPhysicalSize(page: PageResult): string {
+  if (page.userUnit === undefined) return `${formatSize(page)}pt`;
+  const physical = { ...page, width: page.width * page.userUnit, height: page.height * page.userUnit };
+  return `${formatSize(page)} page-view units (UserUnit ${page.userUnit}; ${formatSize(physical)}pt physical)`;
+}
+
 interface AppendOverviewOptions {
   /** The user's explicit --layout choice. Markdown always computes
    *  layout internally, so the Blocks / Tables columns (structural
@@ -36,12 +43,13 @@ export function appendOverview(lines: string[], result: DocumentResult, options:
   const showPageLabels = result.pages.some((p) => p.pageLabel !== undefined);
   const showWarnings = result.pages.some((p) => p.warnings && p.warnings.length > 0);
   const showMatches = result.pages.some((p) => p.matches !== undefined);
+  const showUserUnit = result.pages.some((p) => p.userUnit !== undefined);
 
   lines.push('');
   lines.push('## Overview');
   lines.push('');
   lines.push(
-    `| Page |${showPageLabels ? ' Label |' : ''} Chars | Images | Coverage |${showNonPrint ? ' NonPrint |' : ''}${showRender ? ' Render |' : ''} Size (pt) |${showRotation ? ' Rotation |' : ''}${showVectors ? ' Vectors |' : ''}${showVectorBoxes ? ' VectorBoxes |' : ''}${showLayoutTables ? ' Tables |' : ''}${showVisualRegions ? ' VisualRegions |' : ''}${showBlocks ? ' Blocks |' : ''}${showWarnings ? ' Warnings |' : ''}${showMatches ? ' Matches |' : ''}${showFormFields ? ' Fields |' : ''}${showLinks ? ' Links |' : ''}${showAnnotations ? ' Annots |' : ''}${showStructure ? ' Structure |' : ''}${showPageJsActions ? ' JS Actions |' : ''}`,
+    `| Page |${showPageLabels ? ' Label |' : ''} Chars | Images | Coverage |${showNonPrint ? ' NonPrint |' : ''}${showRender ? ' Render |' : ''} ${showUserUnit ? 'Size' : 'Size (pt)'} |${showRotation ? ' Rotation |' : ''}${showVectors ? ' Vectors |' : ''}${showVectorBoxes ? ' VectorBoxes |' : ''}${showLayoutTables ? ' Tables |' : ''}${showVisualRegions ? ' VisualRegions |' : ''}${showBlocks ? ' Blocks |' : ''}${showWarnings ? ' Warnings |' : ''}${showMatches ? ' Matches |' : ''}${showFormFields ? ' Fields |' : ''}${showLinks ? ' Links |' : ''}${showAnnotations ? ' Annots |' : ''}${showStructure ? ' Structure |' : ''}${showPageJsActions ? ' JS Actions |' : ''}`,
   );
   lines.push(
     `| ---: |${showPageLabels ? ' --- |' : ''} ---: | ---: | ---: |${showNonPrint ? ' ---: |' : ''}${showRender ? ' ---: |' : ''} ---: |${showRotation ? ' ---: |' : ''}${showVectors ? ' ---: |' : ''}${showVectorBoxes ? ' ---: |' : ''}${showLayoutTables ? ' ---: |' : ''}${showVisualRegions ? ' ---: |' : ''}${showBlocks ? ' ---: |' : ''}${showWarnings ? ' ---: |' : ''}${showMatches ? ' ---: |' : ''}${showFormFields ? ' ---: |' : ''}${showLinks ? ' ---: |' : ''}${showAnnotations ? ' ---: |' : ''}${showStructure ? ' ---: |' : ''}${showPageJsActions ? ' ---: |' : ''}`,
@@ -64,6 +72,7 @@ export function appendOverview(lines: string[], result: DocumentResult, options:
       showAnnotations,
       showStructure,
       showPageJsActions,
+      showUserUnit,
     });
   }
 }
@@ -85,6 +94,7 @@ interface OverviewColumns {
   showAnnotations: boolean;
   showStructure: boolean;
   showPageJsActions: boolean;
+  showUserUnit: boolean;
 }
 
 function appendOverviewRow(lines: string[], page: PageResult, columns: OverviewColumns): void {
@@ -110,7 +120,8 @@ function appendOverviewRow(lines: string[], page: PageResult, columns: OverviewC
   const annotationsCell = columns.showAnnotations ? ` ${page.annotationCount ?? page.annotations?.length ?? 0} |` : '';
   const structureCell = columns.showStructure ? ` ${structureNodeCount(page.structure)} |` : '';
   const jsActionsCell = columns.showPageJsActions ? ` ${jsActionCount(page.jsActions)} |` : '';
+  const size = columns.showUserUnit ? formatPhysicalSize(page) : formatSize(page);
   lines.push(
-    `| ${page.page} |${pageLabelCell} ${page.charCount} | ${page.imageCount} | ${coveragePct}% |${nonPrintCell}${renderCell} ${formatSize(page)} |${rotationCell}${vectorsCell}${vectorBoxesCell}${layoutTablesCell}${visualRegionsCell}${blocksCell}${warningsCell}${matchesCell}${formFieldsCell}${linksCell}${annotationsCell}${structureCell}${jsActionsCell}`,
+    `| ${page.page} |${pageLabelCell} ${page.charCount} | ${page.imageCount} | ${coveragePct}% |${nonPrintCell}${renderCell} ${size} |${rotationCell}${vectorsCell}${vectorBoxesCell}${layoutTablesCell}${visualRegionsCell}${blocksCell}${warningsCell}${matchesCell}${formFieldsCell}${linksCell}${annotationsCell}${structureCell}${jsActionsCell}`,
   );
 }

--- a/src/output/matchesOnly.ts
+++ b/src/output/matchesOnly.ts
@@ -16,8 +16,12 @@ import { escapeAttr, escapeText } from './xml/helpers.js';
  *
  * The JSON/TOON model has this flat shape; Markdown and XML expose the same
  * report metadata and match fields in their native representations:
- *   { file, totalPages, queries, totalMatches, matches: [{ page,
- *     queryIndex, source, text, context?, bbox: {x,y,width,height} }] }
+ *   { file, totalPages, queries, totalMatches, pageUserUnits?:
+ *     [{ page, userUnit }], matches: [{ page, queryIndex, source, text,
+ *     context?, bbox: {x,y,width,height} }] }
+ * `pageUserUnits` is omitted when every selected page uses the default value
+ * 1. It keeps raw match boxes physically interpretable without restoring the
+ * full pages[] payload; boxes still pass unchanged to renderRegion.
  */
 
 /** One flattened match, carrying the parent query string (markdown shows
@@ -37,6 +41,7 @@ interface MatchesOnlyModel {
   totalPages: number;
   queries: string[];
   totalMatches: number;
+  pageUserUnits?: { page: number; userUnit: number }[];
   matches: FlatMatch[];
 }
 
@@ -58,7 +63,17 @@ function buildModel(result: DocumentResult, queries: string[]): MatchesOnlyModel
       });
     }
   }
-  return { file: result.file, totalPages: result.totalPages, queries, totalMatches: matches.length, matches };
+  const pageUserUnits = result.pages.flatMap((page) =>
+    page.userUnit === undefined ? [] : [{ page: page.page, userUnit: page.userUnit }],
+  );
+  return {
+    file: result.file,
+    totalPages: result.totalPages,
+    queries,
+    totalMatches: matches.length,
+    ...(pageUserUnits.length > 0 && { pageUserUnits }),
+    matches,
+  };
 }
 
 /** Serialisable entry with the query string dropped — json/xml/toon key
@@ -80,6 +95,7 @@ function serializableModel(model: MatchesOnlyModel) {
     totalPages: model.totalPages,
     queries: model.queries,
     totalMatches: model.totalMatches,
+    ...(model.pageUserUnits !== undefined && { pageUserUnits: model.pageUserUnits }),
     matches: model.matches.map(serializableEntry),
   };
 }
@@ -100,6 +116,11 @@ function formatMarkdown(model: MatchesOnlyModel): string {
   lines.push('');
   lines.push(`- **Pages:** ${model.totalPages}`);
   lines.push(`- **Matches:** ${summaryLine(model)}`);
+  if (model.pageUserUnits) {
+    lines.push(
+      `- **Page UserUnits:** ${model.pageUserUnits.map((item) => `${item.page}=${item.userUnit}`).join(', ')}`,
+    );
+  }
   if (model.totalMatches === 0) return lines.join('\n');
 
   lines.push('');
@@ -129,6 +150,11 @@ function formatXml(model: MatchesOnlyModel): string {
   out.push('<queries>');
   for (const q of model.queries) out.push(`<query>${escapeText(q)}</query>`);
   out.push('</queries>');
+  if (model.pageUserUnits) {
+    out.push('<pageUserUnits>');
+    for (const item of model.pageUserUnits) out.push(`<page no="${item.page}" userUnit="${item.userUnit}"/>`);
+    out.push('</pageUserUnits>');
+  }
   for (const m of model.matches) {
     const attrs = [
       `page="${m.page}"`,

--- a/src/output/xml/documentSections.ts
+++ b/src/output/xml/documentSections.ts
@@ -155,6 +155,7 @@ function appendOverview(out: string[], result: DocumentResult): void {
     ];
     if (p.pageLabel !== undefined) ovAttrs.push(`label="${escapeAttr(p.pageLabel)}"`);
     if (p.renderContentRatio !== undefined) ovAttrs.push(`renderContentRatio="${p.renderContentRatio}"`);
+    if (p.userUnit !== undefined) ovAttrs.push(`userUnit="${p.userUnit}"`);
     ovAttrs.push(`nativeTextStatus="${p.quality.nativeTextStatus}"`);
     if (p.quality.visualStatus !== undefined) ovAttrs.push(`visualStatus="${p.quality.visualStatus}"`);
     if (p.warningCount !== undefined) ovAttrs.push(`warningCount="${p.warningCount}"`);

--- a/src/output/xml/page.ts
+++ b/src/output/xml/page.ts
@@ -32,6 +32,7 @@ function pageAttributes(page: PageResult): string[] {
   if (page.annotationCount !== undefined) attrs.push(`annotationCount="${page.annotationCount}"`);
   if (page.renderContentRatio !== undefined) attrs.push(`renderContentRatio="${page.renderContentRatio}"`);
   if (page.rotation !== undefined) attrs.push(`rotation="${page.rotation}"`);
+  if (page.userUnit !== undefined) attrs.push(`userUnit="${page.userUnit}"`);
   attrs.push(`nativeTextStatus="${page.quality.nativeTextStatus}"`);
   if (page.quality.visualStatus !== undefined) attrs.push(`visualStatus="${page.quality.visualStatus}"`);
   attrs.push(`width="${page.width}"`, `height="${page.height}"`);

--- a/src/types/annotations.ts
+++ b/src/types/annotations.ts
@@ -20,7 +20,7 @@ export interface PageAnnotationPoint {
 }
 
 export interface PageAnnotationBorder {
-  /** Border width in page user-space units. */
+  /** Border width in raw page-view units. */
   width?: number;
   /** PDF border style such as solid, dashed, beveled, inset, or underline. */
   style?: string;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -2,9 +2,10 @@ export type OutputFormat = 'markdown' | 'json' | 'xml' | 'toon';
 
 /**
  * Sub-rectangle of a page to rasterise. Coordinates use the unrotated pdf.js
- * page view box in PDF user-space units (typically points with the default
- * `/UserUnit`) and the top-down origin used by `spans`, `layout.blocks`, and
- * `imageBoxes` — `(0, 0)` is the page's top-left, `y` grows downward.
+ * page view box in raw page-view units and the top-down origin used by
+ * `spans`, `layout.blocks`, and `imageBoxes` — `(0, 0)` is the page's
+ * top-left, `y` grows downward. Multiply by the page's `userUnit` (or 1 when
+ * omitted) to obtain physical points.
  * width / height must be positive; bounds and single-page checks live
  * in the processor so this stays a pure shape type.
  */

--- a/src/types/layout.ts
+++ b/src/types/layout.ts
@@ -3,24 +3,24 @@
  * character, word, or longer string; its bbox covers the whole item rather
  * than individual glyph outlines, and adjacent items are not merged or split
  * in public spans. The rounded aggregate axis-aligned bbox uses unrotated
- * page-view user-space units (typically points with the default `/UserUnit`),
- * with `(0, 0)` at the top-left and y increasing downward. These are page
- * coordinates, not PNG pixels; unrotated overlays scale by image/page
- * dimensions, while rotated overlays use the pdf.js viewport transform.
+ * raw page-view units, with `(0, 0)` at the top-left and y increasing
+ * downward. Multiply by `pages[].userUnit` (or 1 when omitted) for physical
+ * points. These are page coordinates, not PNG pixels; rendered pixels equal
+ * raw lengths × UserUnit × render scale before rotation swaps axes.
  */
 export interface TextSpan {
   /** Text-item content. Already NFKC-normalized and C0-cleaned when `normalize` is on. */
   text: string;
-  /** Top-left x in unrotated page user-space units. */
+  /** Top-left x in raw unrotated page-view units. */
   x: number;
-  /** Top-left y in unrotated page user-space units; y grows downward. */
+  /** Top-left y in raw unrotated page-view units; y grows downward. */
   y: number;
-  /** Rounded aggregate text-item width in page user-space units. */
+  /** Rounded aggregate text-item width in raw page-view units. */
   width: number;
-  /** Rounded aggregate height in page user-space units; matrix-derived when pdf.js reports 0. */
+  /** Rounded aggregate height in raw page-view units; matrix-derived when pdf.js reports 0. */
   height: number;
   /**
-   * Approximate font size in page user-space units: the largest finite,
+   * Approximate font size in raw page-view units: the largest finite,
    * non-zero text-matrix scale, falling back to the reported/effective item
    * height when both matrix scales are unusable.
    */

--- a/src/types/pageOverview.ts
+++ b/src/types/pageOverview.ts
@@ -46,6 +46,8 @@ export interface PageOverview {
    * omits this overview attribute; JSON, decoded TOON, and the library retain it.
    */
   rotation?: number;
+  /** Mirror of {@link PageResult.userUnit}; omitted for the default value of 1. */
+  userUnit?: number;
   /**
    * Mirror of {@link PageResult.quality} so the overview can flag
    * unusable / blank pages at a glance without descending into

--- a/src/types/pageResult.ts
+++ b/src/types/pageResult.ts
@@ -25,7 +25,7 @@ export interface PageResult {
    * Rendered region echoed back when `renderRegion` was passed to the
    * extraction call. Lets consumers tell whether `pages[].image` is the
    * full page or a sub-rectangle without having to track the original
-   * request. Coordinates use the unrotated page-view user-space system
+   * request. Coordinates use the raw unrotated page-view system
    * (top-left origin), matching the input. Omitted for full-page renders.
    */
   renderRegion?: RenderRegion;
@@ -125,13 +125,19 @@ export interface PageResult {
    */
   rotation?: number;
   /**
+   * Physical scale declared by the PDF page dictionary. Omitted for the
+   * default value of 1. Geometry remains in raw pdf.js `page.view` units;
+   * multiply a raw coordinate or length by `userUnit` to obtain points.
+   */
+  userUnit?: number;
+  /**
    * Page width in the unrotated pdf.js `page.view` visible box. This is the
    * CropBox/MediaBox intersection when a distinct valid CropBox applies,
-   * otherwise the MediaBox. With default `/UserUnit`, units are typically
-   * PostScript points (1/72 in).
+   * otherwise the MediaBox. The value is in raw page-view units. Multiply by
+   * `userUnit` (or 1 when omitted) to obtain PostScript points (1/72 in).
    */
   width: number;
-  /** Page-view height in PDF user-space units. See {@link width}. */
+  /** Page-view height in raw page-view units. See {@link width}. */
   height: number;
   /**
    * Per-text-item geometry, only present when `geometry: true` was passed.
@@ -166,7 +172,7 @@ export interface PageResult {
    * where pdf.js reports a path bbox, plus shading fills when pdf.js
    * exposes the active clipping bbox, excluding page-sized white
    * background fills. Coordinates use the same unrotated page-view top-left
-   * user-space system as `spans`, `layout.blocks`, and `imageBoxes`.
+   * raw page-view system as `spans`, `layout.blocks`, and `imageBoxes`.
    */
   vectorBoxes?: VectorBox[];
   /**

--- a/src/types/processDocumentOptions.ts
+++ b/src/types/processDocumentOptions.ts
@@ -50,10 +50,10 @@ export interface ProcessDocumentOptions {
   renderScale?: number;
   /**
    * Sub-rectangle of the page to rasterise instead of the full page. It uses
-   * unrotated page-view user-space units (typically points with the default
-   * `/UserUnit`), with a top-left origin and y growing downward, matching
-   * `pages[].spans`, `layout.blocks`, and `imageBoxes`. With default
-   * `/UserUnit`, a 400×300 region at scale 3 yields a 1200×900px PNG.
+   * raw unrotated page-view units, with a top-left origin and y growing
+   * downward, matching `pages[].spans`, `layout.blocks`, and `imageBoxes`.
+   * Physical points equal raw values × the page's `userUnit` (or 1 when
+   * omitted); pixels equal raw region × UserUnit × render scale.
    *
    * Typical agent flow: run with `--layout`, pick a suspicious block from
    * `warnings[]` / `layout.blocks[blockIndex]`, then re-run with that

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -3,7 +3,7 @@
  * page. Emitted per match, not per page — so the same query found
  * three times on page 5 yields three SearchMatch entries with `page: 5`.
  *
- * The bbox uses unrotated page-view user-space units (top-left origin, y grows
+ * The bbox uses raw unrotated page-view units (top-left origin, y grows
  * downward), matching {@link TextSpan} / {@link LayoutBlock} / {@link ImageBox}.
  * It passes unchanged to a follow-up `renderRegion` call.
  */

--- a/tests/core/processDocument.test.ts
+++ b/tests/core/processDocument.test.ts
@@ -1,10 +1,15 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, resolve } from 'node:path';
+import { decode } from '@toon-format/toon';
 import PDFDocument from 'pdfkit';
 import { describe, expect, it } from 'vitest';
 import { buildPageStructure } from '../../src/core/document/structure.js';
 import { processDocument, processFile } from '../../src/core/processor.js';
+import { formatJson } from '../../src/output/json.js';
+import { formatMarkdown } from '../../src/output/markdown.js';
+import { formatToon } from '../../src/output/toon.js';
+import { formatXml } from '../../src/output/xml.js';
 
 const SAMPLE_PDF = resolve(__dirname, '../fixtures/sample.pdf');
 const SAMPLE_JA_PDF = resolve(__dirname, '../fixtures/sample-ja.pdf');
@@ -161,6 +166,47 @@ function buildPdfWithCroppedView(): Uint8Array {
     '<< /Type /Catalog /Pages 2 0 R >>',
     '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
     '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /CropBox [20 30 220 230] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>',
+    `<< /Length ${length} >>\nstream\n${stream}\nendstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ]);
+}
+
+function buildPdfWithUserUnit(
+  options: {
+    userUnit?: number;
+    width?: number;
+    height?: number;
+    fontSize?: number;
+    textX?: number;
+    textY?: number;
+  } = {},
+): Uint8Array {
+  const userUnit = options.userUnit ?? 1;
+  const width = options.width ?? 200;
+  const height = options.height ?? 100;
+  const fontSize = options.fontSize ?? 10;
+  const textX = options.textX ?? 20;
+  const textY = options.textY ?? 60;
+  const stream = `BT /F1 ${fontSize} Tf ${textX} ${textY} Td (UserUnit geometry) Tj ET`;
+  const length = Buffer.byteLength(stream, 'binary');
+  return buildRawPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${width} ${height}]${userUnit === 1 ? '' : ` /UserUnit ${userUnit}`} /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>`,
+    `<< /Length ${length} >>\nstream\n${stream}\nendstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ]);
+}
+
+function buildPdfWithMixedUserUnits(): Uint8Array {
+  const stream = 'BT /F1 10 Tf 20 60 Td (UserUnit overview) Tj ET';
+  const length = Buffer.byteLength(stream, 'binary');
+  return buildRawPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /UserUnit 2 /Resources << /Font << /F1 7 0 R >> >> /Contents 5 0 R >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /Resources << /Font << /F1 7 0 R >> >> /Contents 6 0 R >>',
+    `<< /Length ${length} >>\nstream\n${stream}\nendstream`,
     `<< /Length ${length} >>\nstream\n${stream}\nendstream`,
     '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
   ]);
@@ -482,12 +528,101 @@ describe('processDocument', () => {
     expect(result.layers).toEqual({ groups: [] });
   });
 
-  it('reports page dimensions in points so agents can reason about layout', async () => {
-    // sample.pdf is US Letter (612 × 792 pt). Width / height let downstream
+  it('reports default-UserUnit page dimensions in raw page-view units', async () => {
+    // sample.pdf is US Letter (612 × 792 raw units with UserUnit 1). Width / height let downstream
     // consumers map render coords / future bbox data back onto the page.
     const result = await processDocument(SAMPLE_PDF, { noCache: true });
     expect(result.pages[0].width).toBe(612);
     expect(result.pages[0].height).toBe(792);
+    expect(result.pages[0].userUnit).toBeUndefined();
+  });
+
+  it('surfaces non-default UserUnit without changing raw page or span geometry', async () => {
+    const defaultUnit = await processDocument('memory://user-unit-default.pdf', {
+      sourceData: buildPdfWithUserUnit(),
+      geometry: true,
+      noCache: true,
+    });
+    const doubleUnit = await processDocument('memory://user-unit-2.pdf', {
+      sourceData: buildPdfWithUserUnit({ userUnit: 2 }),
+      geometry: true,
+      noCache: true,
+    });
+
+    expect(defaultUnit.pages[0].userUnit).toBeUndefined();
+    expect(doubleUnit.pages[0].userUnit).toBe(2);
+    expect(doubleUnit.pages[0].width).toBe(200);
+    expect(doubleUnit.pages[0].height).toBe(100);
+    expect(doubleUnit.pages[0].spans).toEqual(defaultUnit.pages[0].spans);
+  });
+
+  it('preserves non-default UserUnit through a structured cache round-trip', async () => {
+    const cacheRoot = mkdtempSync(resolve(tmpdir(), 'pdfvision-user-unit-cache-'));
+    const previousCache = process.env.PDFVISION_CACHE_DIR;
+    process.env.PDFVISION_CACHE_DIR = cacheRoot;
+    try {
+      const options = { sourceData: buildPdfWithUserUnit({ userUnit: 2 }), geometry: true } as const;
+      const fresh = await processDocument('memory://user-unit-cache.pdf', options);
+      const cached = await processDocument('memory://user-unit-cache.pdf', options);
+      expect(cached).toEqual(fresh);
+      expect(cached.pages[0].userUnit).toBe(2);
+    } finally {
+      if (previousCache === undefined) delete process.env.PDFVISION_CACHE_DIR;
+      else process.env.PDFVISION_CACHE_DIR = previousCache;
+      rmSync(cacheRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('mirrors only non-default UserUnits into the overview and every full formatter', async () => {
+    const result = await processDocument('memory://mixed-user-units.pdf', {
+      sourceData: buildPdfWithMixedUserUnits(),
+      geometry: true,
+      noCache: true,
+    });
+
+    expect(result.pages.map((page) => page.userUnit)).toEqual([2, undefined]);
+    expect(result.overview?.map((page) => page.userUnit)).toEqual([2, undefined]);
+
+    const json = JSON.parse(formatJson(result));
+    expect(json.pages[0].userUnit).toBe(2);
+    expect(json.pages[1]).not.toHaveProperty('userUnit');
+    expect(json.overview[0].userUnit).toBe(2);
+    expect(decode(formatToon(result))).toEqual(json);
+
+    const xml = formatXml(result);
+    expect(xml).toMatch(/<overview>[\s\S]*<page no="1"[^>]*userUnit="2"/);
+    expect(xml).toMatch(/<page no="1"[^>]*userUnit="2"/);
+    expect(xml).not.toMatch(/<page no="2"[^>]*userUnit=/);
+
+    const markdown = formatMarkdown(result);
+    expect(markdown).toContain('| Page | Chars | Images | Coverage | Size |');
+    expect(markdown).toContain('200×100 page-view units (UserUnit 2; 400×200pt physical)');
+    expect(markdown).toContain('· size: 200×100pt_');
+  });
+
+  it('keeps warning behavior and point-based messages equivalent for physically identical raw PDFs', async () => {
+    const defaultUnit = await processDocument('memory://physical-warning-default.pdf', {
+      sourceData: buildPdfWithUserUnit({ fontSize: 1.5 }),
+      geometry: true,
+      noCache: true,
+    });
+    const doubleUnit = await processDocument('memory://physical-warning-user-unit-2.pdf', {
+      sourceData: buildPdfWithUserUnit({
+        userUnit: 2,
+        width: 100,
+        height: 50,
+        fontSize: 0.75,
+        textX: 10,
+        textY: 30,
+      }),
+      geometry: true,
+      noCache: true,
+    });
+
+    expect(doubleUnit.pages[0].warnings).toEqual(defaultUnit.pages[0].warnings);
+    expect(doubleUnit.pages[0].warnings).toContainEqual(expect.objectContaining({ code: 'tiny_native_text_noise' }));
+    expect(doubleUnit.pages[0].spans?.[0].fontSize).toBe(0.75);
+    expect(defaultUnit.pages[0].spans?.[0].fontSize).toBe(1.5);
   });
 
   it('omits the top-level overview field on single-page docs', async () => {
@@ -1390,6 +1525,42 @@ describe('processDocument', () => {
     const img = await loadImage(result.pages[0].image as string);
     expect(img.width).toBe(842);
     expect(img.height).toBe(596);
+  });
+
+  it('applies UserUnit to full-page and cropped pixel dimensions while keeping raw renderRegion input', async () => {
+    const { loadImage } = await import('@napi-rs/canvas');
+    const sourceData = buildPdfWithUserUnit({ userUnit: 2 });
+    const full = await processDocument('memory://user-unit-full-render.pdf', {
+      sourceData,
+      render: true,
+      renderScale: 1,
+      noCache: true,
+    });
+    const fullImage = await loadImage(full.pages[0].image as string);
+    expect(full.pages[0]).toMatchObject({ width: 200, height: 100, userUnit: 2 });
+    expect({ width: fullImage.width, height: fullImage.height }).toEqual({ width: 400, height: 200 });
+
+    const cropped = await processDocument('memory://user-unit-crop-render.pdf', {
+      sourceData,
+      render: true,
+      renderRegion: { x: 10, y: 15, width: 50, height: 25 },
+      renderScale: 1,
+      noCache: true,
+    });
+    const cropImage = await loadImage(cropped.pages[0].image as string);
+    expect(cropped.pages[0].renderRegion).toEqual({ x: 10, y: 15, width: 50, height: 25 });
+    expect({ width: cropImage.width, height: cropImage.height }).toEqual({ width: 100, height: 50 });
+  });
+
+  it('validates renderRegion against raw page-view bounds on non-default UserUnit pages', async () => {
+    await expect(
+      processDocument('memory://user-unit-bounds.pdf', {
+        sourceData: buildPdfWithUserUnit({ userUnit: 2 }),
+        render: true,
+        renderRegion: { x: 160, y: 0, width: 50, height: 25 },
+        noCache: true,
+      }),
+    ).rejects.toThrow(/falls outside page 1 bounds 200×100/);
   });
 
   it('keeps a sub-pixel region from collapsing the canvas to a zero dimension', async () => {

--- a/tests/core/warnings/userUnit.test.ts
+++ b/tests/core/warnings/userUnit.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { detectPageWarnings } from '../../../src/core/warnings/index.js';
+import { warningInputsInPhysicalPoints } from '../../../src/core/warnings/physicalGeometry.js';
+import type { LayoutBlock, PageResult, TextSpan } from '../../../src/types/index.js';
+
+function page(overrides: Partial<PageResult> = {}): PageResult {
+  return {
+    page: 1,
+    text: '',
+    charCount: 0,
+    imageCount: 0,
+    vectorCount: 0,
+    textCoverage: 0,
+    nonPrintableRatio: 0,
+    nonPrintableCount: 0,
+    width: 612,
+    height: 792,
+    quality: { nativeTextStatus: 'ok' },
+    ...overrides,
+  };
+}
+
+function block(x: number, y: number, width: number, height: number): LayoutBlock {
+  return { text: 'closing body text', x, y, width, height, lines: [] };
+}
+
+function span(x: number, y: number, width: number, height: number, fontSize: number): TextSpan {
+  return { text: 'unterminated native text', x, y, width, height, fontSize };
+}
+
+describe('warning UserUnit normalization', () => {
+  it('scales every absolute geometry collection consumed by warning detectors without mutating output', () => {
+    const source = page({
+      userUnit: 2,
+      width: 306,
+      height: 396,
+      spans: [span(10, 20, 30, 5, 5)],
+      layout: {
+        blocks: [
+          {
+            ...block(25, 350, 250, 40),
+            lines: [{ text: 'line', x: 25, y: 350, width: 100, height: 5, fontSize: 5 }],
+          },
+        ],
+      },
+      imageBoxes: [{ x: 1, y: 2, width: 3, height: 4 }],
+      vectorBoxes: [{ x: 5, y: 6, width: 7, height: 8 }],
+      formFields: [
+        {
+          name: 'field',
+          type: 'text',
+          x: 9,
+          y: 10,
+          width: 11,
+          height: 12,
+          label: { text: 'Field label', relation: 'left', x: 1, y: 2, width: 3, height: 4 },
+        },
+      ],
+    });
+    const context = {
+      spans: [span(2, 3, 4, 5, 6)],
+      imageBoxes: [{ x: 3, y: 4, width: 5, height: 6 }],
+      vectorBoxes: [{ x: 4, y: 5, width: 6, height: 7 }],
+      opaqueFillText: {
+        textRuns: ['secret'],
+        fills: [{ x: 5, y: 6, width: 7, height: 8, precedingTextRunCount: 1 }],
+      },
+    };
+
+    const physical = warningInputsInPhysicalPoints(source, context);
+    expect(physical.page).toMatchObject({ width: 612, height: 792 });
+    expect(physical.page.spans?.[0]).toMatchObject({ x: 20, y: 40, width: 60, height: 10, fontSize: 10 });
+    expect(physical.page.layout?.blocks[0]).toMatchObject({ x: 50, y: 700, width: 500, height: 80 });
+    expect(physical.page.layout?.blocks[0].lines[0]).toMatchObject({
+      x: 50,
+      y: 700,
+      width: 200,
+      height: 10,
+      fontSize: 10,
+    });
+    expect(physical.page.imageBoxes?.[0]).toEqual({ x: 2, y: 4, width: 6, height: 8 });
+    expect(physical.page.vectorBoxes?.[0]).toEqual({ x: 10, y: 12, width: 14, height: 16 });
+    expect(physical.page.formFields?.[0]).toMatchObject({
+      x: 18,
+      y: 20,
+      width: 22,
+      height: 24,
+      label: { x: 2, y: 4, width: 6, height: 8 },
+    });
+    expect(physical.context.spans?.[0]).toMatchObject({ x: 4, y: 6, width: 8, height: 10, fontSize: 12 });
+    expect(physical.context.imageBoxes?.[0]).toEqual({ x: 6, y: 8, width: 10, height: 12 });
+    expect(physical.context.vectorBoxes?.[0]).toEqual({ x: 8, y: 10, width: 12, height: 14 });
+    expect(physical.context.opaqueFillText?.fills[0]).toEqual({
+      x: 10,
+      y: 12,
+      width: 14,
+      height: 16,
+      precedingTextRunCount: 1,
+    });
+    expect(source.width).toBe(306);
+    expect(source.spans?.[0].x).toBe(10);
+  });
+
+  it('keeps direct layout warning thresholds and point messages physically equivalent', () => {
+    const defaultUnit = detectPageWarnings(page({ layout: { blocks: [block(50, 700, 500, 80)] } }));
+    const doubleUnit = detectPageWarnings(
+      page({
+        userUnit: 2,
+        width: 306,
+        height: 396,
+        layout: { blocks: [block(25, 350, 250, 40)] },
+      }),
+    );
+
+    expect(doubleUnit).toEqual(defaultUnit);
+    expect(doubleUnit).toContainEqual(
+      expect.objectContaining({
+        code: 'near_bottom_edge',
+        blockIndex: 0,
+        message: expect.stringContaining('12.0pt above the page bottom'),
+      }),
+    );
+  });
+
+  it('scales context-only spans and opaque-fill evidence before every detector', () => {
+    const defaultSpan = span(545, 100, 70, 10, 10);
+    const scaledSpan = span(272.5, 50, 35, 5, 5);
+    const defaultContext = {
+      spans: [defaultSpan],
+      opaqueFillText: {
+        textRuns: [defaultSpan.text],
+        fills: [{ x: 545, y: 100, width: 70, height: 10, precedingTextRunCount: 1 }],
+      },
+    };
+    const scaledContext = {
+      spans: [scaledSpan],
+      opaqueFillText: {
+        textRuns: [scaledSpan.text],
+        fills: [{ x: 272.5, y: 50, width: 35, height: 5, precedingTextRunCount: 1 }],
+      },
+    };
+
+    const defaultUnit = detectPageWarnings(page({ text: defaultSpan.text }), defaultContext);
+    const doubleUnit = detectPageWarnings(
+      page({ text: scaledSpan.text, width: 306, height: 396, userUnit: 2 }),
+      scaledContext,
+    );
+
+    expect(doubleUnit).toEqual(defaultUnit);
+    expect(doubleUnit.map((warning) => warning.code)).toEqual(['page_edge_text_truncated', 'text_under_opaque_fill']);
+  });
+});

--- a/tests/output/matchesOnly.test.ts
+++ b/tests/output/matchesOnly.test.ts
@@ -151,6 +151,27 @@ describe('formatMatchesOnly', () => {
     expect(recovered).toBe(unsafe);
   });
 
+  it('preserves only non-default page UserUnits across every compact format', () => {
+    const result = makeResult([
+      makePage({ page: 1, userUnit: 2, matches: [match({ page: 1 })] }),
+      makePage({ page: 2, matches: [] }),
+    ]);
+
+    const json = JSON.parse(formatMatchesOnly(result, 'json', ['BLEU']));
+    expect(json.pageUserUnits).toEqual([{ page: 1, userUnit: 2 }]);
+    expect(decode(formatMatchesOnly(result, 'toon', ['BLEU']))).toEqual(json);
+    expect(formatMatchesOnly(result, 'xml', ['BLEU'])).toContain(
+      '<pageUserUnits>\n<page no="1" userUnit="2"/>\n</pageUserUnits>',
+    );
+    expect(formatMatchesOnly(result, 'markdown', ['BLEU'])).toContain('- **Page UserUnits:** 1=2');
+
+    const defaultJson = JSON.parse(formatMatchesOnly(THREE_HITS, 'json', ['BLEU']));
+    expect(defaultJson.pageUserUnits).toBeUndefined();
+    expect(formatMatchesOnly(THREE_HITS, 'xml', ['BLEU'])).not.toContain('pageUserUnits');
+    expect(formatMatchesOnly(THREE_HITS, 'markdown', ['BLEU'])).not.toContain('Page UserUnits');
+    expect(decode(formatMatchesOnly(THREE_HITS, 'toon', ['BLEU']))).not.toHaveProperty('pageUserUnits');
+  });
+
   it('multi-query: keeps queryIndex per hit and lists every query', () => {
     const result = makeResult([
       makePage({


### PR DESCRIPTION
## Summary

- preserve every public page bbox in raw pdf.js page-view coordinates while exposing non-default PDF `/UserUnit` values
- define the physical-point and render-pixel conversion formulas across structured output, CLI help, README, docs, and the bundled agent skill
- normalize warning thresholds through a private physical-point projection without mutating emitted geometry or changing default-UserUnit output

## Contract

- `pages[].userUnit` and `overview[].userUnit` are emitted only when the page value is not `1`
- physical points are `raw page-view units × userUnit`
- rendered pixels are `raw page-view units × userUnit × render scale`; DPI remains `72 × render scale`
- compact `--matches-only` output reports non-default values through `pageUserUnits`, including selected zero-hit pages
- cache keys advance so prior results cannot hide the new metadata

Upstream layout grouping, form-label reconstruction, vector shaping, and visual-region generation still apply some absolute thresholds in raw page-view units. The public documentation now states that bounded limitation explicitly.

## Verification

- focused UserUnit, geometry, and output suites: 8 files / 308 tests passed
- full suite: 67 files / 1,358 tests passed
- lint passed
- build passed
- docs build passed
- README synchronization passed
- `npm audit --omit=dev`: zero production vulnerabilities
- `git diff --check` passed
- bundled skill: 8,063 bytes
- real `/UserUnit 2` probes: raw `50×25` crop → 100×50 PNG; `/Rotate 90` → 50×100 PNG
- pre-merge and actual-merge-base independent read-only audits found no blocker

## Non-blocking follow-ups

- add an end-to-end mocked OCR UserUnit bbox regression
- evaluate physical normalization of the documented upstream heuristics separately
