### PR TITLE
test(ci): give Windows runners a timeout that fits the platform

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,14 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
-    testTimeout: 15000,
+    // Windows hosted runners repeatedly time out the same handful of tests
+    // — the ones whose first `processDocument` call in a worker pays for
+    // pdf.js worker startup plus the @napi-rs/canvas native load, several
+    // workers racing at once. Every occurrence has passed on re-run and
+    // passes locally, so 15s is a Linux/macOS-shaped number rather than a
+    // real budget. Re-running a red Windows job each time teaches everyone
+    // to ignore it, which is the actual cost.
+    testTimeout: process.platform === 'win32' ? 40000 : 15000,
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],


### PR DESCRIPTION
## Problem

The same three tests have timed out at the 15s default on `windows-latest` across three unrelated PRs (#158, #165, and the merge commit for #169 on `main`):

- `tests/cli/cli.test.ts > does not treat a blank --remote value as conflicting with a positional file`
- `tests/core/processDocument.test.ts > returns a structured DocumentResult, no JSON parsing required`
- `tests/core/search.test.ts > finds literal substring matches and attaches matches[] per page`

Each is the first `processDocument` call in its worker, so it pays for pdf.js worker startup plus the `@napi-rs/canvas` native load, with several workers racing, on the slowest hosted platform. Every occurrence passed on re-run and passes locally.

## Change

`testTimeout: process.platform === 'win32' ? 40000 : 15000`.

Linux and macOS keep 15s, so a genuine hang still fails fast on the platforms most runs use. This is not hiding a failure — the tests do pass on Windows, just not reliably inside a Linux-shaped budget. The real cost of the status quo is that a red Windows job stops meaning anything.

If these start failing on Windows *with* 40s, that is a signal worth chasing rather than a runner having a bad day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)