### PR TITLE
docs(warnings): explain hidden native text on the site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable user-facing changes to pdfvision are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- Added site guidance for inspecting searchable native text that is invisible or covered by a later opaque fill, including the limits of these warnings and rendered-page verification.
+
 ## [0.18.0] - 2026-08-19
 
 ### Fixed

--- a/docs/src/en/guide/layout-and-warnings.md
+++ b/docs/src/en/guide/layout-and-warnings.md
@@ -84,6 +84,23 @@ Common warning families include:
 - large raster regions whose internal labels may need vision.
 - dense vector pages such as forms, charts, or diagrams.
 
+### Hidden Native Text
+
+A PDF can contain successfully extracted and searchable native text that is not visible on the rendered page. These checks run by default—no geometry or vector flag is required—and they leave the original extracted text unchanged. Inspect `pages[].warnings` separately from `quality.nativeTextStatus`, which can still be `ok`.
+
+| Code | What it means |
+| --- | --- |
+| `invisible_text` | Text was shown while PDF text rendering mode `Tr 3` was active, so it remains in native extraction but is not painted for a viewer. |
+| `text_under_opaque_fill` | A later opaque dark rectangular fill covers extracted text. This can reveal a specific visual-only redaction failure, but it is not a general redaction detector. |
+
+To avoid expected scan/OCR layers, `invisible_text` is suppressed when a full-page raster backs the page, while `text_under_opaque_fill` is suppressed when `raster_backed_text_layer` applies. Inspect the affected page as rendered:
+
+```bash
+pdfvision document.pdf -p 3 --render --format json
+```
+
+A render establishes only what the page visibly shows. Neither a warning nor its absence validates whether redaction succeeded, and absence does not certify visibility, correctness, or safety. These detectors do not find arbitrary hidden text or prompt injection. See `pdfvision docs warnings` for full warning details, and [Security and Privacy](./security-and-privacy.md) before acting on or sharing PDF-derived content.
+
 Warnings are not final judgments. They are inspection cues that tell the agent which page or region deserves a closer look.
 
 ## How Agents Should Use Warnings

--- a/docs/src/ja/guide/layout-and-warnings.md
+++ b/docs/src/ja/guide/layout-and-warnings.md
@@ -82,6 +82,23 @@ visual regions は multimodal model への橋渡しとして使えます。
 - 画像内ラベルを視覚モデルで読むべき大きなラスター領域。
 - フォーム、グラフ、ダイアグラムのような密なベクターページ。
 
+### Hidden Native Text
+
+A PDF can contain successfully extracted and searchable native text that is not visible on the rendered page. These checks run by default—no geometry or vector flag is required—and they leave the original extracted text unchanged. Inspect `pages[].warnings` separately from `quality.nativeTextStatus`, which can still be `ok`.
+
+| Code | What it means |
+| --- | --- |
+| `invisible_text` | Text was shown while PDF text rendering mode `Tr 3` was active, so it remains in native extraction but is not painted for a viewer. |
+| `text_under_opaque_fill` | A later opaque dark rectangular fill covers extracted text. This can reveal a specific visual-only redaction failure, but it is not a general redaction detector. |
+
+To avoid expected scan/OCR layers, `invisible_text` is suppressed when a full-page raster backs the page, while `text_under_opaque_fill` is suppressed when `raster_backed_text_layer` applies. Inspect the affected page as rendered:
+
+```bash
+pdfvision document.pdf -p 3 --render --format json
+```
+
+A render establishes only what the page visibly shows. Neither a warning nor its absence validates whether redaction succeeded, and absence does not certify visibility, correctness, or safety. These detectors do not find arbitrary hidden text or prompt injection. See `pdfvision docs warnings` for full warning details, and [Security and Privacy](./security-and-privacy.md) before acting on or sharing PDF-derived content.
+
 警告は最終判断ではなく、エージェントが次に確認すべき場所を示す手がかりです。
 
 ## エージェントは警告をどう使うべきか

--- a/docs/src/zh-cn/guide/layout-and-warnings.md
+++ b/docs/src/zh-cn/guide/layout-and-warnings.md
@@ -82,6 +82,23 @@ visual regions 可以作为到多模态模型的桥梁：
 - 内部标签可能需要视觉模型读取的大型栅格区域。
 - 表单、图表或示意图这样的密集矢量页面。
 
