### PR TITLE
docs(search): use compact regions in site crop examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Notable user-facing changes to pdfvision are documented here.
 
 ### Changed
 
+- Updated the search-and-zoom guide to distinguish a match's tight `bbox` from the compact report's crop-ready `region`, then pass that region unchanged to `--render-region`.
 - Added site guidance for inspecting searchable native text that is invisible or covered by a later opaque fill, including the limits of these warnings and rendered-page verification.
 
 ### Fixed

--- a/docs/src/en/guide/search-and-region-zoom.md
+++ b/docs/src/en/guide/search-and-region-zoom.md
@@ -12,14 +12,14 @@ This is one of the most agent-friendly workflows in pdfvision: use text search a
 ## Search a PDF
 
 ```bash
-pdfvision report.pdf --search "revenue" --json
+pdfvision report.pdf --search "revenue" --matches-only --json
 ```
 
-Matches are emitted in `pages[].matches[]`. Each match includes the page number, query, source, text snippet, and a bounding box when pdfvision can locate the visible area.
+With `--matches-only`, JSON and TOON emit compact hits in the top-level `matches[]` array without page bodies. Each hit includes its page, `queryIndex` linked to the top-level `queries` array, source, text, optional context, tight `bbox`, and crop-ready `region`. Without `--matches-only`, full JSON and TOON keep hits in `pages[].matches[]` alongside the page payload; those full hits include `bbox`, but not `region`.
 
-Markdown output also shows a per-page `Search matches` table when `--search` is used. Use JSON, XML, or TOON when a downstream tool needs to consume the coordinates directly.
+Full Markdown output still shows a per-page `Search matches` table when `--search` is used. With `--matches-only`, Markdown becomes a compact flat report, while JSON, XML, or TOON remain the better choice when another tool needs to consume coordinates directly.
 
-Add `--matches-only` for a compact flat report without page bodies. If any selected page has a non-default PDF `/UserUnit`, the report preserves it as `pageUserUnits: [{ page, userUnit }]` in JSON/TOON, equivalent `<pageUserUnits>` entries in XML, and a `Page UserUnits` summary in Markdown. The metadata is omitted when every selected page uses UserUnit 1.
+If any selected page has a non-default PDF `/UserUnit`, the compact report preserves it as `pageUserUnits: [{ page, userUnit }]` in JSON/TOON, equivalent `<pageUserUnits>` entries in XML, and a `Page UserUnits` summary in Markdown. The metadata is omitted when every selected page uses UserUnit 1.
 
 Compact output still retains optional diagnostics for every selected page with warnings or non-OK native or visual quality, including pages with no hits and searches with zero total results. JSON/TOON expose `pageDiagnostics` with raw quality and complete warnings; XML and Markdown present the same information in compact diagnostic sections. Inspect it before treating a hit or miss as visible evidence. Native quality describes native text only and does not rule out OCR or field hits. When applicable, `unreadableSource` keeps document-wide XFA placeholder scope and recovery guidance; rendering a confirmed XFA placeholder only renders the placeholder, so open it in Adobe Acrobat/Reader instead.
 
@@ -72,13 +72,15 @@ For multi-query searches, `queryIndex` lets the caller map each hit back to the 
 
 ## Render the Matching Region
 
-Take a match bbox and pass it to `--render-region`:
+`bbox` locates the matched text itself. The compact hit's `region` optionally expands that box to a detected containing table row or visual line, then adds padding and clamps the result within the page. Without a containing structure, it is the padded match geometry. The crop provides nearby visual evidence, but it does not guarantee that an entire table, all headers, or relevant footnotes are included. Compact search computes this region internally, so it does not need `--layout`.
+
+Choose a compact hit by its `page`, `source`, and `context`, then pass its `region` unchanged. For example, if the chosen hit reports the illustrative values `page: 3` and `region: { x: 120, y: 180, width: 360, height: 140 }`, run:
 
 ```bash
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` requires exactly one selected page. The region uses raw unrotated page-view units with a top-left origin, and it must stay within the page bounds. Physical points = raw value × `pages[].userUnit` (or 1 when omitted); pixels = raw region × UserUnit × render scale.
+`--render-region` requires exactly one selected page. The region uses raw unrotated page-view units with a top-left origin; compact regions are already clamped, while a custom region must stay within the page bounds. Physical points = raw value × UserUnit; pixels = raw region × UserUnit × render scale. Read UserUnit from `pages[].userUnit` in the full report or the selected page's `pageUserUnits` entry in the compact report (1 when omitted).
 
 Use `--render-scale` when the crop contains small labels, superscripts, dense table cells, or chart legends:
 
