### PR TITLE
fix(mcp): name the password parameter when a PDF is encrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable user-facing changes to pdfvision are documented here.
 ### Fixed
 
 - Grew a search hit's `render_pdf(ref: …)` crop to the table row or visual line it sits in, instead of padding the glyph bbox by a constant. On a financial table the old crop rendered the row label and none of its values, and a short CJK query produced an unreadable sliver. Hits the page's layout does not cover — OCR-sourced matches, pages with no reconstructed lines — keep the constant padding as the fallback. ([#159](https://github.com/yamadashy/pdfvision/issues/159))
+- Mapped encrypted-PDF failures on the MCP surface to a message naming the `password` parameter, instead of relaying pdf.js's raw `No password given`. A missing password and a wrong one now read as different failures, since the recovery differs. ([#160](https://github.com/yamadashy/pdfvision/issues/160))
 
 ## [0.16.0] - 2026-08-09
 

--- a/skills/pdfvision/references/mcp.md
+++ b/skills/pdfvision/references/mcp.md
@@ -47,6 +47,6 @@ For an intranet document store, set `PDFVISION_MCP_ALLOW_PRIVATE_NETWORK=1`. Kno
 
 ## Errors
 
-Tool failures come back as in-band error results with a recovery instruction, not as protocol errors — an out-of-range page selector, an OCR request over the 5-page budget, an unknown ref, or a malformed `region` all tell the caller what to do instead. Read the message; it names the next call.
+Tool failures come back as in-band error results with a recovery instruction, not as protocol errors — an out-of-range page selector, an OCR request over the 5-page budget, an unknown ref, a malformed `region`, or an encrypted PDF all tell the caller what to do instead. Read the message; it names the next call. Encryption is reported as two distinct failures because the recovery differs: no password given (retry with `password`) versus a wrong one (retry with a different value).
 
 `search_pdf` also relays core search warnings in the response body: a regex that exceeds the ~1s per-page time budget drops that page's results and says so, which is what keeps its "0 matches" from reading as evidence of absence.

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,29 +1,14 @@
-const PDFJS_NEED_PASSWORD = 1;
-const PDFJS_INCORRECT_PASSWORD = 2;
+import { classifyPasswordFailure } from '../core/errors/passwordFailure.js';
 
-function isObject(value: unknown): value is { readonly [key: string]: unknown } {
-  return typeof value === 'object' && value !== null;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
+const CLI_PASSWORD_REMEDY = {
+  missing: 'PDF is encrypted; pass --password <value> or --password-stdin to decrypt it.',
+  incorrect: 'Incorrect PDF password; check the value passed via --password or --password-stdin.',
+} as const;
 
 export function formatCliErrorMessage(error: unknown): string {
-  const message = errorMessage(error);
-  const code = isObject(error) ? error.code : undefined;
-  const name = isObject(error) ? error.name : undefined;
-
-  if (name === 'PasswordException' || /password/i.test(message)) {
-    if (code === PDFJS_NEED_PASSWORD || /^No password given$/i.test(message)) {
-      return 'PDF is encrypted; pass --password <value> or --password-stdin to decrypt it.';
-    }
-    if (code === PDFJS_INCORRECT_PASSWORD || /^Incorrect Password$/i.test(message)) {
-      return 'Incorrect PDF password; check the value passed via --password or --password-stdin.';
-    }
-  }
-
-  return message;
+  const failure = classifyPasswordFailure(error);
+  if (failure) return CLI_PASSWORD_REMEDY[failure];
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function exitWithError(message: string): never {

--- a/src/core/errors/passwordFailure.ts
+++ b/src/core/errors/passwordFailure.ts
@@ -1,0 +1,28 @@
+/**
+ * pdf.js reports an encryption failure as a `PasswordException` carrying a
+ * numeric code, and older/rewrapped errors only carry the message. What is
+ * surface-independent is the *classification*: whether a password is
+ * missing or wrong. The remedy is not — the CLI has `--password`, an MCP
+ * caller has a `password` parameter, and a library caller has an option
+ * object — so each surface maps this to its own wording rather than
+ * inheriting the CLI's flags.
+ */
+export type PasswordFailure = 'missing' | 'incorrect';
+
+const PDFJS_NEED_PASSWORD = 1;
+const PDFJS_INCORRECT_PASSWORD = 2;
+
+function isObject(value: unknown): value is { readonly [key: string]: unknown } {
+  return typeof value === 'object' && value !== null;
+}
+
+export function classifyPasswordFailure(error: unknown): PasswordFailure | undefined {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = isObject(error) ? error.code : undefined;
+  const name = isObject(error) ? error.name : undefined;
+
+  if (name !== 'PasswordException' && !/password/i.test(message)) return undefined;
+  if (code === PDFJS_NEED_PASSWORD || /^No password given$/i.test(message)) return 'missing';
+  if (code === PDFJS_INCORRECT_PASSWORD || /^Incorrect Password$/i.test(message)) return 'incorrect';
+  return undefined;
+}

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -1,0 +1,21 @@
+import { classifyPasswordFailure } from '../core/errors/passwordFailure.js';
+
+/**
+ * Every other MCP failure names the call that fixes it — an unknown ref
+ * says to re-run the search, a missing attachment lists the ones that
+ * exist. Encryption used to be the exception, handing back pdf.js's raw
+ * "No password given": true, but it names neither the `password`
+ * parameter nor the fact that all three tools take one, and tool schemas
+ * are fetched lazily, so the model may not have that in context when the
+ * error arrives.
+ */
+const MCP_PASSWORD_REMEDY = {
+  missing: 'PDF is encrypted and no password was given — retry the same call with `password: "…"`.',
+  incorrect: 'Incorrect PDF password — retry the same call with a different `password` value.',
+} as const;
+
+export function formatMcpErrorMessage(error: unknown): string {
+  const failure = classifyPasswordFailure(error);
+  if (failure) return MCP_PASSWORD_REMEDY[failure];
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { getVersion } from '../cli/version.js';
+import { formatMcpErrorMessage } from './errors.js';
 import { type ToolResult, toolError } from './result.js';
 import { readPdf } from './tools/readPdf.js';
 import { renderPdf } from './tools/renderPdf.js';
@@ -79,7 +80,7 @@ async function run(handler: () => Promise<ToolResult>): Promise<ToolResult> {
   try {
     return await handler();
   } catch (error) {
-    return toolError(error instanceof Error ? error.message : String(error));
+    return toolError(formatMcpErrorMessage(error));
   }
 }
 

--- a/tests/core/passwordFailure.test.ts
+++ b/tests/core/passwordFailure.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { formatCliErrorMessage } from '../../src/cli/errors.js';
+import { classifyPasswordFailure } from '../../src/core/errors/passwordFailure.js';
+import { formatMcpErrorMessage } from '../../src/mcp/errors.js';
+
+function pdfjsError(message: string, code?: number): Error {
+  const error = new Error(message);
+  error.name = 'PasswordException';
+  if (code !== undefined) Object.assign(error, { code });
+  return error;
+}
+
+describe('classifyPasswordFailure', () => {
+  it('classifies a missing password from the pdf.js code', () => {
+    expect(classifyPasswordFailure(pdfjsError('No password given', 1))).toBe('missing');
+  });
+
+  it('classifies a wrong password from the pdf.js code', () => {
+    expect(classifyPasswordFailure(pdfjsError('Incorrect Password', 2))).toBe('incorrect');
+  });
+
+  it('falls back to the message when the code is lost in rewrapping', () => {
+    expect(classifyPasswordFailure(new Error('No password given'))).toBe('missing');
+    expect(classifyPasswordFailure(new Error('Incorrect Password'))).toBe('incorrect');
+  });
+
+  it('leaves unrelated failures alone, including ones that merely mention passwords', () => {
+    expect(classifyPasswordFailure(new Error('Invalid Root reference.'))).toBeUndefined();
+    expect(classifyPasswordFailure(new Error('--password-stdin received no input'))).toBeUndefined();
+    expect(classifyPasswordFailure('not an error at all')).toBeUndefined();
+  });
+});
+
+describe('surface-specific password remedies', () => {
+  it('names flags on the CLI', () => {
+    expect(formatCliErrorMessage(pdfjsError('No password given', 1))).toContain('--password');
+    expect(formatCliErrorMessage(pdfjsError('Incorrect Password', 2))).toContain('--password');
+  });
+
+  it('names the parameter over MCP, never a flag a shell-less caller cannot run', () => {
+    const missing = formatMcpErrorMessage(pdfjsError('No password given', 1));
+    expect(missing).toContain('password: "…"');
+    expect(missing).not.toContain('--password');
+
+    const incorrect = formatMcpErrorMessage(pdfjsError('Incorrect Password', 2));
+    expect(incorrect).toContain('`password`');
+    expect(incorrect).not.toContain('--password');
+  });
+
+  it('distinguishes a missing password from a wrong one, since the recovery differs', () => {
+    expect(formatMcpErrorMessage(pdfjsError('No password given', 1))).not.toEqual(
+      formatMcpErrorMessage(pdfjsError('Incorrect Password', 2)),
+    );
+  });
+
+  it('passes other messages through unchanged on both surfaces', () => {
+    const other = new Error('Invalid Root reference.');
+    expect(formatCliErrorMessage(other)).toBe('Invalid Root reference.');
+    expect(formatMcpErrorMessage(other)).toBe('Invalid Root reference.');
+  });
+});


### PR DESCRIPTION
Closes #160.

## Problem

```
read_pdf(source: "encrypted-user-pass.pdf")
→ pdfvision error: No password given
```

That is pdf.js's raw string. The CLI maps the same failure to `PDF is encrypted; pass --password <value> or --password-stdin to decrypt it.`, but the mapping lived in `src/cli/errors.ts`, which the MCP tools never reach. The agent learns a password is missing, not that `read_pdf` / `search_pdf` / `render_pdf` all take a `password` parameter — and since tool schemas are fetched lazily by most hosts, "a password parameter exists" is not necessarily in context when the error arrives.

This was the only failure path on the MCP surface handing back an unmapped upstream string.

## Change

The classification is surface-independent; the remedy is not. `core/errors/passwordFailure.ts` now owns `classifyPasswordFailure(error) → 'missing' | 'incorrect' | undefined` (pdf.js codes 1/2, with the message fallbacks for rewrapped errors), and each surface maps that to its own wording:

| | missing | incorrect |
|---|---|---|
| CLI | `PDF is encrypted; pass --password <value> or --password-stdin to decrypt it.` | `Incorrect PDF password; check the value passed via --password or --password-stdin.` |
| MCP | ``PDF is encrypted and no password was given — retry the same call with `password: "…"`.`` | ``Incorrect PDF password — retry the same call with a different `password` value.`` |

The two stay distinct because the recovery differs: supply a password vs. supply a different one.

CLI wording and behaviour are unchanged.

## Verification

End-to-end through the local MCP build:

```
read_pdf(source: "encrypted-user-pass.pdf")
→ pdfvision error: PDF is encrypted and no password was given — retry the same call with `password: "…"`.

read_pdf(source: "encrypted-user-pass.pdf", password: "wrong")
→ pdfvision error: Incorrect PDF password — retry the same call with a different `password` value.
```

Tests cover the classification, both surfaces' wording, the "MCP never names a flag" property, and pass-through of unrelated errors — including `--password-stdin received no input`, which mentions passwords but is not an encryption failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)