### PR TITLE
ci(review): skip claude-review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Dependabot-triggered runs only receive Dependabot secrets, so
+    # CLAUDE_CODE_OAUTH_TOKEN is empty there and the action always fails.
+    # Skip by PR author (stable across re-runs) instead of github.actor.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,12 +35,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Renovate and Dependabot author their dependency PRs as bots, and the
-          # action refuses non-human actors unless they are listed here. Name the
-          # two bots rather than '*': allowed bots bypass the repository
-          # permission check, so on a public repo '*' would let any external App
-          # drive this review with a prompt it controls.
-          allowed_bots: 'dependabot[bot],renovate[bot]'
+          # Renovate authors its dependency PRs as a bot, and the action refuses
+          # non-human actors unless they are listed here. Name the bot rather
+          # than '*': allowed bots bypass the repository permission check, so on
+          # a public repo '*' would let any external App drive this review with
+          # a prompt it controls. Dependabot is not listed because its PRs are
+          # skipped at the job level (no secrets in Dependabot-triggered runs).
+          allowed_bots: 'renovate[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Why

The `claude-review` job fails on every Dependabot PR (e.g. #140, #147) with:

> Environment variable validation failed: Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ... is required

Dependabot-triggered workflow runs only receive **Dependabot secrets**, not repository Actions secrets, so `secrets.CLAUDE_CODE_OAUTH_TOKEN` is always empty there. The failure is structural — it says nothing about the PR content, and it blocks otherwise-green dependency PRs from being merged.

## What

- Skip the `claude-review` job when the PR author is `dependabot[bot]`. The condition uses `github.event.pull_request.user.login` rather than `github.actor` so it stays stable across re-runs.
- Drop `dependabot[bot]` from `allowed_bots` — dead configuration once the job never runs for those PRs. Renovate keeps working as before (same-repo App, normal secrets, still reviewed — see #141 where claude-review passed).

## Alternative considered

Adding `CLAUDE_CODE_OAUTH_TOKEN` as a Dependabot secret would keep reviews running on Dependabot PRs. Not done here: Renovate already reviews the same dependency updates, and duplicating the token into a second secret store has its own cost. Easy to revisit later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)