@@ -86,13 +88,13 @@ Use `--render-scale` when the crop contains small labels, superscripts, dense ta
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-scale 3 --render-output ./crops --json
 ```
 
-For best crops, add padding around a match bbox before passing it to `--render-region`. A little surrounding context helps vision models read labels, row headers, and nearby explanatory text.
+Start with the emitted `region` unchanged. If the task needs different context, a custom narrower or wider crop remains available within the page bounds.
 
 ## Agent Workflow
 
-1. Run `--search` to locate candidate evidence.
-2. Inspect `pages[].matches[]` and choose the bbox with the right source and page.
-3. Re-run with `--pages`, `--render`, and `--render-region` for a visual crop.
+1. Run `--search "…" --matches-only --json` to locate candidate evidence without page bodies.
+2. Inspect top-level `matches[]` and choose the hit with the right page, source, and context.
+3. Re-run with exactly that hit's `page` and unchanged `region` in `--pages`, `--render`, and `--render-region`.
 4. Ask the vision model to compare the crop against the native text, OCR text, or extracted table data.
 
 For visual regions that are not text-searchable, use [Rendering and OCR](./rendering-and-ocr.md) with `--visual-regions` or `--render-visual-regions`.
@@ -100,10 +102,10 @@ For visual regions that are not text-searchable, use [Rendering and OCR](./rende
 ## Example: Auditable Claim Check
 
 ```bash
-pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --layout --json
+pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --matches-only --json
 ```
 
-An agent can inspect `pages[].matches[]`, choose the hit with the right page and surrounding context, then request a crop:
+An agent can inspect top-level `matches[]`, choose the hit with the right page, source, and context, then pass its `region` to the crop command. No `--layout` flag is needed because compact search computes the region internally. If that selected hit reports the following illustrative page and region, the follow-up is:
 
 ```bash
 pdfvision annual-report.pdf --pages 42 --render --render-region 72,180,468,180 --render-output ./evidence --json

--- a/docs/src/ja/guide/search-and-region-zoom.md
+++ b/docs/src/ja/guide/search-and-region-zoom.md
@@ -12,12 +12,14 @@ pdfvision は、まずテキストの根拠を探し、その一致領域だけ�
 ## PDF を検索する
 
 ```bash
-pdfvision report.pdf --search "revenue" --json
+pdfvision report.pdf --search "revenue" --matches-only --json
 ```
 
-一致結果は `pages[].matches[]` に出ます。各 match にはページ番号、query、source、テキスト断片、位置を特定できた場合の bbox が含まれます。
+With `--matches-only`, JSON and TOON emit compact hits in the top-level `matches[]` array without page bodies. Each hit includes its page, `queryIndex` linked to the top-level `queries` array, source, text, optional context, tight `bbox`, and crop-ready `region`. Without `--matches-only`, full JSON and TOON keep hits in `pages[].matches[]` alongside the page payload; those full hits include `bbox`, but not `region`.
 
