### PR TITLE
ci(workflows): allow renovate bot to trigger Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Renovate authors its dependency PRs as a bot, and the action refuses
+          # non-human actors unless they are listed here. Name the single bot
+          # rather than '*' so an unrelated App cannot drive this review.
+          allowed_bots: 'renovate'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Problem

Every Renovate PR fails the `claude-review` check before its diff is ever looked at:

```
Action failed with error: Workflow initiated by non-human actor: renovate (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`anthropics/claude-code-action` rejects non-human actors unless they are named in
`allowed_bots` (default: empty = no bots allowed). The job aborts at the actor
check, so the review never runs — and the resulting red check leaves every
Renovate PR permanently `UNSTABLE` rather than `CLEAN`.

Seen on #135 and #136.

## Fix

Set `allowed_bots: 'renovate'`.

The action's `isAllowedBot` lowercases both sides and strips a trailing `[bot]`
suffix, so the bare `renovate` matches the `renovate[bot]` actor.

Naming the single bot rather than `'*'` is deliberate: this is a public repo, and
per the action's [security docs](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md),
allowed bots are **not** checked for repository permissions — with `'*'`, any
external GitHub App able to open a PR could invoke this action with a prompt it
controls.

## Verification

`allowed_bots` confirmed against `action.yml` and `src/github/validation/actor.ts`
upstream. Local lint/test/build were not run: the change touches only CI
configuration, no source or build input. The real check is whether `claude-review`
goes green on the next Renovate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)