### PR TITLE
ci(workflows): allow dependabot in claude-review and match upstream bot spelling

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,10 +36,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Renovate authors its dependency PRs as a bot, and the action refuses
-          # non-human actors unless they are listed here. Name the single bot
-          # rather than '*' so an unrelated App cannot drive this review.
-          allowed_bots: 'renovate'
+          # Renovate and Dependabot author their dependency PRs as bots, and the
+          # action refuses non-human actors unless they are listed here. Name the
+          # two bots rather than '*': allowed bots bypass the repository
+          # permission check, so on a public repo '*' would let any external App
+          # drive this review with a prompt it controls.
+          allowed_bots: 'dependabot[bot],renovate[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Follow-up to #137.

## Dependabot hits the same gate

#137 unblocked Renovate, but Dependabot fails identically — PR #134
(`chore(deps-dev): Bump postcss`) has exactly one failing check:

```
claude-review — Workflow initiated by non-human actor: dependabot
```

Dependabot is active in this repo via GitHub security updates (#128, #129,
#132, #133 all merged recently; there is no `.github/dependabot.yml`), so it
belongs on the list next to Renovate.

## `[bot]` spelling

Switched to `dependabot[bot],renovate[bot]`, the spelling in the action's own
[`docs/usage.md`](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md).

This is **equivalent** to the bare `renovate` merged in #137 — verified against
`src/github/validation/actor.ts` at the `v1` tag (`c96dd0a`), which normalizes
both sides before comparing:

```ts
const allowedList = trimmed.split(",").map(bot =>
  bot.trim().toLowerCase().replace(/\[bot\]$/, ""));
const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
return allowedList.includes(normalizedActor);
```

The change is for readability and fidelity to the real actor login, not a fix.

## Why named bots, not `'*'`

Per the action's [security docs](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md),
allowed bots are **not** checked for repository permissions. On a public repo,
`'*'` would let any external GitHub App able to open a PR invoke this action
with a prompt it controls. A named first-party App cannot be impersonated —
GitHub sets the actor on `pull_request` events.

Residual risk, unchanged in kind from #137: both bots embed upstream changelogs
in their PR bodies, which is third-party content a compromised dependency could
weaponize. The job holds only `contents: read`, `pull-requests: read`,
`issues: read`, so the worst case is a misleading review, not a repo write.

## Verification

CI-config-only change; no source or build input touched, so local lint/test/build
were not run. The real check is whether `claude-review` goes green on the next
Dependabot and Renovate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)