-ページ本文を除いた小さなフラット形式が必要なら、`--matches-only` を追加します。選択ページに既定値以外の PDF `/UserUnit` があれば、JSON/TOON では `pageUserUnits: [{ page, userUnit }]`、XML では同等の `<pageUserUnits>`、Markdown では `Page UserUnits` の要約として保持します。すべての選択ページが UserUnit 1 の場合、このメタデータは省略されます。
+Full Markdown output still shows a per-page `Search matches` table when `--search` is used. With `--matches-only`, Markdown becomes a compact flat report, while JSON, XML, or TOON remain the better choice when another tool needs to consume coordinates directly.
+
+If any selected page has a non-default PDF `/UserUnit`, the compact report preserves it as `pageUserUnits: [{ page, userUnit }]` in JSON/TOON, equivalent `<pageUserUnits>` entries in XML, and a `Page UserUnits` summary in Markdown. The metadata is omitted when every selected page uses UserUnit 1.
 
 Compact output still retains optional diagnostics for every selected page with warnings or non-OK native or visual quality, including pages with no hits and searches with zero total results. JSON/TOON expose `pageDiagnostics` with raw quality and complete warnings; XML and Markdown present the same information in compact diagnostic sections. Inspect it before treating a hit or miss as visible evidence. Native quality describes native text only and does not rule out OCR or field hits. When applicable, `unreadableSource` keeps document-wide XFA placeholder scope and recovery guidance; rendering a confirmed XFA placeholder only renders the placeholder, so open it in Adobe Acrobat/Reader instead.
 
@@ -70,38 +72,40 @@ match の `source` は、エージェントがどの程度信頼すべきかを�
 
 ## 一致領域をレンダリングする
 
-match の bbox を `--render-region` に渡します。
+`bbox` locates the matched text itself. The compact hit's `region` optionally expands that box to a detected containing table row or visual line, then adds padding and clamps the result within the page. Without a containing structure, it is the padded match geometry. The crop provides nearby visual evidence, but it does not guarantee that an entire table, all headers, or relevant footnotes are included. Compact search computes this region internally, so it does not need `--layout`.
+
+Choose a compact hit by its `page`, `source`, and `context`, then pass its `region` unchanged. For example, if the chosen hit reports the illustrative values `page: 3` and `region: { x: 120, y: 180, width: 360, height: 140 }`, run:
 
 ```bash
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` は、選択ページがちょうど 1 ページである必要があります。領域は回転前の生の page-view units と左上原点を使い、ページ境界内に収めます。物理サイズのポイント数は「生の値 × `pages[].userUnit`（省略時は 1）」、ピクセル数は「生の領域 × UserUnit × render scale」です。
+`--render-region` requires exactly one selected page. The region uses raw unrotated page-view units with a top-left origin; compact regions are already clamped, while a custom region must stay within the page bounds. Physical points = raw value × UserUnit; pixels = raw region × UserUnit × render scale. Read UserUnit from `pages[].userUnit` in the full report or the selected page's `pageUserUnits` entry in the compact report (1 when omitted).
 
-小さいラベル、上付き文字、密な表セル、チャート凡例では `--render-scale` を上げます。
+Use `--render-scale` when the crop contains small labels, superscripts, dense table cells, or chart legends:
 
 ```bash
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-scale 3 --render-output ./crops --json
 ```
 
-よい crop にするには、match bbox の周囲に少し余白を足してから `--render-region` に渡します。周辺文脈があると、vision model がラベル、行見出し、近くの説明文を読みやすくなります。
+Start with the emitted `region` unchanged. If the task needs different context, a custom narrower or wider crop remains available within the page bounds.
 
 ## エージェントの流れ
 
-1. `--search` で候補の根拠を探す。
-2. `pages[].matches[]` から page、source、bbox が適切な match を選ぶ。
-3. `--pages`、`--render`、`--render-region` で視覚クロップを作る。
-4. クロップをネイティブテキスト、OCR テキスト、周辺 layout block と比較する。
+1. Run `--search "…" --matches-only --json` to locate candidate evidence without page bodies.
+2. Inspect top-level `matches[]` and choose the hit with the right page, source, and context.
+3. Re-run with exactly that hit's `page` and unchanged `region` in `--pages`, `--render`, and `--render-region`.
+4. Ask the vision model to compare the crop against the native text, OCR text, or extracted table data.
 
 テキスト検索できない視覚領域には、[レンダリングと OCR](./rendering-and-ocr.md) の `--visual-regions` または `--render-visual-regions` を使います。
 
 ## 例: 監査可能な claim check
 
 ```bash
-pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --layout --json
+pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --matches-only --json
 ```
 