+### Hidden Native Text
+
+A PDF can contain successfully extracted and searchable native text that is not visible on the rendered page. These checks run by default—no geometry or vector flag is required—and they leave the original extracted text unchanged. Inspect `pages[].warnings` separately from `quality.nativeTextStatus`, which can still be `ok`.
+
+| Code | What it means |
+| --- | --- |
+| `invisible_text` | Text was shown while PDF text rendering mode `Tr 3` was active, so it remains in native extraction but is not painted for a viewer. |
+| `text_under_opaque_fill` | A later opaque dark rectangular fill covers extracted text. This can reveal a specific visual-only redaction failure, but it is not a general redaction detector. |
+
+To avoid expected scan/OCR layers, `invisible_text` is suppressed when a full-page raster backs the page, while `text_under_opaque_fill` is suppressed when `raster_backed_text_layer` applies. Inspect the affected page as rendered:
+
+```bash
+pdfvision document.pdf -p 3 --render --format json
+```
+
+A render establishes only what the page visibly shows. Neither a warning nor its absence validates whether redaction succeeded, and absence does not certify visibility, correctness, or safety. These detectors do not find arbitrary hidden text or prompt injection. See `pdfvision docs warnings` for full warning details, and [Security and Privacy](./security-and-privacy.md) before acting on or sharing PDF-derived content.
+
 警告不是最终判断，而是告诉智能体下一步应检查哪里。
 
 ## 智能体应如何使用警告

--- a/docs/src/zh-tw/guide/layout-and-warnings.md
+++ b/docs/src/zh-tw/guide/layout-and-warnings.md
@@ -82,6 +82,23 @@ visual regions 可以作為到多模態模型的橋樑：
 - 內部標籤可能需要視覺模型讀取的大型 raster 區域。
 - 表單、圖表或示意圖這樣的密集向量頁面。
 
+### Hidden Native Text
+
+A PDF can contain successfully extracted and searchable native text that is not visible on the rendered page. These checks run by default—no geometry or vector flag is required—and they leave the original extracted text unchanged. Inspect `pages[].warnings` separately from `quality.nativeTextStatus`, which can still be `ok`.
+
+| Code | What it means |
+| --- | --- |
+| `invisible_text` | Text was shown while PDF text rendering mode `Tr 3` was active, so it remains in native extraction but is not painted for a viewer. |
+| `text_under_opaque_fill` | A later opaque dark rectangular fill covers extracted text. This can reveal a specific visual-only redaction failure, but it is not a general redaction detector. |
+
+To avoid expected scan/OCR layers, `invisible_text` is suppressed when a full-page raster backs the page, while `text_under_opaque_fill` is suppressed when `raster_backed_text_layer` applies. Inspect the affected page as rendered:
+
+```bash
+pdfvision document.pdf -p 3 --render --format json
+```
+
+A render establishes only what the page visibly shows. Neither a warning nor its absence validates whether redaction succeeded, and absence does not certify visibility, correctness, or safety. These detectors do not find arbitrary hidden text or prompt injection. See `pdfvision docs warnings` for full warning details, and [Security and Privacy](./security-and-privacy.md) before acting on or sharing PDF-derived content.
+
 警告不是最終判斷，而是告訴代理下一步應檢查哪裡。
 
 ## 代理應如何使用警告


### PR DESCRIPTION
The site did not explain that successfully extracted and searchable native text may be invisible or covered on the page. Add guidance for the existing `invisible_text` and `text_under_opaque_fill` warnings, their render follow-up, and their conservative limits across all four locale guides. Extraction behavior is unchanged.

The examples were checked against the built CLI and rendered fixtures: invisible text remains in extraction while the marker is absent from the image; the covered-text fixture retains its text beneath a visible black rectangle. The guide also explains why page warnings must be read separately from `quality.nativeTextStatus`.

Validation: clean `npm ci`, lint, all 1,974 tests, CLI build, site build, and README usage sync passed. Fixture renders before and after dependency synchronization were byte-identical. New prose is English in every locale, as required by the owner's repository-wide language policy.
