### PR TITLE
chore(release): publish to the official MCP Registry

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Download mcp-publisher
         if: ${{ !inputs.dry-run }}
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Login to MCP Registry
         if: ${{ !inputs.dry-run }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -62,3 +62,27 @@ jobs:
       - name: Publish
         if: ${{ !inputs.dry-run }}
         run: npm publish --provenance --access public
+
+      - name: Download mcp-publisher
+        if: ${{ !inputs.dry-run }}
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Login to MCP Registry
+        if: ${{ !inputs.dry-run }}
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        if: ${{ !inputs.dry-run }}
+        run: |
+          # The registry validates that the npm version it's told about
+          # actually resolves on the npm registry, and npm propagation can
+          # lag behind our own publish step by up to a minute or so.
+          for attempt in 1 2 3 4 5; do
+            if ./mcp-publisher publish; then
+              exit 0
+            fi
+            echo "mcp-publisher publish failed (attempt ${attempt}/5), retrying in 30s..."
+            sleep 30
+          done
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable user-facing changes to pdfvision are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Listed in the official MCP Registry as `io.github.yamadashy/pdfvision`; the npm-publish workflow now publishes `server.json` after each release.
+
 ### Changed
 
 - Added site guidance for inspecting searchable native text that is invisible or covered by a later opaque fill, including the limits of these warnings and rendered-page verification.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "pdfvision",
   "version": "0.18.0",
+  "mcpName": "io.github.yamadashy/pdfvision",
   "description": "Extract text, metadata, and page images from PDF files. Designed for AI agents.",
   "type": "module",
   "main": "./dist/index.mjs",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.yamadashy/pdfvision",
+  "description": "PDF reading for AI agents: search text, check quality signals, render only the region that matters",
+  "title": "pdfvision",
+  "websiteUrl": "https://pdfvision.dev/",
+  "repository": { "url": "https://github.com/yamadashy/pdfvision", "source": "github" },
+  "version": "0.18.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "pdfvision",
+      "version": "0.18.0",
+      "transport": { "type": "stdio" },
+      "packageArguments": [{ "type": "positional", "value": "mcp" }]
+    }
+  ]
+}

--- a/tests/mcp/serverJson.test.ts
+++ b/tests/mcp/serverJson.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+
+interface McpServerJson {
+  name: string;
+  description: string;
+  version: string;
+  packages: Array<{ identifier: string; version: string }>;
+}
+
+/**
+ * server.json is hand-maintained and this repo has no version-bump script,
+ * so nothing else keeps it in sync with package.json. This test is the
+ * tripwire: it fails the moment a release bumps the version in one place
+ * and not the other.
+ */
+describe('server.json', () => {
+  const packageJson = JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')) as {
+    name: string;
+    version: string;
+    mcpName: string;
+  };
+  const serverJson = JSON.parse(readFileSync(`${repoRoot}server.json`, 'utf8')) as McpServerJson;
+
+  it('parses as valid JSON', () => {
+    expect(serverJson).toBeTypeOf('object');
+  });
+
+  it('names the server with the reverse-DNS mcpName from package.json', () => {
+    expect(serverJson.name).toBe(packageJson.mcpName);
+  });
+
+  it('keeps the top-level version and the package version in sync with package.json', () => {
+    expect(serverJson.version).toBe(packageJson.version);
+    expect(serverJson.packages[0]?.version).toBe(packageJson.version);
+  });
+
+  it('identifies the npm package by the package.json name', () => {
+    expect(serverJson.packages[0]?.identifier).toBe(packageJson.name);
+  });
+
+  it('keeps the description within the registry limit', () => {
+    expect(serverJson.description.length).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## Summary
- `package.json`: add `mcpName: io.github.yamadashy/pdfvision`, the field the MCP Registry's npm-publish validation looks for in the published package manifest.
- `server.json`: the registry server description (name, repository, npm package reference, stdio transport with `mcp` positional arg). A new test, `tests/mcp/serverJson.test.ts`, keeps its `name`/`version`/`packages[0].identifier`/`packages[0].version`/`description` length in sync with `package.json`, since the repo has no version-bump script that would otherwise catch drift.
- `.github/workflows/npm-publish.yml`: after the real (non-dry-run) `npm publish` step, download `mcp-publisher`, authenticate via GitHub OIDC (no secrets needed — the job already has `id-token: write`), and publish `server.json` to the registry. The publish step is wrapped in a short retry loop (up to 5 attempts, 30s apart) because the registry validates that the npm version it's told about actually resolves on npm, and npm's own propagation can lag behind our publish step by up to a minute.

The registry entry only goes live starting with the **next** npm release — `mcpName` needs to be present in the published `package.json` for the registry's ownership check to pass, and the current `0.18.0` on npm predates this change.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (includes the new `tests/mcp/serverJson.test.ts`)
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)