-エージェントは `pages[].matches[]` を見て、正しいページと周辺 context を持つ hit を選び、crop を要求できます。
+An agent can inspect top-level `matches[]`, choose the hit with the right page, source, and context, then pass its `region` to the crop command. No `--layout` flag is needed because compact search computes the region internally. If that selected hit reports the following illustrative page and region, the follow-up is:
 
 ```bash
 pdfvision annual-report.pdf --pages 42 --render --render-region 72,180,468,180 --render-output ./evidence --json

--- a/docs/src/zh-cn/guide/search-and-region-zoom.md
+++ b/docs/src/zh-cn/guide/search-and-region-zoom.md
@@ -12,12 +12,14 @@ pdfvision 可以先找到文本证据，再只渲染匹配区域。这适合让�
 ## 搜索 PDF
 
 ```bash
-pdfvision report.pdf --search "revenue" --json
+pdfvision report.pdf --search "revenue" --matches-only --json
 ```
 
-匹配结果会输出到 `pages[].matches[]`。每个 match 包含页码、query、source、文本片段，以及能够定位可见区域时的 bbox。
+With `--matches-only`, JSON and TOON emit compact hits in the top-level `matches[]` array without page bodies. Each hit includes its page, `queryIndex` linked to the top-level `queries` array, source, text, optional context, tight `bbox`, and crop-ready `region`. Without `--matches-only`, full JSON and TOON keep hits in `pages[].matches[]` alongside the page payload; those full hits include `bbox`, but not `region`.
 
-如需省略页面正文的紧凑扁平报告，可添加 `--matches-only`。如果任一选中页面使用非默认 PDF `/UserUnit`，JSON/TOON 会保留 `pageUserUnits: [{ page, userUnit }]`，XML 会输出等价的 `<pageUserUnits>`，Markdown 会输出 `Page UserUnits` 摘要。所有选中页面均使用 UserUnit 1 时，该元数据会被省略。
+Full Markdown output still shows a per-page `Search matches` table when `--search` is used. With `--matches-only`, Markdown becomes a compact flat report, while JSON, XML, or TOON remain the better choice when another tool needs to consume coordinates directly.
+
+If any selected page has a non-default PDF `/UserUnit`, the compact report preserves it as `pageUserUnits: [{ page, userUnit }]` in JSON/TOON, equivalent `<pageUserUnits>` entries in XML, and a `Page UserUnits` summary in Markdown. The metadata is omitted when every selected page uses UserUnit 1.
 
 Compact output still retains optional diagnostics for every selected page with warnings or non-OK native or visual quality, including pages with no hits and searches with zero total results. JSON/TOON expose `pageDiagnostics` with raw quality and complete warnings; XML and Markdown present the same information in compact diagnostic sections. Inspect it before treating a hit or miss as visible evidence. Native quality describes native text only and does not rule out OCR or field hits. When applicable, `unreadableSource` keeps document-wide XFA placeholder scope and recovery guidance; rendering a confirmed XFA placeholder only renders the placeholder, so open it in Adobe Acrobat/Reader instead.
 
@@ -70,38 +72,40 @@ match 的 `source` 帮助智能体判断它应该被多大程度信任：
 
 ## 渲染匹配区域
 
-把 match 的 bbox 传给 `--render-region`：
+`bbox` locates the matched text itself. The compact hit's `region` optionally expands that box to a detected containing table row or visual line, then adds padding and clamps the result within the page. Without a containing structure, it is the padded match geometry. The crop provides nearby visual evidence, but it does not guarantee that an entire table, all headers, or relevant footnotes are included. Compact search computes this region internally, so it does not need `--layout`.
+
+Choose a compact hit by its `page`, `source`, and `context`, then pass its `region` unchanged. For example, if the chosen hit reports the illustrative values `page: 3` and `region: { x: 120, y: 180, width: 360, height: 140 }`, run:
 
 ```bash
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` 要求选中的页恰好为一页。区域使用未旋转的原始 page-view units 和左上角原点，并且必须在页面边界内。物理点数 = 原始值 × `pages[].userUnit`（省略时按 1）；像素数 = 原始区域 × UserUnit × render scale。
+`--render-region` requires exactly one selected page. The region uses raw unrotated page-view units with a top-left origin; compact regions are already clamped, while a custom region must stay within the page bounds. Physical points = raw value × UserUnit; pixels = raw region × UserUnit × render scale. Read UserUnit from `pages[].userUnit` in the full report or the selected page's `pageUserUnits` entry in the compact report (1 when omitted).
 
-如果裁剪图包含小标签、上标、密集表格单元格或图表图例，可以提高 `--render-scale`：
+Use `--render-scale` when the crop contains small labels, superscripts, dense table cells, or chart legends:
 
 ```bash
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-scale 3 --render-output ./crops --json
 ```
 
-为了获得更好的 crop，可在把 match bbox 传给 `--render-region` 前加一点 padding。少量周边上下文能帮助视觉模型读取标签、行头和附近说明文字。
+Start with the emitted `region` unchanged. If the task needs different context, a custom narrower or wider crop remains available within the page bounds.
 
 ## 智能体工作流
 
-1. 运行 `--search` 找到候选证据。
-2. 查看 `pages[].matches[]`，选择 page、source 和 bbox 合适的 match。
-3. 用 `--pages`、`--render` 和 `--render-region` 重新运行，生成视觉裁剪图。
-4. 让视觉模型把裁剪图与原生文本、OCR 文本或提取出的表格数据进行对照。
+1. Run `--search "…" --matches-only --json` to locate candidate evidence without page bodies.
+2. Inspect top-level `matches[]` and choose the hit with the right page, source, and context.
+3. Re-run with exactly that hit's `page` and unchanged `region` in `--pages`, `--render`, and `--render-region`.
+4. Ask the vision model to compare the crop against the native text, OCR text, or extracted table data.
 
 对于无法通过文本搜索定位的视觉区域，请结合 [渲染与 OCR](./rendering-and-ocr.md) 使用 `--visual-regions` 或 `--render-visual-regions`。
 
 ## 示例：可审计的 claim check
 
 ```bash
-pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --layout --json
+pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --matches-only --json
 ```
 
-智能体可以检查 `pages[].matches[]`，选择页面和周边 context 正确的 hit，然后请求 crop：
+An agent can inspect top-level `matches[]`, choose the hit with the right page, source, and context, then pass its `region` to the crop command. No `--layout` flag is needed because compact search computes the region internally. If that selected hit reports the following illustrative page and region, the follow-up is:
 
 ```bash
 pdfvision annual-report.pdf --pages 42 --render --render-region 72,180,468,180 --render-output ./evidence --json

--- a/docs/src/zh-tw/guide/search-and-region-zoom.md
+++ b/docs/src/zh-tw/guide/search-and-region-zoom.md
@@ -12,12 +12,14 @@ pdfvision 可以先找到文字證據，再只渲染匹配區域。這適合讓�
 ## 搜尋 PDF
 
 ```bash
-pdfvision report.pdf --search "revenue" --json
+pdfvision report.pdf --search "revenue" --matches-only --json
 ```
 
-匹配結果會輸出到 `pages[].matches[]`。每個 match 包含頁碼、query、source、文字片段，以及能夠定位可見區域時的 bbox。
+With `--matches-only`, JSON and TOON emit compact hits in the top-level `matches[]` array without page bodies. Each hit includes its page, `queryIndex` linked to the top-level `queries` array, source, text, optional context, tight `bbox`, and crop-ready `region`. Without `--matches-only`, full JSON and TOON keep hits in `pages[].matches[]` alongside the page payload; those full hits include `bbox`, but not `region`.
 
