### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable user-facing changes to pdfvision are documented here.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-08-11
+
 ### Changed
 
 - Added `pdfvision docs` — the topic list and, with a topic name, its body — and cut `--help` from 20 KB to under 5 KB. The help was the first thing every agent read and the thing every error pointed at, so its size was a tax on first contact; the detail it carried now lives in fourteen topics that cost nothing until asked for. The topics are embedded at build time, so they describe the version actually installed rather than whatever the web has, and they need no network access. An unknown topic names the closest match and exits 1 instead of falling back to the list, which would read as "this topic is empty".
@@ -59,5 +61,6 @@ Notable user-facing changes to pdfvision are documented here.
 - Preserved explicit word spaces and corrected common paired-bracket direction when reconstructing right-to-left text. ([#102](https://github.com/yamadashy/pdfvision/pull/102))
 - Reported `checked: true` only for the selected radio widget instead of every widget in its group. ([#104](https://github.com/yamadashy/pdfvision/pull/104))
 
-[Unreleased]: https://github.com/yamadashy/pdfvision/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/yamadashy/pdfvision/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/yamadashy/pdfvision/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/yamadashy/pdfvision/compare/v0.15.0...v0.16.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdfvision",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdfvision",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfvision",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Release v0.17.0.

## Regression gate

Bare-agent regression protocol: **7/7 PASS** on this release state (2026-08-11).

- Headless sonnet sessions, one per task, task text verbatim, Bash-only tools.
- Both skill directories (`~/.claude/skills/`, `~/.agents/skills/`) parked for the run; every transcript grepped for `SKILL.md`, `skills/pdfvision`, and MCP references — all clean.
- Competing extractors (`pdftotext` et al.) shadowed so the run measures what pdfvision itself communicates, per the protocol's Method section.

| Task | Calls | pdfvision output consumed |
|---|---:|---:|
| 1 PLoS reading order | 3 | 10,746 B |
| 2 image-only scan | 2 | 4,785 B |
| 3 CJK chapter | 7 | 34,676 B |
| 4 evidence chain (canary) | 5 | **16,142 B ≈ 4,000 tok** |
| 5 truncated download | 4 | 8,820 B |
| 6 annotations | 2 | 12,575 B |
| 7 XFA form | 2 | 5,159 B |

Canary ceiling is ~5,000 tokens; task 4 came in at ~4,000.

Two observations recorded for the next run:

- **Task 4 diverged from its pass condition's wording.** The condition names `--search --matches-only` then `--render-region`; the agent used `--visual-regions --render-visual-regions`. The resulting crop was the whole of Table 2 and conclusive on its own, so the property under test held — but the condition should be reworded or the behaviour reconsidered.
- **Task 5 followed the error hint into `pdfvision docs` and `pdfvision docs options` unprompted.** That is the discovery path #176 built, working in a bare session with no skill loaded.

## Contents

`docs` and `clear-cache` subcommands, `--help` cut from 20 KB to 5.5 KB, a `security` topic, crop-ready `region` on `--matches-only`, blank-form table collapsing on MCP, warning replay on cache hits, and the fixes listed in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)