### PR TITLE
fix(document): close four review follow-ups on read_pdf attachments

### DIFF
--- a/src/core/document/attachmentContent.ts
+++ b/src/core/document/attachmentContent.ts
@@ -1,4 +1,5 @@
 import type { PDFDocumentProxy } from 'pdfjs-dist/legacy/build/pdf.mjs';
+import type { DocumentAttachment } from '../../types/index.js';
 import { buildPdfJsDocumentOptions } from '../processor/pdfJsSetup.js';
 import { normalizeText } from '../processor/textUtils.js';
 import { collectFileAttachmentAnnotations } from './attachmentAnnotations.js';
@@ -30,7 +31,9 @@ export interface ReadAttachmentOptions {
 
 export type ReadAttachmentResult =
   | { found: true; attachment: AttachmentContent }
-  | { found: false; available: { name: string; size: number }[] };
+  /** `matchedName` set: the selector *did* name a listed attachment, but
+   *  the document only references its bytes without embedding them. */
+  | { found: false; available: { name: string; size: number }[]; matchedName?: string };
 
 /**
  * Resolve `selector` against the same list, in the same order, that
@@ -38,7 +41,40 @@ export type ReadAttachmentResult =
  * insensitive) or a 1-based index. Anything else reports what *is*
  * there, so a caller that guessed wrong can correct itself in one step
  * instead of being told only that it failed.
+ *
+ * A match without bytes is its own outcome, not a miss — a FileAttachment
+ * annotation may reference a file the PDF never embeds, and "no attachment
+ * by that name" followed by a list containing that very name would
+ * contradict itself.
  */
+export function resolveAttachment(
+  attachments: readonly (DocumentAttachment & { content?: Buffer })[],
+  selector: string,
+): ReadAttachmentResult {
+  const trimmed = selector.trim();
+  const byIndex = /^\d+$/.test(trimmed) ? attachments[Number(trimmed) - 1] : undefined;
+  const match =
+    byIndex ??
+    attachments.find((entry) => entry.name.toLocaleLowerCase('en-US') === trimmed.toLocaleLowerCase('en-US'));
+
+  if (match?.content === undefined) {
+    return {
+      found: false,
+      available: attachments.map((entry) => ({ name: entry.name, size: entry.size })),
+      ...(match !== undefined && { matchedName: match.name }),
+    };
+  }
+  return {
+    found: true,
+    attachment: {
+      name: match.name,
+      ...(match.description !== undefined && { description: match.description }),
+      size: match.content.byteLength,
+      content: match.content,
+    },
+  };
+}
+
 export async function readAttachment(
   filePath: string,
   selector: string,
@@ -66,25 +102,7 @@ export async function readAttachment(
       await catalogAttachmentsToRecord(await doc.getAttachments(), (id) => doc.getAttachmentContent(id)),
       await collectFileAttachmentAnnotations(doc),
     );
-    const attachments = buildAttachmentsWithContent(records, { normalizeText: normalize });
-
-    const trimmed = selector.trim();
-    const byIndex = /^\d+$/.test(trimmed) ? attachments[Number(trimmed) - 1] : undefined;
-    const match =
-      byIndex ?? attachments.find((entry) => entry.name.toLocaleLowerCase() === trimmed.toLocaleLowerCase());
-
-    if (!match?.content) {
-      return { found: false, available: attachments.map((entry) => ({ name: entry.name, size: entry.size })) };
-    }
-    return {
-      found: true,
-      attachment: {
-        name: match.name,
-        ...(match.description !== undefined && { description: match.description }),
-        size: match.content.byteLength,
-        content: match.content,
-      },
-    };
+    return resolveAttachment(buildAttachmentsWithContent(records, { normalizeText: normalize }), selector);
   } finally {
     await loadingTask.destroy();
   }

--- a/src/core/document/attachments.ts
+++ b/src/core/document/attachments.ts
@@ -67,7 +67,7 @@ export function buildAttachmentsWithContent(
       const attachment = value as PdfAttachment;
       const content = bytes(attachment.content);
       return {
-        ...buildAttachment(key, attachment, index + 1, usedFilenames, options),
+        ...buildAttachment(key, attachment, index + 1, usedFilenames, options, content),
         ...(content !== undefined && { content }),
       };
     })