-如需省略頁面本文的精簡扁平報告，可加入 `--matches-only`。如果任一選中頁面使用非預設 PDF `/UserUnit`，JSON/TOON 會保留 `pageUserUnits: [{ page, userUnit }]`，XML 會輸出對等的 `<pageUserUnits>`，Markdown 會輸出 `Page UserUnits` 摘要。所有選中頁面均使用 UserUnit 1 時，此中繼資料會省略。
+Full Markdown output still shows a per-page `Search matches` table when `--search` is used. With `--matches-only`, Markdown becomes a compact flat report, while JSON, XML, or TOON remain the better choice when another tool needs to consume coordinates directly.
+
+If any selected page has a non-default PDF `/UserUnit`, the compact report preserves it as `pageUserUnits: [{ page, userUnit }]` in JSON/TOON, equivalent `<pageUserUnits>` entries in XML, and a `Page UserUnits` summary in Markdown. The metadata is omitted when every selected page uses UserUnit 1.
 
 Compact output still retains optional diagnostics for every selected page with warnings or non-OK native or visual quality, including pages with no hits and searches with zero total results. JSON/TOON expose `pageDiagnostics` with raw quality and complete warnings; XML and Markdown present the same information in compact diagnostic sections. Inspect it before treating a hit or miss as visible evidence. Native quality describes native text only and does not rule out OCR or field hits. When applicable, `unreadableSource` keeps document-wide XFA placeholder scope and recovery guidance; rendering a confirmed XFA placeholder only renders the placeholder, so open it in Adobe Acrobat/Reader instead.
 
@@ -70,38 +72,40 @@ match 的 `source` 幫助代理判斷它應該被多大程度信任：
 
 ## 渲染匹配區域
 
-把 match 的 bbox 傳給 `--render-region`：
+`bbox` locates the matched text itself. The compact hit's `region` optionally expands that box to a detected containing table row or visual line, then adds padding and clamps the result within the page. Without a containing structure, it is the padded match geometry. The crop provides nearby visual evidence, but it does not guarantee that an entire table, all headers, or relevant footnotes are included. Compact search computes this region internally, so it does not need `--layout`.
+
+Choose a compact hit by its `page`, `source`, and `context`, then pass its `region` unchanged. For example, if the chosen hit reports the illustrative values `page: 3` and `region: { x: 120, y: 180, width: 360, height: 140 }`, run:
 
 ```bash
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-output ./crops --json
 ```
 
-`--render-region` 要求選中的頁剛好為一頁。區域使用未旋轉的原始 page-view units 和左上角原點，並且必須在頁面邊界內。物理點數 = 原始值 × `pages[].userUnit`（省略時按 1）；像素數 = 原始區域 × UserUnit × render scale。
+`--render-region` requires exactly one selected page. The region uses raw unrotated page-view units with a top-left origin; compact regions are already clamped, while a custom region must stay within the page bounds. Physical points = raw value × UserUnit; pixels = raw region × UserUnit × render scale. Read UserUnit from `pages[].userUnit` in the full report or the selected page's `pageUserUnits` entry in the compact report (1 when omitted).
 
-如果裁切圖包含小標籤、上標、密集表格儲存格或圖表圖例，可以提高 `--render-scale`：
+Use `--render-scale` when the crop contains small labels, superscripts, dense table cells, or chart legends:
 
 ```bash
 pdfvision report.pdf --pages 3 --render --render-region 120,180,360,140 --render-scale 3 --render-output ./crops --json
 ```
 
-為了獲得更好的 crop，可在把 match bbox 傳給 `--render-region` 前加一點 padding。少量周邊上下文能幫助視覺模型讀取標籤、列頭和附近說明文字。
+Start with the emitted `region` unchanged. If the task needs different context, a custom narrower or wider crop remains available within the page bounds.
 
 ## 代理工作流
 
