### PR TITLE
chore(release): bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ Notable user-facing changes to pdfvision are documented here.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-09
+
 ### Added
 
+- Added an MCP server behind `pdfvision mcp`, serving `read_pdf` / `search_pdf` / `render_pdf` over stdio for hosts without a shell (Claude Desktop, Cursor, Cline, Zed, n8n). An unscoped `read_pdf` on a long document returns a document map with next steps, search hits carry short refs that `render_pdf` accepts in place of coordinates, responses are budgeted with named follow-up calls, and remote URLs are refused when they resolve to private, loopback, link-local, CGNAT, or NAT64 addresses. ([#139](https://github.com/yamadashy/pdfvision/pull/139))
+- Added `read_pdf(attachment: "name-or-index")` so an MCP caller can open an embedded file — in Factur-X/ZUGFeRD e-invoices the attachment is the authoritative data. Text attachments come back inline, images as image blocks, and opaque binaries are refused with a pointer to the CLI. ([#151](https://github.com/yamadashy/pdfvision/pull/151), follow-ups [#153](https://github.com/yamadashy/pdfvision/pull/153))
+- Added `--map`: a document map (metadata, outline, per-page quality and warning codes collapsed into ranges) without page bodies — the cheap first move on an unknown document. ([#149](https://github.com/yamadashy/pdfvision/pull/149))
 - Added an always-on `xfa_form` warning and `xfa` structured-output field for XFA documents, plus an `attachmentCount` presence signal for embedded files. Attachment extraction already existed; XFA content itself is not extracted. ([#101](https://github.com/yamadashy/pdfvision/pull/101))
 - Added the `page_edge_text_truncated` error warning for text runs matching pdf.js's page-boundary truncation signature. The warning detects possible loss but does not recover omitted text. ([#105](https://github.com/yamadashy/pdfvision/pull/105))
 - Added tagged-table reconstruction under `--structure`, with GFM table output in Markdown and inferred row/column header metadata in JSON, XML, and TOON. ([#106](https://github.com/yamadashy/pdfvision/pull/106))
@@ -15,12 +20,23 @@ Notable user-facing changes to pdfvision are documented here.
 
 ### Changed
 
+- Bounded regex-mode search at ~1s of regex time per page, enforced with a V8-level interrupt, so a catastrophic-backtracking pattern can no longer stall extraction: the affected page's results are dropped with a warning, an interrupted search result is never cached, and `search_pdf` relays the warning in its MCP response. ([#154](https://github.com/yamadashy/pdfvision/pull/154))
+- Opened `--help` with a Common flows block naming the flagless read, the `--search … --matches-only` → `--render-region` evidence chain, and the OCR re-read, after bare-agent regression runs showed agents never scrolled to `--search`. ([#156](https://github.com/yamadashy/pdfvision/pull/156))
+- TOON output follows the @toon-format/toon v4 wire format, including nested tabular headers. ([#136](https://github.com/yamadashy/pdfvision/pull/136))
+- Upgraded pdfjs-dist to 6.2.108 (security release), accepting the Map-shaped viewer dictionaries it introduces. ([#143](https://github.com/yamadashy/pdfvision/pull/143))
 - Reduced Markdown outline size by omitting non-actionable internal destination identifiers, and corrected the large-output hint to recommend `--outline -p 1`. Structured JSON and XML outline targets remain unchanged. ([#99](https://github.com/yamadashy/pdfvision/pull/99))
 
 ### Fixed
 
+- Kept the `--remote` timeout active until the response body is fully consumed, so a server that sends headers and then stalls the body is aborted at the deadline instead of hanging. ([#116](https://github.com/yamadashy/pdfvision/pull/116))
+- Emitted the per-page search match-cap warning only when a valid match actually exceeds the 10,000 budget, instead of firing on an exact-capacity result. ([#118](https://github.com/yamadashy/pdfvision/pull/118))
+- Defined the structured-output contract precisely: decoded TOON is the exact parsed-JSON equivalent of the JSON output, lone UTF-16 surrogates are rejected before UTF-8 replacement can hide them, and XML represents forbidden controls with reversible markers. ([#120](https://github.com/yamadashy/pdfvision/pull/120))
+- Exposed non-default PDF `/UserUnit` values and documented the physical-point and render-pixel conversion formulas, while keeping all public bboxes in raw pdf.js page-view coordinates. ([#123](https://github.com/yamadashy/pdfvision/pull/123))
+- Hardened cache-root handling: cache use and `--clear-cache` require an owned marker and trusted ancestor chain, unrecognized directories are never destructively adopted, and remote cache hits are read from verified file descriptors. ([#124](https://github.com/yamadashy/pdfvision/pull/124))
+- Defined the CLI exit contract for missing input: no positional input exits 2 with explicit precedence over cache, stdin, and semantic validation, and a sole empty positional argument is treated as missing input. ([#125](https://github.com/yamadashy/pdfvision/pull/125), [#126](https://github.com/yamadashy/pdfvision/pull/126))
 - Preserved short title and author columns in right-to-left reading order on established vertical Japanese pages. ([#100](https://github.com/yamadashy/pdfvision/pull/100))
 - Preserved explicit word spaces and corrected common paired-bracket direction when reconstructing right-to-left text. ([#102](https://github.com/yamadashy/pdfvision/pull/102))
 - Reported `checked: true` only for the selected radio widget instead of every widget in its group. ([#104](https://github.com/yamadashy/pdfvision/pull/104))
 
-[Unreleased]: https://github.com/yamadashy/pdfvision/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/yamadashy/pdfvision/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/yamadashy/pdfvision/compare/v0.15.0...v0.16.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Release 0.16.0. Highlights: the MCP server (`pdfvision mcp`) with document map, refs, and attachment access; `--map` on the CLI; the per-page regex-search time bound; TOON v4 wire format; pdfjs-dist 6.2.108.

## Release gate

[Bare-agent regression protocol](tests/agent-regression/README.md) run 2026-08-09 against this state (pdfjs 6.2.108 / toon v4, cache cleared, bareness verified): **7/7 PASS**. Task 4 failed its first round in two fresh sessions — both agents read `--help | head -50` where `--search` never appeared — release was blocked per protocol, #156 put the evidence chain above the fold, and the full protocol re-ran green. Recorded canary: task 4 consumed ~29 KB of pdfvision output (target ~20 KB), driven by three protocol-tolerated `--layout` refinement reads; the search→region chain itself cost 1.8 KB.

## Changelog

See the `0.16.0` section in CHANGELOG.md (in this diff): 9 Added / 5 Changed / 9 Fixed entries covering #99–#156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)