### PR TITLE
fix(cli): put the search-to-region evidence chain above the help fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Common flows
                                         Locate a term without reading the whole body; each match
                                         reports its page and bbox.
   pdfvision doc.pdf -p <page> --render-region <x,y,w,h>
-                                        Crop a reported bbox as image evidence (use the bbox a
-                                        match or layout block reported).
+                                        Crop a reported bbox as image evidence (use the bbox
+                                        reported for a match or layout block).
   pdfvision doc.pdf -p <pages> --ocr    Re-read scanned pages (quality: empty_but_visual_content).
 
 Options

--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ Usage:
   pdfvision --clear-cache
   pdfvision mcp
 
+Common flows
+  pdfvision doc.pdf                     Read it. Per-page quality and warnings name the next flag
+                                        when the default pass is not enough.
+  pdfvision doc.pdf --search "term" --matches-only
+                                        Locate a term without reading the whole body; each match
+                                        reports its page and bbox.
+  pdfvision doc.pdf -p <page> --render-region <x,y,w,h>
+                                        Crop a reported bbox as image evidence (use the bbox a
+                                        match or layout block reported).
+  pdfvision doc.pdf -p <pages> --ocr    Re-read scanned pages (quality: empty_but_visual_content).
+
 Options
   -p, --pages <range>     Pages to extract: "1", "1-5", "1,3,5", "2-4,7". Default: all pages.
   -f, --format <type>     Output format: markdown (default), json, xml, toon.
@@ -145,8 +156,9 @@ Options
                           when omitted); pixels = raw region × UserUnit × render scale. Single-page
                           only: --pages must resolve to exactly one
                           page (errors otherwise). Region must fit within the page bounds.
-                          Typical use: --layout to find a suspect block, then re-run with that
-                          block's bbox here to zoom in.
+                          Typical use: --search "term" --matches-only reports each match's
+                          bbox; re-run with that bbox here to zoom in (--layout for a
+                          block-level bbox when there is no term to search).
       --no-normalize      Disable Unicode NFKC normalization and C0-control cleanup. Default ON;
                           pre-normalization text is `pages[].rawText` in JSON/TOON and a sibling
                           `<rawText>` element in XML when normalization changed the string.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -21,8 +21,8 @@ Common flows
                                         Locate a term without reading the whole body; each match
                                         reports its page and bbox.
   pdfvision doc.pdf -p <page> --render-region <x,y,w,h>
-                                        Crop a reported bbox as image evidence (use the bbox a
-                                        match or layout block reported).
+                                        Crop a reported bbox as image evidence (use the bbox
+                                        reported for a match or layout block).
   pdfvision doc.pdf -p <pages> --ocr    Re-read scanned pages (quality: empty_but_visual_content).
 
 Options

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -14,6 +14,17 @@ Usage:
   pdfvision --clear-cache
   pdfvision mcp
 
+Common flows
+  pdfvision doc.pdf                     Read it. Per-page quality and warnings name the next flag
+                                        when the default pass is not enough.
+  pdfvision doc.pdf --search "term" --matches-only
+                                        Locate a term without reading the whole body; each match
+                                        reports its page and bbox.
+  pdfvision doc.pdf -p <page> --render-region <x,y,w,h>
+                                        Crop a reported bbox as image evidence (use the bbox a
+                                        match or layout block reported).
+  pdfvision doc.pdf -p <pages> --ocr    Re-read scanned pages (quality: empty_but_visual_content).
+
 Options
   -p, --pages <range>     Pages to extract: "1", "1-5", "1,3,5", "2-4,7". Default: all pages.
   -f, --format <type>     Output format: markdown (default), json, xml, toon.
@@ -44,8 +55,9 @@ Options
                           when omitted); pixels = raw region × UserUnit × render scale. Single-page
                           only: --pages must resolve to exactly one
                           page (errors otherwise). Region must fit within the page bounds.
-                          Typical use: --layout to find a suspect block, then re-run with that
-                          block's bbox here to zoom in.
+                          Typical use: --search "term" --matches-only reports each match's
+                          bbox; re-run with that bbox here to zoom in (--layout for a
+                          block-level bbox when there is no term to search).
       --no-normalize      Disable Unicode NFKC normalization and C0-control cleanup. Default ON;
                           pre-normalization text is \`pages[].rawText\` in JSON/TOON and a sibling
                           \`<rawText>\` element in XML when normalization changed the string.


### PR DESCRIPTION
Release-gate finding from the [bare-agent regression protocol](tests/agent-regression/README.md), run 2026-08-09 against the v0.16.0 release state (agent: headless `claude -p`, sonnet, bareness verified — pdfvision skill parked out of every discovery path, transcripts greped for skill loads).

## The failure this fixes (protocol task 4, two fresh sessions)

Task: *"What BLEU scores does this paper report? Show me the evidence as an image."* Pass requires the `--search … --matches-only` → `--render-region <reported bbox>` chain with a crop that is conclusive on its own.

Both sessions began with `pdfvision --help | head -50` — and in those 50 lines `--search` never appears (it sat at line 129). Both agents therefore grepped the full 46 KB Markdown body instead, and the one that did crop got its bbox from `-p 8 --layout --json` (49 KB, consumed three times), because `--render-region`'s own help said "Typical use: --layout to find a suspect block". The tool steered agents onto exactly the token-hungry path `--search` exists to replace. Tasks 1–3 and 5–7 passed; task 4 was scored FAIL on the letter of the pass condition and the release blocked per the protocol.

## Fix

- A **Common flows** block inside the first 20 lines of `--help`: flagless read, `--search "term" --matches-only` → `--render-region` evidence chain, OCR re-read.
- `--render-region`'s typical-use sentence now leads with the search chain; `--layout` stays as the fallback for block-level bboxes.
- README regenerated with `scripts/sync-readme-usage.mjs` (CI sync check).

## Verification — full protocol re-run on the release state

`npm ci` first (local deps had drifted: the initial round ran on pdfjs 6.1/toon 2; the re-run is on pdfjs 6.2.108/toon 4 with the cache cleared), then all seven tasks in fresh bare sessions: **7/7 PASS**.

Task 4 with this fix: `--search BLEU --matches-only` (1.8 KB) → bbox refined via layout → `--render-region 100,65,410,175` → agent read the crop → correct scores (27.3/28.4/38.1/41.8 + baselines). Crop verified conclusive (full Table 2 with caption, bold 28.4/41.8). Steering visibly improved elsewhere too: task 3 now used `--search 第3章 --matches-only` unprompted, and task 2 took the flagless-read → empty-text-warning → `--ocr` route.

Recorded per protocol: task 4 consumed ~29 KB of pdfvision output against the ~20 KB canary — over target, driven by three `--layout` refinement reads the protocol tolerates as additional verification; the chain itself cost 1.8 KB + render notices. Two `--render-region` invocations failed first (missing `--render` companion) and the error text recovered the agent both times.

`npm run lint` / `test` (1597) / `build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)