### PR TITLE
test(warnings): pin the default remedy clause as a literal too

### DIFF
--- a/tests/core/warnings/readingOrder.test.ts
+++ b/tests/core/warnings/readingOrder.test.ts
@@ -25,6 +25,10 @@ describe('detectPageWarnings', () => {
       expect(divergence).toBeDefined();
       expect(divergence?.blockIndex).toBe(0);
       expect(divergence?.message).toContain('Why Most Published Research Findings');
+      // Pinned as a literal, not built from the constant: `message` is a
+      // public field that JSON, XML, and TOON serialize verbatim, so this
+      // is the guard against rewording it by accident.
+      expect(divergence?.message.endsWith('prefer layout.blocks order when sequence matters')).toBe(true);
     });
 
     it('does not flag when native order matches the layout order', () => {


### PR DESCRIPTION
Follow-up to #165, from a codex review of the merged result.

#165 pinned the character-reorder variant (`when exact sequence matters`) as a string literal so that rewording it would fail the suite. The clause the other seven detectors emit — `prefer layout.blocks order when sequence matters` — was still asserted through the constant that produces it, so changing that constant would have kept every test green while changing a public `pages[].warnings[].message` that JSON, XML, and TOON serialize verbatim.

One literal assertion on the heading-divergence detector closes the gap. No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)