-1. 執行 `--search` 找到候選證據。
-2. 查看 `pages[].matches[]`，選擇 page、source 和 bbox 合適的 match。
-3. 用 `--pages`、`--render` 和 `--render-region` 重新執行，產生視覺裁切圖。
-4. 讓視覺模型把裁切圖與原生文字、OCR 文字或擷取出的表格資料進行對照。
+1. Run `--search "…" --matches-only --json` to locate candidate evidence without page bodies.
+2. Inspect top-level `matches[]` and choose the hit with the right page, source, and context.
+3. Re-run with exactly that hit's `page` and unchanged `region` in `--pages`, `--render`, and `--render-region`.
+4. Ask the vision model to compare the crop against the native text, OCR text, or extracted table data.
 
 對於無法透過文字搜尋定位的視覺區域，請結合 [渲染與 OCR](./rendering-and-ocr.md) 使用 `--visual-regions` 或 `--render-visual-regions`。
 
 ## 範例：可稽核的 claim check
 
 ```bash
-pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --layout --json
+pdfvision annual-report.pdf --search "Net sales" --search "Operating income" --matches-only --json
 ```
 
-代理可以檢查 `pages[].matches[]`，選擇頁面和周邊 context 正確的 hit，然後請求 crop：
+An agent can inspect top-level `matches[]`, choose the hit with the right page, source, and context, then pass its `region` to the crop command. No `--layout` flag is needed because compact search computes the region internally. If that selected hit reports the following illustrative page and region, the follow-up is:
 
 ```bash
 pdfvision annual-report.pdf --pages 42 --render --render-region 72,180,468,180 --render-output ./evidence --json

--- a/src/output/matchesOnly.ts
+++ b/src/output/matchesOnly.ts
@@ -8,11 +8,12 @@ import { escapeAttr, escapeText } from './xml/helpers.js';
 /**
  * Focused search report. Retain the file, total page/match counts, and query
  * list, then emit flat matches with page, source, text, optional context, and
- * bbox. Diagnostics are retained only for selected pages with warnings or
- * non-OK quality, without restoring their page bodies. The full pages/body
- * payload is omitted so an agent asking "where does BLEU appear" can feed a
- * reported bbox into `--render-region`. Output size still grows with the
- * emitted matches, context, and diagnostics.
+ * both the tight bbox and crop-ready region. Diagnostics are retained only
+ * for selected pages with warnings or non-OK quality, without restoring their
+ * page bodies. The full pages/body payload is omitted so an agent asking
+ * "where does BLEU appear" can feed the reported region unchanged into
+ * `--render-region`. Output size still grows with the emitted matches, context,
+ * and diagnostics.
  *
  * A run that matched nothing anywhere still succeeds (exit 0) and emits a
  * zero-match report — a zero count is a valid observation for an agent,
@@ -31,7 +32,8 @@ import { escapeAttr, escapeText } from './xml/helpers.js';
  * regionX/regionY/regionWidth/regionHeight on <match>.
  * `pageUserUnits` is omitted when every selected page uses the default value
  * 1. It keeps raw match boxes physically interpretable without restoring the
- * full pages[] payload; boxes still pass unchanged to renderRegion.
+ * full pages[] payload; the emitted region still passes unchanged to
+ * `--render-region`.
  */
 
 /** One flattened match, carrying the parent query string (markdown shows


### PR DESCRIPTION
The site search guides tell readers to crop a match's tight bounding box, which can show a financial row label while excluding its values. Start with `--matches-only`, select a hit from top-level `matches[]`, and pass its existing `region` unchanged to a single-page render. Explain how this differs from full JSON/TOON output, where UserUnit metadata lives, and why a crop may still omit headers or footnotes.

Updated all four search guides, the stale formatter comment, and CHANGELOG. New public prose is English in every locale per the owner's policy. Runtime behavior is unchanged.

Validation: lint, all 1,989 tests on main 17d5fd2, build, VitePress build, README usage sync, and byte-identical compact search output for an Apple financial statement and a vertical ruby fixture. Independently viewed both bbox and region crops: the financial region includes all four row values, and the vertical region includes the surrounding column text.

Independent read-only Claude review of the supplied diff and surrounding implementation found no substantive inaccuracies.
