### PR TITLE
fix(cli): make the Common flows crop example runnable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable user-facing changes to pdfvision are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the `--render-region` line in `--help`'s Common flows block, which omitted `-r` and therefore failed with `--render-region requires --render or --ocr` when typed as printed. That block exists to steer agents to the evidence chain, so a command that errors is worse than no example. ([#168](https://github.com/yamadashy/pdfvision/pull/168))
+
 ### Changed
 
 - Collapsed a blank form's field table to a count and a type breakdown on surfaces that request the pass on the caller's behalf (the MCP server), instead of a full-width row per empty widget. On the IRS W-9 that table was 37% of page 1 while the response budget pushed pages 4-6 out. Filled values, checked boxes, scripted widgets, and hidden/locked ones still get a row each; `--form-fields` on the CLI is unchanged. ([#162](https://github.com/yamadashy/pdfvision/issues/162))

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Common flows
   pdfvision doc.pdf --search "term" --matches-only
                                         Locate a term without reading the whole body; each match
                                         reports its page and bbox.
-  pdfvision doc.pdf -p <page> --render-region <x,y,w,h>
+  pdfvision doc.pdf -p <page> -r --render-region <x,y,w,h>
                                         Crop a reported bbox as image evidence (use the bbox
                                         reported for a match or layout block).
   pdfvision doc.pdf -p <pages> --ocr    Re-read scanned pages (quality: empty_but_visual_content).

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -20,7 +20,7 @@ Common flows
   pdfvision doc.pdf --search "term" --matches-only
                                         Locate a term without reading the whole body; each match
                                         reports its page and bbox.
-  pdfvision doc.pdf -p <page> --render-region <x,y,w,h>
+  pdfvision doc.pdf -p <page> -r --render-region <x,y,w,h>
                                         Crop a reported bbox as image evidence (use the bbox
                                         reported for a match or layout block).
   pdfvision doc.pdf -p <pages> --ocr    Re-read scanned pages (quality: empty_but_visual_content).


### PR DESCRIPTION
Found by a broad codex review of `main`.

## Problem

`--help` opens with a Common flows block, added in #156 because bare-agent regression runs showed agents read only the first ~50 lines and never reached `--search`. Its third line reads:

```
pdfvision doc.pdf -p <page> --render-region <x,y,w,h>
```

Typed as printed, that exits 1:

```
Error: --render-region requires --render or --ocr
```

The block exists specifically to steer an agent to the search → crop evidence chain, so an example that fails on the first try is worse than no example — and 0.16.0 shipped it. The `Examples` section further down has it right (`-p 3 -r --render-region …`), as does the README's multimodal section; only the flow line was wrong.

## Change

Add the missing `-r`, and regenerate the README usage block from the built `--help` (CI checks the two stay in sync).

Verified the corrected command runs and writes the crop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)