@@ -102,11 +102,14 @@ function buildAttachment(
   index: number,
   usedFilenames: Set<string>,
   options: BuildAttachmentsOptions,
+  // Defaulted so callers that already converted the bytes (Buffer.from
+  // copies a Uint8Array) can hand them in instead of paying for a
+  // second copy per attachment.
+  content: Buffer | undefined = bytes(attachment.content),
 ): DocumentAttachment {
   const name = textValue(attachment.filename, options.normalizeText) ?? textValue(key, options.normalizeText) ?? key;
   const rawName = textValue(attachment.rawFilename, options.normalizeText);
   const description = textValue(attachment.description, options.normalizeText);
-  const content = bytes(attachment.content);
   const path =
     options.outputDir && content
       ? writeAttachment(options.outputDir, safeAttachmentFilename(name, index, usedFilenames), content)

--- a/src/core/document/attachments.ts
+++ b/src/core/document/attachments.ts
@@ -42,7 +42,7 @@ export function buildAttachments(
   const usedFilenames = new Set<string>();
   return Object.entries(attachments)
     .map(([key, value], index) => buildAttachment(key, value as PdfAttachment, index + 1, usedFilenames, options))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => a.name.localeCompare(b.name, 'en-US'));
 }
 
 /**
@@ -65,12 +65,13 @@ export function buildAttachmentsWithContent(
   return Object.entries(attachments)
     .map(([key, value], index) => {
       const attachment = value as PdfAttachment;
+      const content = bytes(attachment.content);
       return {
         ...buildAttachment(key, attachment, index + 1, usedFilenames, options),
-        ...(bytes(attachment.content) !== undefined && { content: bytes(attachment.content) }),
+        ...(content !== undefined && { content }),
       };
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => a.name.localeCompare(b.name, 'en-US'));
 }
 
 export function mergeAttachmentRecords(

--- a/src/mcp/tools/readPdf.ts
+++ b/src/mcp/tools/readPdf.ts
@@ -99,6 +99,11 @@ export async function readPdf(input: ReadPdfInput): Promise<ToolResult> {
       password: input.password,
     });
     if (!found.found) {
+      if (found.matchedName !== undefined) {
+        throw new Error(
+          `Attachment "${found.matchedName}" is listed by this document, but its bytes are referenced rather than embedded, so there is nothing to read.`,
+        );
+      }
       const list = found.available
         .map((entry, index) => `${index + 1}. ${entry.name} (${entry.size} bytes)`)
         .join('; ');

--- a/tests/core/attachments.unit.test.ts
+++ b/tests/core/attachments.unit.test.ts
@@ -2,8 +2,10 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { resolveAttachment } from '../../src/core/document/attachmentContent.js';
 import {
   buildAttachments,
+  buildAttachmentsWithContent,
   catalogAttachmentsToRecord,
   mergeAttachmentRecords,
 } from '../../src/core/document/attachments.js';
@@ -102,6 +104,17 @@ describe('buildAttachments', () => {
     }
   });
 
+  it('carries bytes only for entries the document actually embeds', () => {
+    const list = buildAttachmentsWithContent({
+      embedded: { filename: 'a.txt', content: new Uint8Array([65]) },
+      referenced: { filename: 'b.txt' },
+    });
+
+    expect(list.map((entry) => entry.name)).toEqual(['a.txt', 'b.txt']);
+    expect(list[0].content?.toString('utf8')).toBe('A');
+    expect('content' in list[1]).toBe(false);
+  });
+
   it('refuses to write attachment bytes into a symlinked output directory', () => {
     if (process.platform === 'win32') return;
     const dir = mkdtempSync(join(tmpdir(), 'pdfvision-attachments-symlink-unit-'));
@@ -116,5 +129,38 @@ describe('buildAttachments', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveAttachment', () => {
+  const embedded = { name: 'invoice.xml', size: 3, content: Buffer.from('abc') };
+  const referenced = { name: 'linked.dat', size: 0 };
+
+  it('resolves a 1-based index in listed order', () => {
+    const result = resolveAttachment([embedded, { name: 'stamp.png', size: 1, content: Buffer.from('x') }], '2');
+    expect(result).toMatchObject({ found: true, attachment: { name: 'stamp.png' } });
+  });
+
+  it('matches names case-insensitively without host-locale surprises', () => {
+    expect(resolveAttachment([embedded], 'INVOICE.XML')).toMatchObject({ found: true });
+  });
+
+  it('reports a listed-but-not-embedded match by name instead of calling it a miss', () => {
+    // A FileAttachment annotation may reference a file the PDF never
+    // embeds. Calling that "no attachment" while listing the very name
+    // the caller asked for would contradict itself.
+    expect(resolveAttachment([embedded, referenced], 'linked.dat')).toEqual({
+      found: false,
+      matchedName: 'linked.dat',
+      available: [
+        { name: 'invoice.xml', size: 3 },
+        { name: 'linked.dat', size: 0 },
+      ],
+    });
+  });
+
+  it('omits matchedName on a plain miss, including an out-of-range index', () => {
+    expect(resolveAttachment([embedded], 'nope.txt')).not.toHaveProperty('matchedName');
+    expect(resolveAttachment([embedded], '5')).not.toHaveProperty('matchedName');
   });
 });

--- a/tests/core/attachments.unit.test.ts
+++ b/tests/core/attachments.unit.test.ts
@@ -136,9 +136,10 @@ describe('resolveAttachment', () => {
   const embedded = { name: 'invoice.xml', size: 3, content: Buffer.from('abc') };
   const referenced = { name: 'linked.dat', size: 0 };
 
-  it('resolves a 1-based index in listed order', () => {
-    const result = resolveAttachment([embedded, { name: 'stamp.png', size: 1, content: Buffer.from('x') }], '2');
-    expect(result).toMatchObject({ found: true, attachment: { name: 'stamp.png' } });
+  it('resolves a 1-based index in listed order, tolerating surrounding whitespace', () => {
+    const list = [embedded, { name: 'stamp.png', size: 1, content: Buffer.from('x') }];
+    expect(resolveAttachment(list, '2')).toMatchObject({ found: true, attachment: { name: 'stamp.png' } });
+    expect(resolveAttachment(list, ' 2 ')).toMatchObject({ found: true, attachment: { name: 'stamp.png' } });
   });
 
   it('matches names case-insensitively without host-locale surprises', () => {


### PR DESCRIPTION
Self-review of #151 after merge found four small defects, none reachable from the happy path the tests exercised.

## What was wrong

1. **A listed-but-not-embedded attachment was reported as a miss.** A `FileAttachment` annotation can reference a file the PDF never embeds (`fileId` absent → no content bytes). Selecting it produced `No attachment "X". This document has 2: 1. X (0 bytes); …` — an error that lists the very name it just denied. The match is now its own outcome, and the MCP error says what is actually wrong: the bytes are referenced, not embedded.
2. **`buildAttachmentsWithContent` called `bytes()` twice per entry.** `Buffer.from(Uint8Array)` copies, so every attachment was copied twice with one copy discarded — wasted memory proportional to attachment size.
3. **Name matching used `toLocaleLowerCase()` with no locale.** On a Turkish host locale, `I`/`i` case folding breaks and `INVOICE.XML` stops matching `invoice.xml`.
4. **The display sort used `localeCompare()` with no locale.** Now that a 1-based index addresses the list, host-locale-dependent ordering means "attachment 2" can name different files on different machines. Pinned to `en-US`, matching `canonicalAttachmentFilename` in the same module.

## How

Selector resolution is extracted from `readAttachment` into a pure `resolveAttachment(attachments, selector)`, so the no-bytes outcome is unit-testable with fabricated entries instead of a hand-crafted stream-less PDF fixture.

Considered and deliberately skipped: surrogate-pair splitting at `BODY_CHAR_CAP` (ES2019 well-formed `JSON.stringify` keeps it safe on the wire, and it is the same pre-existing pattern as `truncate.ts`), and an all-digit attachment name being shadowed by the index reading (documented precedence; a miss returns the list, so it self-recovers).

## Verification

- `npm run test` — 1584 passed (+5)
- Biome (scoped), oxlint, tsc, secretlint clean; `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)