### PR TITLE
docs(website): add the MCP server guide in four languages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -39,6 +39,7 @@ type LocaleLabels = {
   renderingAndOcr: string;
   searchAndRegionZoom: string;
   agentSkill: string;
+  mcpServer: string;
   promptExamples: string;
   libraryApi: string;
   securityAndPrivacy: string;
@@ -62,6 +63,7 @@ const labelsEn: LocaleLabels = {
   renderingAndOcr: 'Rendering and OCR',
   searchAndRegionZoom: 'Search and Region Zoom',
   agentSkill: 'Agent Skills',
+  mcpServer: 'MCP Server',
   promptExamples: 'Prompt Examples',
   libraryApi: 'Library API',
   securityAndPrivacy: 'Security and Privacy',
@@ -85,6 +87,7 @@ const labelsJa: LocaleLabels = {
   renderingAndOcr: 'レンダリングと OCR',
   searchAndRegionZoom: '検索と領域ズーム',
   agentSkill: 'Agent Skills',
+  mcpServer: 'MCP サーバー',
   promptExamples: 'プロンプト例',
   libraryApi: 'ライブラリ API',
   securityAndPrivacy: 'セキュリティとプライバシー',
@@ -108,6 +111,7 @@ const labelsZhCn: LocaleLabels = {
   renderingAndOcr: '渲染与 OCR',
   searchAndRegionZoom: '搜索与区域放大',
   agentSkill: 'Agent Skills',
+  mcpServer: 'MCP 服务器',
   promptExamples: '提示词示例',
   libraryApi: '库 API',
   securityAndPrivacy: '安全与隐私',
@@ -131,6 +135,7 @@ const labelsZhTw: LocaleLabels = {
   renderingAndOcr: '渲染與 OCR',
   searchAndRegionZoom: '搜尋與區域放大',
   agentSkill: 'Agent Skills',
+  mcpServer: 'MCP 伺服器',
   promptExamples: '提示詞範例',
   libraryApi: '函式庫 API',
   securityAndPrivacy: '安全與隱私',
@@ -169,6 +174,7 @@ const guideSidebar = (prefix: string, labels: LocaleLabels): DefaultTheme.Sideba
       text: labels.agentsAndDevelopers,
       items: [
         { text: labels.agentSkill, link: withPrefix(prefix, '/guide/agent-skill') },
+        { text: labels.mcpServer, link: withPrefix(prefix, '/guide/mcp-server') },
         { text: labels.promptExamples, link: withPrefix(prefix, '/guide/prompt-examples') },
         { text: labels.libraryApi, link: withPrefix(prefix, '/guide/library-api') },
       ],
@@ -234,6 +240,7 @@ const jsonLd = {
         'JSON, XML, Markdown, and TOON output formats',
         'Local and remote PDF extraction with cache support',
         'Bundled Agent Skills for Claude Code, Codex, and Cursor workflows',
+        'MCP server for shell-less hosts such as Claude Desktop and Cursor',
       ],
     },
   ],

--- a/docs/src/en/guide/mcp-server.md
+++ b/docs/src/en/guide/mcp-server.md
@@ -1,0 +1,67 @@
+---
+title: MCP Server
+description: Serve pdfvision over the Model Context Protocol for hosts without a shell — Claude Desktop, Cursor, Cline, Zed, and workflow tools like n8n.
+---
+
+# MCP Server
+
+`pdfvision mcp` serves the same extraction engine over the [Model Context Protocol](https://modelcontextprotocol.io/) on stdio. It exists for hosts that cannot run a shell — Claude Desktop, Cursor, Cline, Zed, n8n, and similar environments where the model can only call tools.
+
+If your agent has a shell (Claude Code, Codex, or another CLI-capable environment), prefer the CLI plus the [Agent Skills](./agent-skill.md). The skill loads on demand and costs nothing until it is used, while MCP tool schemas sit in the host's context for the whole session.
+
+## Setup
+
+The server is a subcommand of the main binary, not a separate package:
+
+```json
+{
+  "mcpServers": {
+    "pdfvision": { "command": "npx", "args": ["-y", "pdfvision", "mcp"] }
+  }
+}
+```
+
+`pdfvision mcp` takes no arguments. It speaks JSON-RPC on stdout, so anything the process would otherwise log goes to stderr.
+
+## The Three Tools
+
+| Tool | Returns | Parameters |
+|---|---|---|
+| `read_pdf` | Text as Markdown | `source`, `pages`, `ocr`, `attachment`, `password` |
+| `search_pdf` | Flat hit list with a short `ref` per match | `source`, `query`, `pages`, `regex`, `password` |
+| `render_pdf` | Page or region PNGs as image blocks | `source`, `pages`, `ref`, `region`, `password` |
+
+`source` takes a local path or an `http(s)` URL — there is no separate remote parameter.
+
+The surface is deliberately smaller than the CLI. There is no format, include, scale, or cache parameter: anything pdfvision can decide from the document itself, the server decides. `read_pdf` always runs layout, form fields, links, and annotations, and simply omits sections that found nothing. This keeps the permanently-resident tool schemas small and leaves the model nothing to misconfigure.
+
+## How a Session Flows
+
+An unscoped `read_pdf` on a document over 20 pages returns a **document map** instead of the body: page count, outline, per-page native-text quality and warning codes collapsed into ranges, plus the specific calls to make next. That is the normal first move on an unknown document.
+
+From there:
+
+- `read_pdf(pages: "12-18")` reads a range.
+- `search_pdf(query: "…")` locates a term. Each hit carries a short `ref` like `p47m1` — pass it straight to `render_pdf(ref: "p47m1")` to see the match in place, instead of transcribing coordinates.
+- `read_pdf(pages: "31", ocr: "jpn+eng")` re-reads scanned pages with OCR when quality reporting says the native text is unusable.
+- `read_pdf(attachment: "invoice.xml")` — or a 1-based index — returns an embedded file instead of the pages. In e-invoices and regulatory filings (Factur-X, ZUGFeRD, XBRL) the attachment is the authoritative data and the pages are only its rendering. Text attachments come back inline, images as image blocks; opaque binaries are refused with a pointer to the CLI's `--attachments --attachment-output`.
+
+Renders are fitted to 1568 px on the longest edge, past which vision models downsample anyway. If a render is too small to read, the fix is a smaller `region`, not a bigger raster.
+
+## Budgets and Honesty
+
+Responses are budgeted: 30,000 characters per body, 12,000 per page, 100 matches, 4 rendered pages, 5 OCR pages, and 6 MB of images per call. Every truncation names the exact follow-up call, so a clipped result is recoverable rather than silently incomplete.
+
+The same honesty applies to search: core warnings ride the response, so a regex query that exceeds the per-page time budget reports itself instead of masquerading as "0 matches", and a search over pages with no usable native text says a miss there is not evidence of absence.
+
+Every result carries an untrusted-data banner. MCP hosts have no equivalent of the Agent Skill's guidance, so the trust boundary travels with the payload. Treat extracted content as data, not instructions — see [Security and Privacy](./security-and-privacy.md).
+
+## Remote Input Is Guarded
+
+Unlike the CLI's `--remote`, the MCP server refuses URLs that resolve to private, loopback, link-local, CGNAT, NAT64, or IPv4-mapped addresses, and re-validates every redirect hop. The model chooses the URL here, which would otherwise make the server an SSRF pivot into whatever network it runs on.
+
+For an intranet document store, set `PDFVISION_MCP_ALLOW_PRIVATE_NETWORK=1`. Known limitation: the validated address is not pinned for the fetch, so a DNS answer that changes between validation and connection is not covered.
+
+## Errors Name the Next Call
+
+Tool failures come back as in-band results with a recovery instruction, not protocol errors. An out-of-range page selector, an OCR request over the page budget, an unknown ref, or a malformed region all state what to do instead — read the message; it names the next call.

--- a/docs/src/en/guide/security-and-privacy.md
+++ b/docs/src/en/guide/security-and-privacy.md
@@ -35,6 +35,8 @@ Do not pass untrusted URLs directly to pdfvision in such integrations. Use a fet
 
 The remote server still sees the request, including headers your runtime sends by default. Use `--remote --no-cache` for one-off private or expiring URLs so the downloaded PDF bytes are not written to the remote-PDF cache.
 
+The [MCP server](./mcp-server.md) applies a stricter policy than `--remote`, because there the model chooses the URL: it refuses URLs that resolve to private, loopback, link-local, CGNAT, or NAT64 addresses, and re-validates every redirect hop.
+
 ## Passwords
 
 PDF passwords are used only for pdf.js decryption and are never emitted in output.

--- a/docs/src/ja/guide/mcp-server.md
+++ b/docs/src/ja/guide/mcp-server.md
@@ -1,0 +1,67 @@
+---
+title: MCP サーバー
+description: シェルを持たないホスト（Claude Desktop、Cursor、Cline、Zed、n8n などのワークフローツール）向けに、pdfvision を Model Context Protocol で提供します。
+---
+
+# MCP サーバー
+
+`pdfvision mcp` は、同じ抽出エンジンを [Model Context Protocol](https://modelcontextprotocol.io/) 経由で stdio 上に提供します。シェルを実行できないホスト — Claude Desktop、Cursor、Cline、Zed、n8n など、モデルが tool 呼び出ししかできない環境のためのものです。
+
+エージェントがシェルを持つ場合（Claude Code、Codex など CLI を実行できる環境）は、CLI と [Agent Skills](./agent-skill.md) の組み合わせを推奨します。skill は必要になるまで context を消費しませんが、MCP の tool schema はセッションの間ずっとホストの context に常駐します。
+
+## セットアップ
+
+サーバーは別パッケージではなく、メインバイナリのサブコマンドです:
+
+```json
+{
+  "mcpServers": {
+    "pdfvision": { "command": "npx", "args": ["-y", "pdfvision", "mcp"] }
+  }
+}
+```
+
+`pdfvision mcp` は引数を取りません。stdout で JSON-RPC を話すため、プロセスのログはすべて stderr に出ます。
+
+## 3 つの Tool
+
+| Tool | 返すもの | パラメータ |
+|---|---|---|
+| `read_pdf` | Markdown のテキスト | `source`、`pages`、`ocr`、`attachment`、`password` |
+| `search_pdf` | match ごとに短い `ref` の付いたヒット一覧 | `source`、`query`、`pages`、`regex`、`password` |
+| `render_pdf` | ページまたは領域の PNG（image block） | `source`、`pages`、`ref`、`region`、`password` |
+
+`source` はローカルパスまたは `http(s)` URL を受け付けます — remote 用の別パラメータはありません。
+
+この surface は CLI より意図的に小さくしてあります。format、include、scale、cache のパラメータはありません: 文書自体から判断できることは、すべてサーバー側が判断します。`read_pdf` は常に layout、form field、link、annotation を実行し、何も見つからなかったセクションは単に省きます。これにより常駐する tool schema を小さく保ち、モデルが設定を誤る余地をなくしています。
+
+## セッションの流れ
+
+20 ページを超える文書への `pages` なしの `read_pdf` は、本文の代わりに**ドキュメントマップ**を返します: ページ数、アウトライン、ページごとの native text 品質と warning code をレンジに集約したもの、そして次に実行すべき具体的な呼び出しです。未知の文書への最初の一手はこれが標準です。
+
+そこからは:
+
+- `read_pdf(pages: "12-18")` でレンジを読む。
+- `search_pdf(query: "…")` で語句を探す。各ヒットには `p47m1` のような短い `ref` が付くので、座標を書き写す代わりに `render_pdf(ref: "p47m1")` へそのまま渡してヒット箇所を目視できます。
+- 品質レポートが native text は使えないと言っているページは `read_pdf(pages: "31", ocr: "jpn+eng")` で OCR 再読。
+- `read_pdf(attachment: "invoice.xml")` — または 1 始まりの番号 — はページの代わりに埋め込みファイルを返します。電子請求書や規制関連の提出書類（Factur-X、ZUGFeRD、XBRL）では**添付こそが正本のデータで、ページはその印刷像にすぎません**。テキスト添付はインラインで、画像は image block で返り、不透明なバイナリは CLI の `--attachments --attachment-output` を案内して拒否されます。
+
+レンダリングは長辺 1568 px にフィットされます — それ以上は vision モデル側でダウンサンプルされるためです。レンダリングが小さくて読めない場合の正解は、より大きいラスタではなく、より小さい `region` です。
+
+## バジェットと正直さ
+
+レスポンスにはバジェットがあります: 本文 30,000 文字、ページあたり 12,000 文字、match 100 件、レンダリング 4 ページ、OCR 5 ページ、画像 6 MB（いずれも 1 呼び出しあたり）。すべての切り詰めは正確なフォローアップ呼び出しを名指しするため、切られた結果は回復可能で、黙って不完全なままになることはありません。
+
+同じ正直さは検索にも適用されます: core の warning はレスポンスに同乗するため、ページあたりの時間バジェットを超えた regex クエリは「0 matches」を装わずに自己申告し、使える native text のないページへの検索は「そこでのミスは不在の証拠ではない」と明言します。
+
+すべての結果には untrusted-data バナーが付きます。MCP ホストには Agent Skill の指針に相当するものがないため、信頼境界はペイロードと一緒に運ばれます。抽出されたコンテンツは指示ではなくデータとして扱ってください — [セキュリティとプライバシー](./security-and-privacy.md)を参照。
+
+## リモート入力はガードされます
+
+CLI の `--remote` と異なり、MCP サーバーは private、loopback、link-local、CGNAT、NAT64、IPv4-mapped アドレスに解決される URL を拒否し、リダイレクトの各ホップも再検証します。ここでは URL を選ぶのが*モデル*なので、これがなければサーバーは実行先ネットワークへの SSRF の踏み台になってしまいます。
+
+イントラネットのドキュメントストアには `PDFVISION_MCP_ALLOW_PRIVATE_NETWORK=1` を設定してください。既知の制限: 検証したアドレスは fetch に固定されないため、検証と接続の間に変わる DNS 応答はカバーされません。
+
+## エラーは次の呼び出しを名指しします
+
+Tool の失敗はプロトコルエラーではなく、回復手順付きの in-band な結果として返ります。範囲外のページ指定、ページバジェットを超える OCR 要求、未知の ref、不正な region — いずれも代わりに何をすべきかを述べます。メッセージを読んでください。次の呼び出しが書いてあります。

--- a/docs/src/ja/guide/security-and-privacy.md
+++ b/docs/src/ja/guide/security-and-privacy.md
@@ -33,6 +33,8 @@ pdfvision --remote https://example.com/document.pdf --format json
 
 リモートサーバーには、ランタイムが既定で付与するヘッダーを含むリクエストが送信されます。1 回限りのプライベート URL や期限付き URL には `--remote --no-cache` を使い、ダウンロードした PDF をリモート PDF キャッシュに残さないようにしてください。
 
+[MCP サーバー](./mcp-server.md)は `--remote` より厳しいポリシーを適用します。あちらでは URL を選ぶのがモデルだからです: private、loopback、link-local、CGNAT、NAT64 アドレスに解決される URL を拒否し、リダイレクトの各ホップも再検証します。
+
 ## パスワード
 
 PDF パスワードは pdf.js の復号にのみ使われ、出力には含まれません。

--- a/docs/src/zh-cn/guide/mcp-server.md
+++ b/docs/src/zh-cn/guide/mcp-server.md
@@ -1,0 +1,67 @@
+---
+title: MCP 服务器
+description: 通过 Model Context Protocol，为没有 shell 的宿主——Claude Desktop、Cursor、Cline、Zed，以及 n8n 等工作流工具——提供 pdfvision 服务。
+---
+
+# MCP 服务器
+
+`pdfvision mcp` 通过 stdio，在 [Model Context Protocol](https://modelcontextprotocol.io/) 上提供同一套提取引擎。它是为那些无法运行 shell 的宿主而存在的——Claude Desktop、Cursor、Cline、Zed、n8n，以及模型只能调用 tool 的类似环境。
+
+如果你的智能体拥有 shell（Claude Code、Codex 或其他支持 CLI 的环境），优先使用 CLI 加 [Agent Skills](./agent-skill.md) 的组合。skill 按需加载，未被使用前不消耗任何 context，而 MCP tool schema 会在整个会话期间常驻宿主的 context。
+
+## 设置
+
+服务器是主可执行文件的子命令，而不是单独的 package：
+
+```json
+{
+  "mcpServers": {
+    "pdfvision": { "command": "npx", "args": ["-y", "pdfvision", "mcp"] }
+  }
+}
+```
+
+`pdfvision mcp` 不接受任何参数。它在 stdout 上使用 JSON-RPC 通信，因此进程原本要输出的日志都会转到 stderr。
+
+## 三个 Tool
+
+| Tool | 返回内容 | 参数 |
+|---|---|---|
+| `read_pdf` | Markdown 格式的文本 | `source`、`pages`、`ocr`、`attachment`、`password` |
+| `search_pdf` | 每个 match 都带一个短 `ref` 的扁平命中列表 | `source`、`query`、`pages`、`regex`、`password` |
+| `render_pdf` | 页面或区域 PNG（image block） | `source`、`pages`、`ref`、`region`、`password` |
+
+`source` 接受本地路径或 `http(s)` URL——没有单独的远程参数。
+
+这个 surface 比 CLI 刻意做得更小。没有 format、include、scale 或 cache 参数：凡是 pdfvision 能从文档本身判断的事，都由服务器决定。`read_pdf` 总是会运行 layout、form field、link 和 annotation 提取，只是省略那些一无所获的 section。这让常驻的 tool schema 保持精简，也不给模型留下配置出错的余地。
+
+## 会话如何进行
+
+对超过 20 页的文档执行不带 `pages` 的 `read_pdf`，返回的不是正文，而是**文档地图**：页数、outline、按区间折叠的每页原生文本质量与 warning code，以及接下来该调用什么。面对未知文档时，这是标准的第一步。
+
+由此往后：
+
+- `read_pdf(pages: "12-18")` 读取一个区间。
+- `search_pdf(query: "…")` 定位一个词。每个命中项都带一个像 `p47m1` 这样的短 `ref`——把它原样传给 `render_pdf(ref: "p47m1")`，就能就地查看匹配内容，不必抄写坐标。
+- 当 quality 报告说原生文本不可用时，用 `read_pdf(pages: "31", ocr: "jpn+eng")` 对扫描页重新做 OCR。
+- `read_pdf(attachment: "invoice.xml")`——或一个从 1 开始的索引——返回一个嵌入文件，而不是页面。在电子发票和监管申报文件（Factur-X、ZUGFeRD、XBRL）中，附件才是权威数据，页面只是它的渲染呈现。文本附件会内联返回，图像作为 image block 返回；不透明的二进制文件会被拒绝，并指向 CLI 的 `--attachments --attachment-output`。
+
+渲染图会被适配到最长边 1568 px，超过这个尺寸 vision 模型本来也会做下采样。如果渲染图小到读不清，该做的是缩小 `region`，而不是放大分辨率。
+
+## Budget 与诚实
+
+响应是有 budget 的：正文 30,000 字符、每页 12,000 字符、100 个 match、4 个渲染页面、5 个 OCR 页面，以及每次调用 6 MB 的图像。每次截断都会指明确切的后续调用，因此被截断的结果是可恢复的，而不是悄悄地不完整。
+
+同样的诚实也适用于搜索：core warning 会随响应一起返回，因此当一个 regex query 超出单页时间 budget 时，它会如实报告，而不是伪装成“0 matches”；对没有可用原生文本的页面搜索时，也会说明该处的落空并不代表证据缺失。
+
+每个结果都带有 untrusted-data 提示条。MCP 宿主没有 Agent Skill 那样的指引，所以信任边界要随负载一起传递。请把提取出的内容当作数据而非指令来对待——参见[安全与隐私](./security-and-privacy.md)。
+
+## 远程输入受到防护
+
+与 CLI 的 `--remote` 不同，MCP 服务器会拒绝解析到私有地址、环回地址、链路本地地址、CGNAT 地址、NAT64 地址或 IPv4 映射地址的 URL，并重新验证每一跳重定向。这里选择 URL 的是模型，如果不这样做，服务器就会变成通往其所在网络的 SSRF 跳板。
+
+对于内网文档存储，请设置 `PDFVISION_MCP_ALLOW_PRIVATE_NETWORK=1`。已知限制：已验证的地址不会为这次 fetch 固定下来，因此在验证与连接之间发生变化的 DNS 答案不在覆盖范围内。
+
+## 错误会指明下一次调用
+
+Tool 失败会以带恢复说明的带内结果返回，而不是协议错误。越界的页面选择器、超出页面 budget 的 OCR 请求、未知的 ref，或格式错误的 region，都会说明该怎么做——读一下这条消息，它会指明下一次调用。

--- a/docs/src/zh-cn/guide/security-and-privacy.md
+++ b/docs/src/zh-cn/guide/security-and-privacy.md
@@ -33,6 +33,8 @@ pdfvision --remote https://example.com/document.pdf --format json
 
 远程服务器仍然会看到这次请求，包括运行时默认发送的请求头。对一次性的私有或临时 URL，使用 `--remote --no-cache`，这样下载的 PDF 字节就不会写入远程 PDF 缓存。
 
+[MCP 服务器](./mcp-server.md)采用比 `--remote` 更严格的策略，因为在那里选择 URL 的是模型：它会拒绝解析到私有地址、环回地址、链路本地地址、CGNAT 地址或 NAT64 地址的 URL，并重新验证每一跳重定向。
+
 ## 密码
 
 PDF 密码只用于 pdf.js 解密，不会出现在输出中。

--- a/docs/src/zh-tw/guide/mcp-server.md
+++ b/docs/src/zh-tw/guide/mcp-server.md
@@ -1,0 +1,67 @@
+---
+title: MCP 伺服器
+description: 透過 Model Context Protocol，為沒有 shell 的宿主——Claude Desktop、Cursor、Cline、Zed，以及 n8n 等工作流程工具——提供 pdfvision 服務。
+---
+
+# MCP 伺服器
+
+`pdfvision mcp` 透過 stdio，在 [Model Context Protocol](https://modelcontextprotocol.io/) 上提供同一套擷取引擎。它是為那些無法執行 shell 的宿主而存在的——Claude Desktop、Cursor、Cline、Zed、n8n，以及模型只能呼叫 tool 的類似環境。
+
+如果你的代理擁有 shell（Claude Code、Codex 或其他支援 CLI 的環境），優先使用 CLI 搭配 [Agent Skills](./agent-skill.md) 的組合。skill 按需載入，尚未使用前不消耗任何 context，而 MCP tool schema 會在整個工作階段期間常駐宿主的 context。
+
+## 設定
+
+伺服器是主要執行檔的子指令，而不是獨立的 package：
+
+```json
+{
+  "mcpServers": {
+    "pdfvision": { "command": "npx", "args": ["-y", "pdfvision", "mcp"] }
+  }
+}
+```
+
+`pdfvision mcp` 不接受任何參數。它在 stdout 上使用 JSON-RPC 通訊，因此程序原本要輸出的記錄都會轉到 stderr。
+
+## 三個 Tool
+
+| Tool | 回傳內容 | 參數 |
+|---|---|---|
+| `read_pdf` | Markdown 格式的文字 | `source`、`pages`、`ocr`、`attachment`、`password` |
+| `search_pdf` | 每個 match 都帶一個短 `ref` 的扁平命中清單 | `source`、`query`、`pages`、`regex`、`password` |
+| `render_pdf` | 頁面或區域 PNG（image block） | `source`、`pages`、`ref`、`region`、`password` |
+
+`source` 接受本機路徑或 `http(s)` URL——沒有獨立的遠端參數。
+
+這個 surface 比 CLI 刻意做得更小。沒有 format、include、scale 或 cache 參數：凡是 pdfvision 能從文件本身判斷的事，都由伺服器決定。`read_pdf` 總是會執行 layout、form field、link 和 annotation 擷取，只是省略那些一無所獲的 section。這讓常駐的 tool schema 保持精簡，也不給模型留下設定出錯的餘地。
+
+## 工作階段如何進行
+
+對超過 20 頁的文件執行不帶 `pages` 的 `read_pdf`，回傳的不是本文，而是**文件地圖**：頁數、outline、依區間折疊的每頁原生文字品質與 warning code，以及接下來該呼叫什麼。面對未知文件時，這是標準的第一步。
+
+由此往後：
+
+- `read_pdf(pages: "12-18")` 讀取一個區間。
+- `search_pdf(query: "…")` 定位一個詞。每個命中項都帶一個像 `p47m1` 這樣的短 `ref`——把它原樣傳給 `render_pdf(ref: "p47m1")`，就能就地查看匹配內容，不必抄寫座標。
+- 當 quality 報告說原生文字不可用時，用 `read_pdf(pages: "31", ocr: "jpn+eng")` 對掃描頁重新做 OCR。
+- `read_pdf(attachment: "invoice.xml")`——或一個從 1 開始的索引——回傳一個嵌入檔案，而不是頁面。在電子發票和監管申報文件（Factur-X、ZUGFeRD、XBRL）中，附件才是權威資料，頁面只是它的渲染呈現。文字附件會內嵌回傳，影像作為 image block 回傳；不透明的二進位檔案會被拒絕，並指向 CLI 的 `--attachments --attachment-output`。
+
+渲染圖會被調整到最長邊 1568 px，超過這個尺寸 vision 模型本來也會做降採樣。如果渲染圖小到讀不清，該做的是縮小 `region`，而不是放大解析度。
+
+## Budget 與誠實
+
+回應是有 budget 的：本文 30,000 字元、每頁 12,000 字元、100 個 match、4 個渲染頁面、5 個 OCR 頁面，以及每次呼叫 6 MB 的影像。每次截斷都會指明確切的後續呼叫，因此被截斷的結果是可復原的，而不是悄悄地不完整。
+
+同樣的誠實也適用於搜尋：core warning 會隨回應一起傳回，因此當一個 regex query 超出單頁時間 budget 時，它會如實回報，而不是偽裝成「0 matches」；對沒有可用原生文字的頁面搜尋時，也會說明該處的落空並不代表證據缺失。
+
+每個結果都帶有 untrusted-data 提示條。MCP 宿主沒有 Agent Skill 那樣的指引，所以信任邊界要隨負載一起傳遞。請把擷取出的內容當作資料而非指令來對待——參見[安全與隱私](./security-and-privacy.md)。
+
+## 遠端輸入受到防護
+
+與 CLI 的 `--remote` 不同，MCP 伺服器會拒絕解析到私有位址、迴路位址、鏈路本地位址、CGNAT 位址、NAT64 位址或 IPv4 映射位址的 URL，並重新驗證每一跳重新導向。這裡選擇 URL 的是模型，如果不這樣做，伺服器就會變成通往其所在網路的 SSRF 跳板。
+
+對於內網文件儲存庫，請設定 `PDFVISION_MCP_ALLOW_PRIVATE_NETWORK=1`。已知限制：已驗證的位址不會為這次 fetch 固定下來，因此在驗證與連線之間發生變化的 DNS 回覆不在涵蓋範圍內。
+
+## 錯誤會指明下一次呼叫
+
+Tool 失敗會以帶復原說明的帶內結果傳回，而不是協定錯誤。超出範圍的頁面選擇器、超出頁面 budget 的 OCR 要求、未知的 ref，或格式錯誤的 region，都會說明該怎麼做——讀一下這則訊息，它會指明下一次呼叫。

--- a/docs/src/zh-tw/guide/security-and-privacy.md
+++ b/docs/src/zh-tw/guide/security-and-privacy.md
@@ -33,6 +33,8 @@ pdfvision --remote https://example.com/document.pdf --format json
 
 遠端伺服器仍然會看到這次請求，包括執行環境預設傳送的請求標頭。對一次性的私有或臨時 URL，使用 `--remote --no-cache`，這樣下載的 PDF 位元組就不會寫入遠端 PDF 快取。
 
+[MCP 伺服器](./mcp-server.md)採用比 `--remote` 更嚴格的策略，因為在那裡選擇 URL 的是模型：它會拒絕解析到私有位址、迴路位址、鏈路本地位址、CGNAT 位址或 NAT64 位址的 URL，並重新驗證每一跳重新導向。
+
 ## 密碼
 
 PDF 密碼只用於 pdf.js 解密，不會出現在輸出中。


### PR DESCRIPTION
Closes the deferred docs item from the MCP work: the website never gained a page for `pdfvision mcp` (v0.15 shipped with README coverage only).

## What's in it

New `guide/mcp-server` page in **en / ja / zh-cn / zh-tw**, covering:

- Setup (`mcpServers` config; subcommand, not a separate package)
- The three tools and their parameters, and why the surface is deliberately smaller than the CLI (the server decides what the document can decide)
- How a session flows: document map as the first call on a >20-page document, `ref` handles instead of coordinates, OCR re-reads, `read_pdf(attachment:)` for e-invoices
- Budgets and honesty: per-call limits, truncations that name the follow-up call, the search warning relay, the untrusted-data banner
- The SSRF guard (private/loopback/link-local/CGNAT/NAT64/IPv4-mapped refusal, per-hop revalidation), `PDFVISION_MCP_ALLOW_PRIVATE_NETWORK=1`, and the documented DNS-pinning limitation

Sidebar entry sits under **Agents and Developers** next to Agent Skills, keeping the README's framing: shell-capable agents should prefer the CLI plus the skill; MCP exists for hosts that cannot run one.

The security pages' Remote PDFs sections (×4) now note the MCP server's stricter destination policy and link to the new page. One `featureList` line added to the site's JSON-LD.

Translations follow the established house style (English technical terms kept where existing pages keep them; zh-tw uses Taiwan conventions rather than converted zh-cn).

## Verification

- `npm run docs:build` — clean (VitePress fails on dead links; the cross-links resolve)
- `npm run lint` — clean
- Content cross-checked against `skills/pdfvision/references/mcp.md` and the README MCP section as merged through #154 (includes the warning relay and attachment behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)